### PR TITLE
feat: collect workouts, fix workout_schedule, auto-check Remember Me

### DIFF
--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -150,6 +150,17 @@ class GarminClient:
         pwd_input.click()
         self._page.keyboard.type(self.password, delay=30)
 
+        # Auto-check "Remember Me" on login page
+        try:
+            self._page.evaluate("""
+                () => {
+                    const cb = document.querySelector('input[name="remember"], input[id="remember"]');
+                    if (cb && !cb.checked) cb.click();
+                }
+            """)
+        except Exception:
+            pass
+
         submit = self._page.locator('button[type="submit"], button:has-text("Sign In")').first
         submit.click()
         print("Credentials submitted, waiting for Garmin...")
@@ -214,6 +225,17 @@ class GarminClient:
             if not mfa_prompted and is_mfa_page:
                 mfa_prompted = True
                 log.info("MFA page detected: %s", url)
+
+                # Auto-check "Remember this browser" if available
+                try:
+                    self._page.evaluate("""
+                        () => {
+                            const cb = document.querySelector('input[name="remember"], input[id="remember"], input[type="checkbox"]');
+                            if (cb && !cb.checked) cb.click();
+                        }
+                    """)
+                except Exception:
+                    pass
 
                 if sys.stdin.isatty():
                     import threading

--- a/garmin_client/endpoints.py
+++ b/garmin_client/endpoints.py
@@ -24,6 +24,7 @@ def profile_endpoints() -> dict:
         "weight_first": "/gc-api/weight-service/weight/first",
         "daily_summaries_count": "/gc-api/usersummary-service/usersummary/dailySummariesCount",
         "earned_badges": "/gc-api/badge-service/badge/earned",
+        "workouts": "/gc-api/workout-service/workouts?start=0&limit=100",
     }
 
 

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -400,6 +400,15 @@ CREATE TABLE IF NOT EXISTS workout_schedule (
     raw_json        TEXT
 );
 
+CREATE TABLE IF NOT EXISTS workouts (
+    workout_id      INTEGER PRIMARY KEY,
+    workout_name    TEXT,
+    sport_type      TEXT,
+    created_date    TEXT,
+    updated_date    TEXT,
+    raw_json        TEXT
+);
+
 -- =========================================================================
 -- Profile Tables (rarely change)
 -- =========================================================================
@@ -1399,9 +1408,30 @@ def upsert_health_snapshot(conn, record):
 
 
 def upsert_workout_schedule(conn, record):
-    d = record.get("calendarDate") or record.get("date")
+    d = record.get("calendarDate") or record.get("scheduleDate") or record.get("date")
     if d:
         _upsert_raw_only(conn, "workout_schedule", "calendar_date", record, d)
+
+
+def upsert_workout(conn: sqlite3.Connection, record: dict) -> None:
+    wid = record.get("workoutId")
+    if not wid:
+        return
+    sport = record.get("sportType", {})
+    sport_key = sport.get("sportTypeKey") if isinstance(sport, dict) else None
+    conn.execute(
+        """INSERT OR REPLACE INTO workouts
+           (workout_id, workout_name, sport_type, created_date, updated_date, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (
+            wid,
+            record.get("workoutName"),
+            sport_key,
+            record.get("createdDate"),
+            record.get("updateDate"),
+            json.dumps(record),
+        ),
+    )
 
 
 def upsert_personal_record(conn, record):
@@ -1712,6 +1742,11 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
         elif name == "workout_schedule":
             for rec in records:
                 upsert_workout_schedule(conn, rec)
+                count += 1
+
+        elif name == "workouts":
+            for rec in records:
+                upsert_workout(conn, rec)
                 count += 1
 
         elif name in ("hrv", "hrv_daily"):


### PR DESCRIPTION
## Summary
- Add `workouts` REST endpoint to profile fetch (captures all saved workouts)
- Fix `workout_schedule` upsert: look for `scheduleDate` field (was missing scheduled workouts)
- Add `workouts` table (workout_id, name, sport_type, dates) — 48 tables total
- Auto-check 'Remember Me' on login and 'Remember this browser' on MFA page

## Tested locally
- workouts: 100 rows captured
- workout_schedule: 7 rows captured (was 0 before fix)
- Remember Me checkbox auto-checked on login