### PR TITLE
fix: increase PyPI wait for Homebrew auto-update

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get release info from PyPI
         id: pypi
         run: |
-          sleep 30  # wait for PyPI to index the new version
+          sleep 90  # wait for PyPI to index the new version
           VERSION="${GITHUB_REF_NAME#v}"
           python3 -c "
           import urllib.request, json


### PR DESCRIPTION
30s wasn't enough — PyPI sometimes takes longer to index. Bumped to 90s.