### PR TITLE
feat: 44 MCP tools, security hardening, weight date fix (#13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 *.db-shm
 *.db-wal
 garmin_session.json
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You paid for the hardware. You generated the data with your body. You should be 
 
 This project gets your data out of Garmin Connect and into a local SQLite database where **you** own it and **AI can analyze it** through an MCP server for Claude Code.
 
+**47 tables, 10+ years of history, 44 MCP tools for AI analysis. Your data stays on your machine.**
+
 ## The Problem
 
 - **No public API**: Garmin's [Connect Developer Program](https://developer.garmin.com/gc-developer-program/) requires a business application. Individual developers are denied.
@@ -26,112 +28,272 @@ This project gets your data out of Garmin Connect and into a local SQLite databa
 
 **Nobody should buy Garmin products until they open their API to the people who paid for the hardware.**
 
-### How Garmin Compares to Competitors
+## Quick Start
 
-Other wearable companies prove that open data access and a successful business are not mutually exclusive:
+### Install
 
-| Company | Open API for Individuals? | Real-time Access? | Export Formats | Data Portability Grade |
-|---------|--------------------------|-------------------|----------------|----------------------|
-| **[Oura](https://cloud.ouraring.com/v2/docs)** | Yes — free, any ring owner | Yes, REST API | JSON, CSV | **A+** |
-| **[WHOOP](https://developer.whoop.com/)** | Yes — free, any member | Yes, API + webhooks | JSON, CSV | **A+** |
-| **[Fitbit](https://dev.fitbit.com/)** | Yes — personal app type | Yes, REST API | JSON, CSV, TCX | **A** |
-| **[Apple Health](https://developer.apple.com/documentation/healthkit)** | Yes — HealthKit on-device | Yes, on-device | XML | **A-** |
-| **[Polar](https://www.polar.com/accesslink-api/)** | Yes — any developer | Partial (new data only) | TCX, GPX, FIT, JSON | **B+** |
-| **[Wahoo](https://developers.wahooligan.com/)** | Yes, with approval | Yes, REST API | FIT, JSON | **B** |
-| **[Suunto](https://apizone.suunto.com/)** | Partner program | Yes, if approved | FIT, GPX, JSON | **B-** |
-| **Garmin** | **No — business-only** | **No** | **Incomplete ZIP after 30 days** | **D** |
-| **COROS** | No — partner-only | No | One-at-a-time only | **D+** |
-| **Samsung** | No — deprecated SDK | On-device only | Limited CSV | **D** |
-| **Amazfit/Zepp** | No | No | Barely (1-by-1 GPX) | **F** |
+```bash
+# macOS
+brew install nrvim/tap/garmin-givemydata
 
-Oura and WHOOP give every user free, documented API access with real-time data. Garmin — a company with $6B+ annual revenue — refuses to offer the same. **This tool exists to fill that gap.**
+# pip (Linux / Windows / macOS)
+pip install garmin-givemydata
 
-## The Solution
-
-This project uses browser automation to log into Garmin Connect the same way you would — through a real browser. It handles authentication, extracts your data through the web interface, and stores it locally.
-
-### What You Get
-
-- **ALL your data** in one command — 47 tables covering health metrics, performance scores, activities with splits/weather/HR zones, AND original FIT files
-- **10+ years** of historical data fetched automatically
-- **Smart sync**: first run fetches everything, subsequent runs only fetch what's new
-- **47-table SQLite database** — structured and optimized for analysis, with every field Garmin tracks
-- **Per-activity details** — splits, HR zone time, weather conditions, exercise sets for strength training
-- **Performance scores** — endurance score, hill score, race predictions (5K/10K/half/marathon)
-- **Original FIT files** — lossless device data for every activity, ready to import to Strava, TrainingPeaks, or any platform
-- **MCP server** — let AI analyze your health data through Claude Code, Claude Desktop, OpenClaw, or any MCP-compatible client
-- **Export to anything** — CSV, JSON, GPX, TCX from your local data
-- **Your data stays local** — everything is stored on your machine, nothing is sent anywhere
-
-## Features
-
-### AI-Powered Health Analysis (MCP Server)
-
-The built-in [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server lets any compatible AI assistant query your health database in natural language. No code needed — just ask questions:
-
-```
-"How has my resting heart rate changed over 6 months?"
-"Show me my cycling activities this year with power data"
-"Compare my sleep quality this month vs last month"
-"What's my training readiness trend?"
-"Am I overtraining? Look at my HRV and stress patterns"
-"What day of the week do I sleep best?"
-"How is my endurance score trending? Am I getting fitter?"
-"What are my predicted race times for a 10K?"
-"Show me the weather and HR zones for my last run"
-"Break down my last activity by splits — where did I slow down?"
-"Give me a full sports medicine health check using all my data"
+# or clone
+git clone https://github.com/nrvim/garmin-givemydata.git
+cd garmin-givemydata && ./setup.sh
 ```
 
-Works with:
-- **[Claude Code](https://claude.ai/code)** (CLI, desktop app, VS Code, JetBrains)
-- **[Claude Desktop](https://claude.ai/download)** (macOS, Windows)
-- **[OpenClaw](https://github.com/nicobailey/OpenClaw)** and other open-source MCP clients
-- **Any MCP-compatible tool** — the server follows the standard [MCP protocol](https://spec.modelcontextprotocol.io/)
+### Fetch your data
 
-6 tools are available to the AI:
+```bash
+garmin-givemydata                    # fetches all historical data + FIT files
+```
+
+First run prompts for credentials, launches a headless browser, and fetches your full history (~30 min for 10 years). After that, daily syncs take seconds.
+
+### Connect AI
+
+Add the MCP server to Claude Code, Claude Desktop, or any MCP client. The config depends on how you installed:
+
+**Homebrew or pip install** — `garmin-mcp` is already in your PATH:
+
+```json
+{
+  "mcpServers": {
+    "garmin": {
+      "command": "garmin-mcp"
+    }
+  }
+}
+```
+
+**Git clone** — use absolute paths to the venv:
+
+```json
+{
+  "mcpServers": {
+    "garmin": {
+      "command": "/absolute/path/to/garmin-givemydata/venv/bin/python",
+      "args": ["/absolute/path/to/garmin-givemydata/run_mcp.py"],
+      "cwd": "/absolute/path/to/garmin-givemydata"
+    }
+  }
+}
+```
+
+Save this as:
+- **Claude Code:** `.mcp.json` in your project root, or `~/.claude/settings.json` under `mcpServers` for global access
+- **Claude Desktop:** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows)
+
+Restart your client and run `/mcp` to approve the server. Then ask:
+
+```
+"How was my sleep this week?"
+"Am I overtraining? Check my HRV and recovery"
+"Compare my fitness this month vs last month"
+"Give me a full sports medicine health check"
+```
+
+<details>
+<summary>Windows, OpenClaw, and other MCP clients</summary>
+
+#### Windows (git clone)
+
+```json
+{
+  "mcpServers": {
+    "garmin": {
+      "command": "C:\\Users\\jane\\code\\garmin-givemydata\\venv\\Scripts\\python.exe",
+      "args": ["C:\\Users\\jane\\code\\garmin-givemydata\\run_mcp.py"],
+      "cwd": "C:\\Users\\jane\\code\\garmin-givemydata"
+    }
+  }
+}
+```
+
+#### Other MCP clients (OpenClaw, Cline, Cursor)
+
+Any client supporting [MCP stdio transport](https://spec.modelcontextprotocol.io/specification/basic/transports/#stdio) can connect. For pip/brew: `garmin-mcp`. For git clone:
+
+```bash
+/path/to/garmin-givemydata/venv/bin/python /path/to/garmin-givemydata/run_mcp.py
+```
+
+**Important:** Paths must be **absolute** — relative paths will not work.
+
+</details>
+
+## What You Get
+
+- **ALL your data** in one command — 47 tables, activities with splits/weather/HR zones, original FIT files
+- **10+ years** of history fetched automatically, smart incremental sync after that
+- **44 MCP tools** for AI analysis — not just raw data, but tools with clinical context, anomaly detection, and professional training metrics
+- **Export to anything** — CSV, JSON, GPX, TCX from your local database
+- **Your data stays local** — nothing is sent anywhere
+
+## MCP Tools (44)
+
+The MCP server gives AI assistants deep access to your health data. Every tool returns **data + context** — not just numbers, but trend direction, anomaly flags, clinical thresholds, and goal attainment.
+
+<details>
+<summary><strong>Data & Sync (3 tools)</strong></summary>
 
 | Tool | What It Does |
 |------|-------------|
+| `garmin_sync` | Check data freshness and pull latest data from Garmin — always shows when the last sync happened. Use `refresh=False` to just check status |
 | `garmin_schema` | Show all 47 tables, columns, and row counts |
-| `garmin_query` | Run any SELECT query against the 47-table database |
-| `garmin_health_summary` | Health overview for any date range: daily metrics, sleep, training readiness, endurance score, hill score, race predictions |
-| `garmin_activities` | List/filter activities by type, date, distance — includes power, HR, training load, location |
-| `garmin_trends` | Weekly/monthly trends for 17 metrics: `resting_hr`, `hrv`, `stress`, `steps`, `sleep_hours`, `body_battery`, `spo2`, `training_readiness`, `floors`, `calories`, `active_minutes`, `respiration`, `weight`, `endurance_score`, `hill_score`, `race_5k`, `race_10k` |
-| `garmin_sync` | Pull latest data from Garmin without leaving the chat |
+| `garmin_query` | Run any read-only SELECT query (read-only enforced at the SQLite engine level) |
 
-The AI can combine these tools to answer complex questions — correlating sleep with training load, spotting trends you wouldn't notice, comparing HR zones across activities, predicting race times, or building custom reports across years of data. It can also query per-activity details like splits, weather, and exercise sets via `garmin_query`.
+</details>
 
-### Smart Sync
+<details>
+<summary><strong>Daily Overview (3 tools)</strong></summary>
 
-One command gets everything — health data to SQLite, FIT files to disk:
+| Tool | What It Does |
+|------|-------------|
+| `garmin_today` | Complete snapshot: daily summary, last night's sleep, training readiness, HRV, fitness age, last activity |
+| `garmin_week_summary` | Current week's totals vs goals: steps, intensity minutes, floors, calories |
+| `garmin_health_summary` | Health overview for any date range with all metrics aggregated |
+
+</details>
+
+<details>
+<summary><strong>Health Metrics (13 tools)</strong> — enriched with trends, anomaly flags, clinical thresholds</summary>
+
+| Tool | What It Does |
+|------|-------------|
+| `garmin_heart_rate` | Resting HR with 7-day rolling average and anomaly detection (flags >5 bpm spikes) |
+| `garmin_hrv` | HRV with baseline position, BALANCED/UNBALANCED streak, trend direction |
+| `garmin_sleep` | Per-night breakdown with stages, deep/REM %, SpO2, stress, Garmin feedback |
+| `garmin_stress` | Time-in-zone breakdown (hours in low/medium/high per day) |
+| `garmin_body_battery` | Charge/drain patterns with wake values and sleep quality correlation |
+| `garmin_spo2` | Clinical threshold flags (<95% warning, <80% sleep apnea recommendation) |
+| `garmin_respiration` | Waking respiration with elevated-day flags (>20 breaths/min) |
+| `garmin_steps` | Steps with goal attainment % and longest goal-met streak |
+| `garmin_floors` | Floors climbed vs goal with ascent/descent breakdown |
+| `garmin_calories` | Calorie breakdown: total, active, BMR, consumed |
+| `garmin_intensity_minutes` | Weekly intensity vs WHO 150 min/week target, moderate vs vigorous |
+| `garmin_hydration` | Fluid intake vs Garmin-calculated goal |
+| `garmin_blood_pressure` | Readings with AHA guideline flags (>140/90 mmHg) |
+
+</details>
+
+<details open>
+<summary><strong>Training & Performance (13 tools)</strong> — includes tools unique to this project</summary>
+
+| Tool | What It Does |
+|------|-------------|
+| `garmin_training_load` | **CTL/ATL/TSB** — professional periodization metrics with weekly volume and load by sport |
+| `garmin_recovery` | **Post-workout recovery signatures** — RHR/HRV/body battery tracking after hard sessions, by sport |
+| `garmin_compare` | **Side-by-side period comparison** — any two date ranges, all metrics, deltas + % changes |
+| `garmin_activities` | List/filter activities by type and date — power, HR, training load, location |
+| `garmin_activity_detail` | Deep-dive: splits, HR zones, weather, exercise sets in one call |
+| `garmin_race_predictions` | 5K/10K/half/marathon times with human-readable formatting and trend |
+| `garmin_endurance_score` | Endurance score with classification tier and trend |
+| `garmin_hill_score` | Hill score with endurance and strength sub-scores |
+| `garmin_vo2max` | VO2max estimates from activities and dedicated tracking |
+| `garmin_training_status` | Status history (Productive/Recovery/Detraining) with transition detection |
+| `garmin_fitness_age` | Fitness age vs chronological age trajectory with gap analysis |
+| `garmin_records` | All PRs with human-readable names (Fastest 5K, Longest Ride, etc.) |
+| `garmin_trends` | Weekly/monthly trends for 17 metrics |
+
+</details>
+
+<details>
+<summary><strong>Profile & Devices (12 tools)</strong></summary>
+
+| Tool | What It Does |
+|------|-------------|
+| `garmin_user_profile` | Profile and settings from Garmin Connect |
+| `garmin_devices` | Connected devices with type and last sync |
+| `garmin_gear` | Equipment tracking (shoes, bikes, etc.) |
+| `garmin_badges` | Earned achievements with dates |
+| `garmin_body_composition` | Weight, BMI, body fat, muscle mass history |
+| `garmin_workouts` | Workout library, training plans, scheduled workouts |
+| `garmin_goals` | Active fitness goals |
+| `garmin_challenges` | Garmin Connect challenges |
+| `garmin_health_snapshot` | On-demand 2-minute health readings (HR, HRV, SpO2, stress) |
+| `garmin_daily_events` | Daily events (stress spikes, body battery events) |
+| `garmin_activity_types` | All activity type definitions |
+| `garmin_hr_zones` | Heart rate zone definitions per sport |
+
+</details>
+
+## Usage
+
+### Fetch (from Garmin Connect)
 
 ```bash
-# First run: empty DB → fetches all historical data + downloads all FIT files
-python garmin_givemydata.py
-
-# Next day: DB has data → fetches only new data + downloads only new FIT files
-python garmin_givemydata.py
-
-# Override: fetch last 90 days regardless
-python garmin_givemydata.py --days 90
+garmin-givemydata                              # smart sync (all data + FIT files)
+garmin-givemydata --full                       # force full historical re-fetch
+garmin-givemydata --days 90                    # fetch last 90 days
+garmin-givemydata --since 2025-01-01           # fetch from specific date
+garmin-givemydata --profile health             # health metrics only
+garmin-givemydata --profile activities         # activities + FIT files only
+garmin-givemydata --profile sleep              # sleep data only
+garmin-givemydata --no-files                   # skip FIT file downloads
+garmin-givemydata --status                     # check database contents
 ```
 
-### Fetch Profiles
-
-Not everyone needs everything. Pick what you want:
+### FIT file download only
 
 ```bash
-python garmin_givemydata.py                       # all data + FIT files (default)
-python garmin_givemydata.py --profile health       # health metrics only (HR, sleep, stress, HRV)
-python garmin_givemydata.py --profile activities    # activities + FIT files only
-python garmin_givemydata.py --profile sleep         # sleep data only
-python garmin_givemydata.py --no-files              # any profile, but skip FIT downloads
+garmin-givemydata --fit-only --latest          # latest FIT file
+garmin-givemydata --fit-only --date 2026-03-30 # specific date
+garmin-givemydata --fit-only --days 7          # last 7 days
+garmin-givemydata --fit-only                   # all FIT files
 ```
 
-### Comprehensive Data — 47 Tables
+### Export (from local database)
 
-Every metric Garmin tracks, extracted and stored locally in 47 dedicated SQLite tables:
+```bash
+garmin-givemydata --export ./output            # CSV + JSON
+garmin-givemydata --export-gpx ./gpx           # GPX (for Strava, Komoot)
+garmin-givemydata --export-tcx ./tcx           # TCX (for TrainingPeaks)
+```
+
+<details>
+<summary>Supported export formats</summary>
+
+| Format | Content | How |
+|--------|---------|-----|
+| **SQLite** | Health + activities | Default — always created |
+| **FIT** (ZIP) | Activities (lossless) | Default — downloaded automatically |
+| **CSV** | Health + activities | `--export ./dir` |
+| **JSON** | Health + activities | `--export ./dir` |
+| **GPX** | Activities (GPS tracks) | `--export-gpx ./dir` |
+| **TCX** | Activities (XML) | `--export-tcx ./dir` |
+
+</details>
+
+### Browser engines
+
+| Engine | Flag | Headless | Cloudflare bypass |
+|--------|------|----------|-------------------|
+| **Camoufox** (default) | none | Yes | Yes |
+| **Chrome** | `--chrome --visible` | Needs `--visible` for first login | Only with visible window |
+
+<details>
+<summary>Where data is stored</summary>
+
+| Install method | Data location |
+|---------------|---------------|
+| **Homebrew / pip** | `~/.garmin-givemydata/` |
+| **Git clone** | Current directory |
+| **Custom** | Set `GARMIN_DATA_DIR` env var |
+
+```
+garmin.db              # SQLite database (all health + activity data)
+browser_profile/       # Browser session (persists ~1 year)
+.env                   # Garmin credentials
+fit/                   # Original FIT files (lossless)
+```
+
+</details>
+
+<details>
+<summary>Comprehensive data — 47 tables</summary>
 
 | Category | Data |
 |----------|------|
@@ -165,95 +327,67 @@ Every metric Garmin tracks, extracted and stored locally in 47 dedicated SQLite 
 | **Health Status** | Overall daily health status assessment |
 | **Hydration** | Daily goal and intake in ml |
 
-## Getting Started
+</details>
 
-### Option A: Homebrew (macOS — recommended)
+## Architecture
 
-```bash
-brew install nrvim/tap/garmin-givemydata
-garmin-givemydata
+<details>
+<summary>Project structure and data flow</summary>
+
+```
+garmin-givemydata/
+├── garmin_givemydata.py       # Main entry: smart sync (full or incremental)
+├── garmin_client/              # Playwright-based Garmin Connect client
+│   ├── client.py               #   GarminClient (login, fetch, export)
+│   └── endpoints.py            #   API endpoint definitions
+├── garmin_mcp/                 # MCP server + database layer
+│   ├── db.py                   #   SQLite schema (47 tables), upsert helpers
+│   ├── server.py               #   FastMCP server with 44 tools
+│   ├── export.py               #   CSV, JSON, GPX, TCX export
+│   ├── import_json.py          #   JSON → SQLite bulk import
+│   └── sync.py                 #   Incremental sync engine
+├── run_mcp.py                  # MCP server entry point
+├── garmin.db                   # Your health data (SQLite, gitignored)
+├── fit/                        # Your activity files (FIT/ZIP, gitignored)
+├── browser_profile/            # Browser session (gitignored)
+└── pyproject.toml
 ```
 
-### Option B: pip install (Linux / Windows / macOS)
+**Data flow:**
+```
+Garmin Connect ──→ SQLite (health + activity metrics)
+                └─→ fit/ (original FIT files, lossless)
 
-```bash
-pip install garmin-givemydata
-garmin-givemydata
+SQLite ──→ MCP server (AI queries via 44 tools)
+       ├─→ CSV/JSON (--export)
+       └─→ GPX/TCX (--export-gpx, --export-tcx)
 ```
 
-### Option C: Clone the repo
+</details>
 
-```bash
-git clone https://github.com/nrvim/garmin-givemydata.git
-cd garmin-givemydata
-./setup.sh                  # macOS/Linux (setup.bat for Windows)
-python garmin_givemydata.py
-```
+## Platform Support
 
-### First run
+| Platform | Status | Notes |
+|----------|--------|-------|
+| **macOS** | Tested | Primary development platform |
+| **Linux (Ubuntu/Debian/Fedora)** | Supported | May need `playwright install-deps` for system libraries |
+| **Windows 10/11** | Supported | Use PowerShell or Command Prompt |
+| **WSL2** | Supported | Works headless with Camoufox |
 
-1. The tool launches a headless browser (no window visible) and navigates to Garmin login
-2. If you have MFA enabled, you will be prompted to enter the code in the **terminal**
-3. The tool prompts for your credentials and saves them to `.env`
-4. Full history is fetched year by year — takes about **30 minutes** for 10 years of data
-5. All subsequent runs reuse saved session cookies (~1 year lifetime) — no login needed
-
-### Browser engines
-
-The default browser engine is **Camoufox** (anti-detect Firefox). It runs fully headless and bypasses Cloudflare bot detection without showing a browser window.
-
-If Camoufox does not work on your setup, you can fall back to Chrome:
-
-```bash
-garmin-givemydata --chrome --visible
-```
-
-| Engine | Flag | Headless | Cloudflare bypass |
-|--------|------|----------|-------------------|
-| **Camoufox** (default) | none | Yes | Yes |
-| **Chrome** | `--chrome --visible` | Needs `--visible` for first login | Only with visible window |
-
-### Where data is stored
-
-| Install method | Data location |
-|---------------|---------------|
-| **Homebrew / pip** | `~/.garmin-givemydata/` |
-| **Git clone** | Current directory (same as the repo) |
-| **Custom** | Set `GARMIN_DATA_DIR` env var |
-
-Inside the data directory:
-```
-garmin.db              # SQLite database (all health + activity data)
-browser_profile/       # Browser session (persists ~1 year)
-.env                   # Garmin credentials (email + password)
-fit/                   # Original FIT files (lossless activity data)
-```
-
-### Reset / clean start
-
-To start fresh, delete the data directory:
-
-```bash
-# Homebrew / pip install
-rm -rf ~/.garmin-givemydata
-
-# Git clone
-rm -f garmin.db && rm -rf browser_profile
-```
-
-### Manual setup (if setup script doesn't work)
+<details>
+<summary>Manual setup (if setup script doesn't work)</summary>
 
 <details>
 <summary>macOS</summary>
 
 ```bash
-brew install python@3.12       # skip if you have Python 3.10+
+brew install python@3.12
 cd garmin-givemydata
 python3.12 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python -m playwright install chromium   # only needed for --chrome fallback
-cp .env.example .env           # edit .env with your credentials
+python -m playwright install chromium   # only for --chrome fallback
+cp .env.example .env
 ```
 </details>
 
@@ -266,9 +400,9 @@ cd garmin-givemydata
 python3.12 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python -m playwright install chromium   # only needed for --chrome fallback
-sudo python -m playwright install-deps chromium   # system libraries
-cp .env.example .env           # edit .env with your credentials
+python -m playwright install chromium
+sudo python -m playwright install-deps chromium
+cp .env.example .env
 ```
 </details>
 
@@ -281,455 +415,136 @@ cd garmin-givemydata
 python3.12 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python -m playwright install chromium   # only needed for --chrome fallback
+python -m playwright install chromium
 sudo python -m playwright install-deps chromium
-cp .env.example .env           # edit .env with your credentials
+cp .env.example .env
 ```
 </details>
 
 <details>
 <summary>Windows</summary>
 
-Install Python 3.10+ from [python.org](https://www.python.org/downloads/) — check **"Add to PATH"** during install.
+Install Python 3.10+ from [python.org](https://www.python.org/downloads/) — check **"Add to PATH"**.
 
 ```powershell
 cd garmin-givemydata
 python -m venv venv
-venv\Scripts\Activate.ps1      # or venv\Scripts\activate.bat for CMD
+venv\Scripts\Activate.ps1
 pip install -r requirements.txt
-python -m playwright install chromium   # only needed for --chrome fallback
-copy .env.example .env         # edit .env with your credentials
+python -m playwright install chromium
+copy .env.example .env
 ```
 
-If PowerShell blocks the activate script:
-```powershell
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-```
+If PowerShell blocks the activate script: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 </details>
 
-### 3. Connect AI (Optional)
-
-The MCP server lets any AI assistant query your Garmin database. It exposes 6 tools over the [Model Context Protocol](https://modelcontextprotocol.io/):
-
-| Tool | What It Does |
-|------|-------------|
-| `garmin_schema` | Show all 47 tables, columns, and row counts |
-| `garmin_query` | Run any SELECT query against the database |
-| `garmin_health_summary` | Health overview: daily metrics, sleep, training readiness, endurance, hill score, race predictions |
-| `garmin_activities` | List/filter activities by type, date, distance — includes power, HR, training load |
-| `garmin_trends` | Weekly/monthly trends for 17 metrics: `resting_hr`, `hrv`, `stress`, `steps`, `sleep_hours`, `body_battery`, `spo2`, `training_readiness`, `floors`, `calories`, `active_minutes`, `respiration`, `weight`, `endurance_score`, `hill_score`, `race_5k`, `race_10k` |
-| `garmin_sync` | Pull latest data from Garmin without leaving the chat |
-
-#### Claude Code (CLI, Desktop App, VS Code, JetBrains)
-
-Create a `.mcp.json` file. You have two options:
-
-**Option A — Global (available in all projects):**
-
-Create `~/.claude/.mcp.json`:
-
-```bash
-# macOS / Linux
-cat > ~/.claude/.mcp.json << 'EOF'
-{
-  "mcpServers": {
-    "garmin": {
-      "command": "/absolute/path/to/garmin-givemydata/venv/bin/python",
-      "args": ["/absolute/path/to/garmin-givemydata/run_mcp.py"]
-    }
-  }
-}
-EOF
-```
-
-**Option B — Per-project (available only in that directory):**
-
-Create `.mcp.json` in your project folder:
-
-```json
-{
-  "mcpServers": {
-    "garmin": {
-      "command": "/absolute/path/to/garmin-givemydata/venv/bin/python",
-      "args": ["/absolute/path/to/garmin-givemydata/run_mcp.py"]
-    }
-  }
-}
-```
-
-**Important:** Replace `/absolute/path/to/garmin-givemydata` with the actual path where you cloned the repo. Paths must be **absolute** — relative paths will not work.
-
-Example with a real path:
-```json
-{
-  "mcpServers": {
-    "garmin": {
-      "command": "/Users/jane/code/garmin-givemydata/venv/bin/python",
-      "args": ["/Users/jane/code/garmin-givemydata/run_mcp.py"]
-    }
-  }
-}
-```
-
-**Windows:**
-```json
-{
-  "mcpServers": {
-    "garmin": {
-      "command": "C:\\Users\\jane\\code\\garmin-givemydata\\venv\\Scripts\\python.exe",
-      "args": ["C:\\Users\\jane\\code\\garmin-givemydata\\run_mcp.py"]
-    }
-  }
-}
-```
-
-After creating the file, restart Claude Code and run `/mcp` to approve the Garmin server.
-
-#### Claude Desktop
-
-Edit the config file:
-- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add the Garmin server to the `mcpServers` object (same format as above). Restart Claude Desktop.
-
-#### OpenClaw / Other MCP Clients
-
-Any client that supports the [MCP stdio transport](https://spec.modelcontextprotocol.io/specification/basic/transports/#stdio) can connect. The server command is:
-
-```bash
-/path/to/garmin-givemydata/venv/bin/python /path/to/garmin-givemydata/run_mcp.py
-```
-
-#### Verify It Works
-
-Once connected, ask your AI:
-
-```
-"Show me the garmin schema"
-"Give me a health summary for the last 7 days"
-"How has my resting heart rate changed over 6 months?"
-"Show me my cycling activities this year"
-"What's my endurance score trend?"
-"Show me the splits and weather for my last run"
-"Give me a full sports medicine health check"
-```
-
-## Usage
-
-### Fetch (from Garmin Connect)
-
-```bash
-# Smart sync — all data + FIT files (full if empty, incremental if data exists)
-python garmin_givemydata.py
-
-# Force full historical re-fetch
-python garmin_givemydata.py --full
-
-# Fetch specific range
-python garmin_givemydata.py --days 90
-python garmin_givemydata.py --since 2025-01-01
-
-# Fetch profiles — get only what you need
-python garmin_givemydata.py --profile health       # health metrics only
-python garmin_givemydata.py --profile activities    # activities + FIT files
-python garmin_givemydata.py --profile sleep         # sleep data only
-
-# Skip FIT file downloads (faster, API data only)
-python garmin_givemydata.py --no-files
-
-# Check what's in your database
-python garmin_givemydata.py --status
-```
-
-### FIT file download only (skip health data sync)
-
-```bash
-# Download the latest FIT file
-garmin-givemydata --fit-only --latest
-
-# Download FIT file for a specific date
-garmin-givemydata --fit-only --date 2026-03-30
-
-# Download FIT files for the last 7 days
-garmin-givemydata --fit-only --days 7
-
-# Download all FIT files
-garmin-givemydata --fit-only
-```
-
-### Export (from local database — no Garmin login needed)
-
-```bash
-# Export to CSV + JSON (for Excel, pandas, R, web apps)
-python garmin_givemydata.py --export ./my_garmin_data
-
-# Export activities as GPX (for Strava, Komoot, AllTrails)
-python garmin_givemydata.py --export-gpx ./gpx_files
-
-# Export activities as TCX (for TrainingPeaks)
-python garmin_givemydata.py --export-tcx ./tcx_files
-```
-
-### What gets stored where
-
-```
-garmin-givemydata/
-├── garmin.db              # SQLite — all health + activity data (queryable)
-└── fit/                   # Original FIT files (lossless device data)
-    ├── 2026-03-03_12345678901_Morning_Road_Cycling.zip
-    ├── 2026-02-28_12345678902_Evening_Running.zip
-    └── ...
-```
-
-FIT files are the **master copy** of your activity data — lossless, straight from the device. You can re-import them to Strava, TrainingPeaks, Intervals.icu, or any platform. GPX and TCX are lossy conversions available as export options for tools that need them.
-
-**All supported formats:**
-
-| Format | Content | How |
-|--------|---------|-----|
-| **SQLite** | Health + activities | Default — always created |
-| **FIT** (ZIP) | Activities (lossless) | Default — downloaded automatically |
-| **CSV** | Health + activities | `--export ./dir` |
-| **JSON** | Health + activities | `--export ./dir` |
-| **GPX** | Activities (GPS tracks) | `--export-gpx ./dir` |
-| **TCX** | Activities (XML) | `--export-tcx ./dir` |
-
-## Architecture
-
-```
-garmin-givemydata/
-├── garmin_givemydata.py       # Main entry: smart sync (full or incremental)
-├── garmin_client/              # Playwright-based Garmin Connect client
-│   ├── client.py               #   GarminClient (login, fetch, export)
-│   └── endpoints.py            #   API endpoint definitions
-├── garmin_mcp/                 # MCP server + database layer
-│   ├── db.py                   #   SQLite schema (47 tables), upsert helpers
-│   ├── server.py               #   FastMCP server with 6 tools
-│   ├── export.py               #   CSV, JSON, GPX, TCX export
-│   ├── import_json.py          #   JSON → SQLite bulk import
-│   └── sync.py                 #   Incremental sync engine
-├── run_mcp.py                  # MCP server entry point
-├── garmin.db                   # Your health data (SQLite, gitignored, stored in data dir)
-├── fit/                        # Your activity files (FIT/ZIP, gitignored)
-├── browser_profile/            # Browser session (gitignored, stored in data dir)
-└── pyproject.toml
-```
-
-**Data flow:**
-```
-Garmin Connect ──→ SQLite (health + activity metrics)
-                └─→ fit/ (original FIT files, lossless)
-
-SQLite ──→ MCP server (AI queries)
-       ├─→ CSV/JSON (--export)
-       └─→ GPX/TCX (--export-gpx, --export-tcx)
-```
-
-## Platform Support
-
-| Platform | Status | Notes |
-|----------|--------|-------|
-| **macOS** | Tested | Primary development platform |
-| **Linux (Ubuntu/Debian/Fedora)** | Supported | May need `playwright install-deps` for system libraries |
-| **Windows 10/11** | Supported | Use PowerShell or Command Prompt |
-| **WSL2** | Supported | Works headless with Camoufox. Chrome fallback needs `DISPLAY` set for X11 forwarding |
-
-## Known Limitations
-
-- **MFA on first login**: If MFA is enabled, you will be prompted to enter the code in the **terminal**. After that, the session persists ~1 year.
-- **Browser memory**: Camoufox uses roughly 200-300 MB RAM while running. It closes automatically when the sync is done.
-- **Garmin can change things**: If Garmin updates their bot detection or API endpoints, this tool may need updates. Open an issue if it breaks.
-- **First fetch is slow**: 10 years of daily data takes ~30 minutes. After that, daily syncs take seconds.
-- **Chrome fallback**: If Camoufox does not work on your system, use `--chrome --visible` to fall back to Chrome. Chrome headless gets blocked by Cloudflare, so `--visible` is required for the first login.
-- **Garmin ToS**: This accesses Garmin's web interface the same way you do. We believe data portability is a right.
+</details>
 
 ## Troubleshooting
 
-**"Login failed"**: Delete the browser profile and run again for a fresh session. For pip/brew: `rm -rf ~/.garmin-givemydata/browser_profile`. For git clone: `rm -rf browser_profile/`.
+<details>
+<summary>Common issues and fixes</summary>
 
-**Script crashed / "Execution context was destroyed"**: If using `--chrome --visible`, don't close the Chrome window. The script needs the browser open to fetch data. Run again.
+**"Login failed"**: Delete the browser profile and run again. For pip/brew: `rm -rf ~/.garmin-givemydata/browser_profile`. For git clone: `rm -rf browser_profile/`.
 
-**"Python not found" or wrong version**: Make sure Python 3.10+ is installed and on your PATH. On macOS use `brew install python@3.12`, on Ubuntu `sudo apt install python3.12 python3.12-venv`.
+**Script crashed / "Execution context was destroyed"**: If using `--chrome --visible`, don't close the Chrome window. Run again.
 
-**403 or session errors**: Session may have expired. Delete the browser profile (see "Reset / clean start" above) and re-login.
+**"Python not found"**: Make sure Python 3.10+ is on your PATH. macOS: `brew install python@3.12`. Ubuntu: `sudo apt install python3.12 python3.12-venv`.
 
-**Chrome doesn't open (Linux)**: If using `--chrome --visible`, you need a display. Either use a desktop environment, or install Xvfb: `sudo apt install xvfb && xvfb-run python garmin_givemydata.py`. With the default Camoufox engine, no display is needed.
+**403 or session errors**: Session expired. Delete the browser profile and re-login.
 
-**Playwright install fails (Linux)**: Run `sudo python -m playwright install-deps` to install system dependencies (libnss3, libatk, etc.).
+**Chrome doesn't open (Linux)**: Use the default Camoufox engine (no display needed), or install Xvfb: `sudo apt install xvfb && xvfb-run python garmin_givemydata.py`.
 
-**MCP server "failed to connect"**:
-- Paths in `.mcp.json` must be **absolute** (not relative)
-- On Windows use `\\` or `/` in paths, and point to `venv\Scripts\python.exe`
-- Test manually: `<path-to-venv>/python <path-to>/run_mcp.py`
-- Check Python version: needs 3.10+
+**Playwright install fails (Linux)**: `sudo python -m playwright install-deps`
 
-**Empty data for some metrics**: Training readiness, HRV, body battery, endurance score, hill score, and race predictions require a compatible Garmin device (Fenix 7+, Forerunner 265+, Venu 3+, etc.). Older devices may not support all metrics. Activity weather requires GPS-enabled activities.
+**MCP server "failed to connect"**: Paths in `.mcp.json` must be **absolute**. Test: `<path>/venv/bin/python <path>/run_mcp.py`
 
-**"No existing data found" on every run**: Make sure `garmin.db` is in the project root directory (same folder as `garmin_givemydata.py`).
+**Empty data for some metrics**: Training readiness, HRV, body battery, endurance score, hill score, and race predictions require compatible devices (Fenix 7+, Forerunner 265+, Venu 3+, etc.).
 
-**Windows: "execution of scripts is disabled"**: Run `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser` in PowerShell to allow activating the venv.
+**Windows: "execution of scripts is disabled"**: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
+
+</details>
+
+<details>
+<summary><strong>How Garmin compares to competitors</strong></summary>
+
+| Company | Open API for Individuals? | Real-time Access? | Data Portability Grade |
+|---------|--------------------------|-------------------|----------------------|
+| **[Oura](https://cloud.ouraring.com/v2/docs)** | Yes — free, any ring owner | Yes, REST API | **A+** |
+| **[WHOOP](https://developer.whoop.com/)** | Yes — free, any member | Yes, API + webhooks | **A+** |
+| **[Fitbit](https://dev.fitbit.com/)** | Yes — personal app type | Yes, REST API | **A** |
+| **[Apple Health](https://developer.apple.com/documentation/healthkit)** | Yes — HealthKit on-device | Yes, on-device | **A-** |
+| **[Polar](https://www.polar.com/accesslink-api/)** | Yes — any developer | Partial | **B+** |
+| **Garmin** | **No — business-only** | **No** | **D** |
+| **COROS** | No — partner-only | No | **D+** |
+| **Samsung** | No — deprecated SDK | On-device only | **D** |
+| **Amazfit/Zepp** | No | No | **F** |
+
+</details>
 
 ## Contributing
 
-This project exists because Garmin refuses to give users access to their own data. If you believe in data portability, help make this better:
+<details>
+<summary>How to help</summary>
 
-- **New endpoints**: Garmin has hundreds of internal APIs. If you discover new ones via browser dev tools, add them to `endpoints.py`.
-- **More MCP tools**: Build specialized analysis tools — training load analysis, injury risk prediction, sleep optimization, race readiness scoring, overtraining detection.
-- **MCP client integrations**: Test and document setup with more MCP clients — OpenClaw, Cline, Continue, Cursor, or your own tools.
-- **Other platforms**: Test on ARM (Raspberry Pi), Docker containers, and other environments.
-- **Data visualization**: Build dashboards, charts, or reports from the SQLite data.
-- **Export formats**: Add CSV, Parquet, or other export formats for use with pandas, R, or other analysis tools.
-- **Other wearables**: The architecture (browser auth + SQLite + MCP) could work for COROS, Samsung, Amazfit/Zepp, and others that restrict API access. Fork this and adapt it. (Note: Oura, WHOOP, Polar, Fitbit, Wahoo, and Apple HealthKit already offer open APIs — use those directly instead of scraping.)
-- **Testing**: Add tests, CI, and help us support more platforms.
+- **New endpoints**: Garmin has hundreds of internal APIs. Discover new ones via browser dev tools and add them to `endpoints.py`.
+- **More MCP tools**: The server has 44 tools including CTL/ATL/TSB, recovery signatures, and period comparison. Ideas: injury risk prediction, sleep optimization, race readiness scoring, overtraining detection.
+- **MCP client integrations**: Test with OpenClaw, Cline, Continue, Cursor, or other clients.
+- **Other platforms**: ARM (Raspberry Pi), Docker, etc.
+- **Data visualization**: Dashboards, charts, reports from SQLite.
+- **Export formats**: Parquet, or other formats for pandas, R.
+- **Other wearables**: The architecture (browser auth + SQLite + MCP) could work for COROS, Samsung, Amazfit/Zepp.
+- **Testing**: Tests, CI, more platform support.
 
-Open an issue or submit a PR. Let's build the data portability tools these companies should have given us.
+Open an issue or submit a PR.
+
+</details>
 
 ## Support This Project
 
-If you find this tool useful, please consider supporting its continued development:
-
 - **Star this repository** — helps others discover the project
-- **Report issues** — help improve stability and compatibility
-- **Spread the word** — share with other Garmin users who want access to their own data
+- **Report issues** — improve stability and compatibility
+- **Spread the word** — share with other Garmin users
 - **Contribute code** — new endpoints, MCP tools, export formats, bug fixes
-- **File a GDPR/CCPA data portability request with Garmin** through their [Data Management portal](https://www.garmin.com/en-US/account/datamanagement/) — the more users who formally request proper data portability, the harder it is for Garmin to ignore. The day Garmin opens a real API for individual users, this project can be decommissioned. That's the goal.
-
-## Why This Matters
-
-You bought a $500+ watch. You wear it 24/7. It tracks your heart rate, sleep, stress, blood oxygen, respiration, training load, and recovery — the most intimate data about your body.
-
-And Garmin says you can't have it unless you're a business.
-
-The [garth library](https://github.com/matin/garth) served the community for years, reaching 350k+ monthly PyPI downloads. When Garmin broke it in March 2026, the maintainer couldn't keep up with the arms race and deprecated it. [python-garminconnect](https://github.com/cyberjunky/python-garminconnect), with 2,000 stars, is stuck waiting for a fix that may never come.
-
-This is not about piracy or scraping. This is about **data portability**. The EU's GDPR gives you the right to your data. California's CCPA does too. But rights without tools are meaningless.
-
-**garmin-givemydata** is the tool.
+- **[File a GDPR/CCPA request with Garmin](https://www.garmin.com/en-US/account/datamanagement/)** — the more users who formally request data portability, the harder it is to ignore
 
 ## Acknowledgments
 
-This project stands on the shoulders of the community that has been fighting for Garmin data access for years:
+<details>
+<summary>Standing on the shoulders of the community</summary>
 
-- **[garth](https://github.com/matin/garth)** by [@matin](https://github.com/matin) — The authentication library that powered the entire Garmin Python ecosystem. Reached 350k+ monthly PyPI downloads before Garmin's changes forced its deprecation in March 2026. Garth's clean design and the maintainer's tireless work through multiple Garmin SSO changes kept the community alive for years.
-- **[python-garminconnect](https://github.com/cyberjunky/python-garminconnect)** by [@cyberjunky](https://github.com/cyberjunky) — 2,000+ stars, 127+ API methods mapped, the most comprehensive Garmin API wrapper. The endpoint catalog in this project was informed by their work.
-- **[GarminDB](https://github.com/tcgoetz/GarminDB)** by [@tcgoetz](https://github.com/tcgoetz) — 3,000+ stars, pioneered the approach of storing Garmin data in a local database with analysis notebooks. The SQLite-first design of garmin-givemydata follows their lead.
-- **[garmin-connect-export](https://github.com/pe-st/garmin-connect-export)** — Reliable activity export tool supporting GPX, TCX, FIT, and JSON formats.
-- **[garmin-data-export](https://github.com/sirredbeard/garmin-data-export)** — Exports Garmin data into LLM-readable text files.
-- **[garmy](https://github.com/bes-dev/garmy)** — Brought AI-first thinking to Garmin data access with MCP server support.
+- **[garth](https://github.com/matin/garth)** by [@matin](https://github.com/matin) — 350k+ monthly PyPI downloads before deprecation. The auth library that powered the Garmin Python ecosystem.
+- **[python-garminconnect](https://github.com/cyberjunky/python-garminconnect)** by [@cyberjunky](https://github.com/cyberjunky) — 2,000+ stars, 127+ API methods. The endpoint catalog was informed by their work.
+- **[GarminDB](https://github.com/tcgoetz/GarminDB)** by [@tcgoetz](https://github.com/tcgoetz) — 3,000+ stars. Pioneered SQLite-first Garmin data storage.
+- **[garmin-connect-export](https://github.com/pe-st/garmin-connect-export)** — Reliable activity export (GPX, TCX, FIT, JSON).
+- **[garmin-data-export](https://github.com/sirredbeard/garmin-data-export)** — Garmin data into LLM-readable text files.
+- **[garmy](https://github.com/bes-dev/garmy)** — AI-first Garmin data access with MCP support.
 
-These projects served the community faithfully. When Garmin broke them, we built on what they taught us.
+</details>
 
-### Before garmin-givemydata
+<details>
+<summary>Your legal right to your data (GDPR, CCPA, EU Data Act)</summary>
 
-The community has been working around Garmin's restrictions for years using various formats and tools:
+### EU/EEA — GDPR
 
-| Approach | Format | Limitation |
-|----------|--------|------------|
-| Garmin Connect web export | CSV (bulk), GPX/TCX/FIT (per activity) | Manual, one activity at a time for GPS data |
-| Garmin GDPR data request | JSON (zip file) | Can take **up to 30 days** to process |
-| garmin-connect-export | GPX, TCX, FIT, JSON | Activities only, no health metrics |
-| GarminDB | SQLite (from FIT files) | Requires USB download from device |
-| python-garminconnect | JSON (API responses) | Broken since March 2026 |
-| garth | JSON (auth only) | Deprecated March 2026 |
+**Article 20 — Right to Data Portability** grants the right to receive personal data in a "structured, commonly used and machine-readable format." This covers raw sensor data (heart rate, sleep, steps, SpO2). Derived metrics (training readiness, fitness age) are covered under **Article 15 — Right of Access**.
 
-garmin-givemydata gives you **all your data** — health metrics AND original FIT files — in a **queryable database** (not raw files), with **AI analysis built in** (not just export), and **daily incremental sync** (not a one-time dump).
+### United States — CCPA
 
-## Your Legal Right to Your Data
+**Section 1798.100(d)** requires businesses to provide personal information in a "readily useable format that allows the consumer to transmit this information from one entity to another entity without hindrance."
 
-Data portability laws in multiple jurisdictions grant individuals the right to access and receive their personal data. Your applicable rights depend on your jurisdiction and which Garmin entity controls your data (Garmin Ltd. is incorporated in Switzerland; Garmin International is in Kansas, USA).
+### EU Data Act (Since September 2025)
 
-### EU/EEA — General Data Protection Regulation (GDPR)
+**Article 3** explicitly requires IoT manufacturers to make data available "without undue delay, free of charge, and, where applicable, continuously and in real-time." A Garmin watch is an IoT device. The data it generates belongs to the user.
 
-**Article 20 — Right to Data Portability:**
+**If Garmin provided an open API, this tool would not need to exist.**
 
-> *"The data subject shall have the right to receive the personal data concerning him or her, which he or she has provided to a controller, in a structured, commonly used and machine-readable format and have the right to transmit those data to another controller without hindrance from the controller to which the personal data have been provided."*
-
-Article 20 covers data you directly provided and data observed/collected by sensors (heart rate readings, sleep stages, steps, SpO2, respiration — i.e., raw sensor data from your Garmin device). Note that Article 20 may **not** cover derived or inferred data — metrics like training readiness scores, endurance scores, hill scores, race predictions, and fitness age are algorithmic outputs that Garmin computes from raw data. These derived metrics may fall outside Article 20's portability requirement (per EDPB guidance), though they are covered under **Article 15 — Right of Access**, which grants the right to access **all** personal data a controller processes, including derived data.
-
-If Garmin's official export is inadequate, the proper legal remedy under GDPR is to file a complaint with your national Data Protection Authority. This tool helps you exercise your right of access in practice.
-
-**Applies to:** EU/EEA residents only.
-
-### United States — California Consumer Privacy Act (CCPA)
-
-**Section 1798.100(a) — Right to Know:**
-
-> *"A consumer shall have the right to request that a business that collects a consumer's personal information disclose to that consumer the categories and specific pieces of personal information the business has collected."*
-
-**Section 1798.100(d) — Right to Portability:** Businesses must provide personal information in a "readily useable format that allows the consumer to transmit this information from one entity to another entity without hindrance."
-
-The CCPA allows up to **two right-to-know requests per 12-month period**, with a 45-day response window (extendable by 45 more days). California residents (and residents of states with similar laws — Colorado, Connecticut, Virginia, Utah, Oregon, Texas, Montana, and others) have statutory rights to their personal data.
-
-**Applies to:** California residents (and residents of other states with similar privacy laws).
-
-### US Federal — Computer Fraud and Abuse Act (CFAA)
-
-In **Van Buren v. United States (2021)**, the US Supreme Court narrowed the CFAA's "exceeds authorized access" provision, holding it means accessing areas of a computer one is not entitled to access at all — not using authorized access for purposes that violate a terms-of-service agreement. However, Van Buren addressed the "exceeds authorized access" prong, not the separate "without authorization" prong. Whether a platform can revoke authorization through technical measures (like bot detection) and thereby make continued automated access "without authorization" is **not settled law**.
-
-In practice, accessing your own account with your own legitimate credentials to retrieve your own personal data carries low CFAA risk, but the interaction between ToS violations and the CFAA remains an open legal question.
-
-### Brazil — Lei Geral de Proteção de Dados (LGPD)
-
-**Article 18(V) — Right to Data Portability:**
-
-> *"The data subject has the right to obtain from the controller, at any time and upon request: [...] V - portability of the data to another service or product provider, through an express request, subject to observance of commercial and industrial secrets."*
-
-Brazilian residents have similar (though not identical) data portability rights to EU citizens. The LGPD portability right is still largely unregulated by Brazil's ANPD and includes additional restrictions around commercial and industrial secrets.
-
-**Applies to:** Brazilian residents only.
-
-### Why This Tool Exists
-
-**This tool would not need to exist if Garmin provided adequate data portability.**
-
-Garmin offers a data export through their Data Management portal. In practice, the export has significant gaps:
-
-| Issue | Garmin's Export | What we believe the law requires |
-|-------|----------------|----------------------------------|
-| **Completeness** | Missing raw sensor data: continuous heart rate readings, detailed HRV nightly data, per-activity running dynamics (ground contact time, vertical oscillation, stride length, ground contact balance). Garmin collects and displays these in their app but does not include them in the export | GDPR Art. 15 requires access to **all** personal data; Art. 20 requires portability of raw sensor data in a machine-readable format |
-| **Format** | Raw JSON blobs in a ZIP file — not tabular, not queryable, not structured for transfer to another service | GDPR Art. 20 requires "structured, commonly used and machine-readable" format that enables transfer "without hindrance" |
-| **Timeliness** | One-time snapshot that can take up to 30 days (within the legally permitted window, but not designed for ongoing access) | While 30 days is technically compliant with GDPR Art. 12, the lack of any real-time or incremental export mechanism means users cannot practically exercise ongoing control over their data |
-
-Garmin collects your heart rate every second, your sleep stages every night, your stress levels continuously, your running dynamics on every step — and displays all of it in their app. But their official export omits much of this raw sensor data and delivers it in a format not suited for analysis or transfer to another service.
-
-Even if Garmin's one-time export were complete and well-formatted, it would still be insufficient. Your body generates new health data **every day** — every heartbeat, every night's sleep, every workout. A one-time ZIP dump is stale the moment it's delivered. What data portability actually requires is **ongoing, programmatic access** — an API or daily export that lets you keep your local copy current, analyze trends in real-time, and feed your data to the tools of your choice. Garmin has the infrastructure (their app syncs in seconds), but they choose not to expose it to users. They reserve programmatic access exclusively for approved business partners through the [Garmin Connect Developer Program](https://developer.garmin.com/gc-developer-program/), which individual developers are denied entry to.
-
-**If Garmin provided an open API or even a daily automated export, this tool would not need to exist.** We built it because the official channels fail to deliver what the law intends and what users need.
-
-### EU Data Act (Applicable Since September 2025)
-
-The [EU Data Act](https://eur-lex.europa.eu/eli/reg/2023/2854/oj) (Regulation 2023/2854) goes further than GDPR. It **explicitly requires manufacturers of connected devices (IoT) to provide users access to data generated by their devices** — which includes fitness trackers and wearables like Garmin watches.
-
-**Article 3 — Obligation to make data accessible:**
-
-> *"Where data cannot be directly accessed by the user from the product, the data holder shall make available to the user the data [...] without undue delay, free of charge, and, where applicable, continuously and in real-time."*
-
-**Article 4 — Right of users to access and use data:**
-
-Users have the right to access data generated by their connected devices, and manufacturers must make this data available in a "comprehensive, structured, commonly used and machine-readable format."
-
-Under the EU Data Act, Garmin is legally required to provide EU users with real-time, machine-readable access to the data generated by their watches — including heart rate, sleep, steps, GPS, and all other sensor data. The Act applies to data generated by the device, not just data "provided by" the user (which was the narrower scope of GDPR Article 20).
-
-**This is now EU law. A Garmin watch is an IoT device. The data it generates belongs to the user.**
+</details>
 
 ## Disclaimer
 
-**This project is for personal, educational, and research purposes only. Nothing in this document constitutes legal advice. Consult a qualified attorney in your jurisdiction for legal guidance specific to your situation.**
-
-- This tool is **unofficial** and is **not affiliated with, endorsed by, or supported by Garmin Ltd. or its subsidiaries**.
-- This tool accesses Garmin Connect using your own credentials to retrieve your own personal data. It does not access, collect, or store any other user's data.
-- **Use of this tool may violate Garmin's Terms of Service.** While we believe the legal right to data portability is clear, the interaction between data protection law and terms of service is unsettled in many jurisdictions. **You assume all risk and responsibility** for your use of this tool, including the risk of account suspension or termination by Garmin.
-- The authors and contributors of this project are **not responsible** for any consequences arising from the use of this tool, including but not limited to: account termination, data loss, legal action, breach of contract claims, or any other damages.
-- This tool is provided **"as is"**, without warranty of any kind, express or implied.
-- This tool does **not** bypass any authentication, encryption, or security measures. It logs in through the standard web interface using your own credentials, the same way you would in a browser.
-- **Do not** use this tool to access accounts that do not belong to you.
-- **Do not** use this tool for commercial purposes, competitive intelligence, or any activity that harms Garmin or its users.
-- Users are solely responsible for complying with all applicable laws and terms of service in their jurisdiction.
-- Raw personal health data (sensor readings) is not copyrightable. However, Garmin's specific data structures, API designs, and derived algorithmic outputs may have intellectual property protections.
-
-If you believe in the right to personal data portability, consider filing a formal GDPR/CCPA data portability request with Garmin through their [Data Management portal](https://www.garmin.com/en-US/account/datamanagement/) to establish a record of what their official export provides and what it omits.
+This tool is **unofficial** and **not affiliated with Garmin**. It accesses Garmin Connect using your own credentials to retrieve your own data. **Use may violate Garmin's Terms of Service.** You assume all risk and responsibility. See the [full disclaimer](https://github.com/nrvim/garmin-givemydata/wiki/Disclaimer) for details.
 
 ## License
 
-[AGPL-3.0](LICENSE) — Free to use, modify, and distribute. If you build a service using this code, you must keep it open source. This ensures data portability tools remain available to everyone.
+[AGPL-3.0](LICENSE) — Free to use, modify, and distribute. If you build a service using this code, you must keep it open source.

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -1091,14 +1091,23 @@ def upsert_fitness_age(conn: sqlite3.Connection, record: dict, cal_date: str = N
 
 
 def upsert_weight(conn: sqlite3.Connection, record: dict, cal_date: str = None) -> None:
-    d = cal_date or record.get("calendarDate") or record.get("date")
+    from datetime import datetime
+
+    d = cal_date or record.get("calendarDate")
+
+    # The "date" field from weight endpoints is a Unix timestamp in
+    # milliseconds (e.g. 1743345400000), not a calendar date string.
+    # Convert it properly instead of storing the raw integer.
     if not d:
-        # weight_latest has a timestamp, not a date
         ts = record.get("date")
         if isinstance(ts, (int, float)):
-            from datetime import datetime
+            # Garmin uses milliseconds; values > 1e10 are ms timestamps
+            if ts > 1e10:
+                ts = ts / 1000
+            d = datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+        elif isinstance(ts, str) and ts[:4].isdigit() and "-" in ts:
+            d = ts[:10]
 
-            d = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d")
     if not d:
         return
     d = str(d)[:10]
@@ -1910,3 +1919,28 @@ def query(conn: sqlite3.Connection, sql: str, params: Any = None) -> list[dict]:
     """Execute *sql* with optional *params* and return results as a list of dicts."""
     cursor = conn.execute(sql, params or [])
     return [dict(row) for row in cursor.fetchall()]
+
+
+def query_readonly(sql: str, params: Any = None, limit: int = 1000) -> list[dict]:
+    """Execute a read-only query against the database.
+
+    Opens the database in SQLite read-only mode (``?mode=ro`` URI),
+    which enforces read-only at the engine level — no writes, no
+    PRAGMA changes, regardless of the SQL content.  Additionally
+    blocks ATTACH/DETACH to prevent filesystem side-effects.
+    """
+    # Block ATTACH/DETACH before opening any connection — these can
+    # create zero-byte files on disk even in read-only mode.
+    check = sql.strip().upper()
+    if "ATTACH" in check or "DETACH" in check:
+        raise PermissionError("ATTACH and DETACH are not permitted.")
+
+    ro_conn = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+    ro_conn.row_factory = sqlite3.Row
+    try:
+        ro_conn.execute("PRAGMA busy_timeout = 5000")
+        cursor = ro_conn.execute(sql, params or [])
+        rows = [dict(row) for row in cursor.fetchmany(limit)]
+        return rows
+    finally:
+        ro_conn.close()

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -1938,9 +1938,10 @@ def query_readonly(sql: str, params: Any = None, limit: int = 1000) -> list[dict
     ro_conn = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
     ro_conn.row_factory = sqlite3.Row
     try:
+        clamped = max(1, min(limit if isinstance(limit, int) else 1000, 10000))
         ro_conn.execute("PRAGMA busy_timeout = 5000")
         cursor = ro_conn.execute(sql, params or [])
-        rows = [dict(row) for row in cursor.fetchmany(limit)]
+        rows = [dict(row) for row in cursor.fetchmany(clamped)]
         return rows
     finally:
         ro_conn.close()

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -65,7 +65,8 @@ def garmin_query(sql: str, limit: int = 1000) -> str:
     the SQL content.  Results are capped at *limit* rows (default 1000).
     """
     try:
-        rows = query_readonly(sql, limit=limit)
+        clamped = max(1, min(limit, 10000))
+        rows = query_readonly(sql, limit=clamped)
         return json.dumps(rows, indent=2, default=str)
     except Exception as exc:
         log.exception("garmin_query failed")
@@ -428,9 +429,15 @@ def _run_incremental_sync() -> dict:
 
         return incremental_sync()
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        future = pool.submit(_go)
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = pool.submit(_go)
+    try:
         return future.result(timeout=300)
+    except concurrent.futures.TimeoutError:
+        pool.shutdown(wait=False, cancel_futures=True)
+        raise
+    finally:
+        pool.shutdown(wait=False)
 
 
 def _get_data_freshness() -> dict:

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -4,13 +4,12 @@ Garmin MCP server — exposes health and activity data via FastMCP tools.
 
 import json
 import logging
-import math
 import threading
 from datetime import date, timedelta
 
 from mcp.server.fastmcp import FastMCP
 
-from .db import DB_PATH, get_connection, init_db, query, query_readonly
+from .db import get_connection, init_db, query, query_readonly
 
 log = logging.getLogger(__name__)
 
@@ -426,6 +425,7 @@ def _run_incremental_sync() -> dict:
 
     def _go():
         from .sync import incremental_sync
+
         return incremental_sync()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
@@ -823,12 +823,14 @@ def garmin_training_load() -> str:
             # Only emit weekly points + last 14 days for conciseness
             remaining = days_range - i
             if remaining <= 14 or i % 7 == 0:
-                timeline.append({
-                    "date": d,
-                    "ctl": round(ctl, 1),
-                    "atl": round(atl, 1),
-                    "tsb": round(ctl - atl, 1),
-                })
+                timeline.append(
+                    {
+                        "date": d,
+                        "ctl": round(ctl, 1),
+                        "atl": round(atl, 1),
+                        "tsb": round(ctl - atl, 1),
+                    }
+                )
 
         # Weekly volume (last 12 weeks)
         twelve_weeks_ago = str(today - timedelta(weeks=12))
@@ -868,9 +870,12 @@ def garmin_training_load() -> str:
                 "atl_fatigue": current.get("atl"),
                 "tsb_form": current.get("tsb"),
                 "interpretation": (
-                    "FRESH — ready to race/test" if current.get("tsb", 0) > 15
-                    else "OPTIMAL — good training balance" if current.get("tsb", 0) > 0
-                    else "FATIGUED — absorbing training load" if current.get("tsb", 0) > -15
+                    "FRESH — ready to race/test"
+                    if current.get("tsb", 0) > 15
+                    else "OPTIMAL — good training balance"
+                    if current.get("tsb", 0) > 0
+                    else "FATIGUED — absorbing training load"
+                    if current.get("tsb", 0) > -15
                     else "OVERREACHING — need recovery"
                 ),
             },
@@ -902,6 +907,7 @@ def garmin_compare(
     """
     conn = get_connection()
     try:
+
         def _fetch_period(start: str, end: str) -> dict:
             daily = query(
                 conn,
@@ -1049,10 +1055,7 @@ def garmin_fitness_age(period: str = "month") -> str:
     if period not in ("week", "month"):
         return json.dumps({"error": "period must be 'week' or 'month'."})
 
-    group_expr = (
-        "strftime('%Y-W%W', calendar_date)" if period == "week"
-        else "strftime('%Y-%m', calendar_date)"
-    )
+    group_expr = "strftime('%Y-W%W', calendar_date)" if period == "week" else "strftime('%Y-%m', calendar_date)"
 
     conn = get_connection()
     try:
@@ -1150,8 +1153,12 @@ def garmin_hrv(days: int = 30) -> str:
                 "baseline_low": latest["baseline_low"],
                 "baseline_upper": latest["baseline_upper"],
                 "position": (
-                    "ABOVE baseline" if latest["weekly_avg"] and latest["baseline_upper"] and latest["weekly_avg"] > latest["baseline_upper"]
-                    else "BELOW baseline" if latest["weekly_avg"] and latest["baseline_low"] and latest["weekly_avg"] < latest["baseline_low"]
+                    "ABOVE baseline"
+                    if latest["weekly_avg"]
+                    and latest["baseline_upper"]
+                    and latest["weekly_avg"] > latest["baseline_upper"]
+                    else "BELOW baseline"
+                    if latest["weekly_avg"] and latest["baseline_low"] and latest["weekly_avg"] < latest["baseline_low"]
                     else "WITHIN baseline"
                 ),
             },
@@ -1200,9 +1207,9 @@ def garmin_body_battery(days: int = 14) -> str:
 
         # Flag critical days (wake < 40 or low < 15)
         critical_days = [
-            r["calendar_date"] for r in rows
-            if (r["at_wake"] is not None and r["at_wake"] < 40)
-            or (r["low"] is not None and r["low"] < 15)
+            r["calendar_date"]
+            for r in rows
+            if (r["at_wake"] is not None and r["at_wake"] < 40) or (r["low"] is not None and r["low"] < 15)
         ]
 
         # Average wake value
@@ -1306,14 +1313,16 @@ def garmin_heart_rate(days: int = 30) -> str:
             avg_7d = round(sum(window) / len(window), 1) if window else None
             rhr = r["rhr"]
             elevated = rhr and avg_7d and (rhr - avg_7d > 5)
-            output.append({
-                "date": r["calendar_date"],
-                "rhr": rhr,
-                "min_hr": r["min_hr"],
-                "max_hr": r["max_hr"],
-                "avg_7d": avg_7d,
-                "elevated": elevated,
-            })
+            output.append(
+                {
+                    "date": r["calendar_date"],
+                    "rhr": rhr,
+                    "min_hr": r["min_hr"],
+                    "max_hr": r["max_hr"],
+                    "avg_7d": avg_7d,
+                    "elevated": elevated,
+                }
+            )
 
         # Trim to requested days
         cutoff = str(date.today() - timedelta(days=days - 1))
@@ -1578,16 +1587,18 @@ def garmin_recovery(days_after: int = 3) -> str:
             else:
                 rhr_delta = None
 
-            results.append({
-                "activity": a["activity_name"],
-                "type": a["activity_type"],
-                "date": d,
-                "load": a["load"],
-                "duration_min": a["duration_min"],
-                "avg_hr": a["avg_hr"],
-                "rhr_delta_after": rhr_delta,
-                "recovery": recovery_days,
-            })
+            results.append(
+                {
+                    "activity": a["activity_name"],
+                    "type": a["activity_type"],
+                    "date": d,
+                    "load": a["load"],
+                    "duration_min": a["duration_min"],
+                    "avg_hr": a["avg_hr"],
+                    "rhr_delta_after": rhr_delta,
+                    "recovery": recovery_days,
+                }
+            )
 
         # Aggregate: avg recovery by sport type
         by_sport: dict[str, list] = {}
@@ -1603,13 +1614,18 @@ def garmin_recovery(days_after: int = 3) -> str:
                 "avg_rhr_impact": round(sum(deltas) / len(deltas), 1),
                 "sessions": len(deltas),
             }
-            for sport, deltas in by_sport.items() if deltas
+            for sport, deltas in by_sport.items()
+            if deltas
         }
 
-        return json.dumps({
-            "recovery_by_sport": sport_summary,
-            "sessions": results,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "recovery_by_sport": sport_summary,
+                "sessions": results,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1656,12 +1672,16 @@ def garmin_training_status(days: int = 90) -> str:
 
         current = rows[-1]["status"] if rows else None
 
-        return json.dumps({
-            "current_status": current,
-            "days_in_status": counts,
-            "transitions": transitions[-10:],
-            "daily": rows,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "current_status": current,
+                "days_in_status": counts,
+                "transitions": transitions[-10:],
+                "daily": rows,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1700,11 +1720,15 @@ def garmin_workouts() -> str:
             """SELECT id, raw_json FROM training_plans""",
         )
 
-        return json.dumps({
-            "workout_library": workouts,
-            "scheduled": schedule,
-            "training_plans": plans,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "workout_library": workouts,
+                "scheduled": schedule,
+                "training_plans": plans,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1738,11 +1762,15 @@ def garmin_badges() -> str:
                 by_category[cat] = []
             by_category[cat].append(r)
 
-        return json.dumps({
-            "total_badges": len(rows),
-            "badges": rows,
-            "by_category": {k: len(v) for k, v in by_category.items()},
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "total_badges": len(rows),
+                "badges": rows,
+                "by_category": {k: len(v) for k, v in by_category.items()},
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1778,12 +1806,16 @@ def garmin_hydration(days: int = 30) -> str:
 
         tracked = [r for r in rows if r["intake_ml"] and r["intake_ml"] > 0]
 
-        return json.dumps({
-            "days_tracked": len(tracked),
-            "days_total": len(rows),
-            "data": rows if tracked else [],
-            "note": "No hydration data logged" if not tracked else None,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "days_tracked": len(tracked),
+                "days_total": len(rows),
+                "data": rows if tracked else [],
+                "note": "No hydration data logged" if not tracked else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1818,13 +1850,17 @@ def garmin_respiration(days: int = 14) -> str:
         avgs = [r["avg_waking"] for r in rows if r["avg_waking"]]
         elevated = [r["calendar_date"] for r in rows if r["avg_waking"] and r["avg_waking"] > 20]
 
-        return json.dumps({
-            "summary": {
-                "period_avg": round(sum(avgs) / len(avgs), 1) if avgs else None,
-                "elevated_days": elevated,
+        return json.dumps(
+            {
+                "summary": {
+                    "period_avg": round(sum(avgs) / len(avgs), 1) if avgs else None,
+                    "elevated_days": elevated,
+                },
+                "daily": rows,
             },
-            "daily": rows,
-        }, indent=2, default=str)
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1859,10 +1895,14 @@ def garmin_intensity_minutes(days: int = 30) -> str:
             [start],
         )
 
-        return json.dumps({
-            "who_target": "150 min/week (moderate) or 75 min/week (vigorous)",
-            "weekly": rows,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "who_target": "150 min/week (moderate) or 75 min/week (vigorous)",
+                "weekly": rows,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1896,14 +1936,18 @@ def garmin_floors(days: int = 14) -> str:
         ups = [r["floors_up"] for r in rows if r["floors_up"]]
         goal_met = sum(1 for r in rows if r["pct_of_goal"] and r["pct_of_goal"] >= 100)
 
-        return json.dumps({
-            "summary": {
-                "avg_floors_day": round(sum(ups) / len(ups), 1) if ups else None,
-                "days_goal_met": goal_met,
-                "days_total": len(rows),
+        return json.dumps(
+            {
+                "summary": {
+                    "avg_floors_day": round(sum(ups) / len(ups), 1) if ups else None,
+                    "days_goal_met": goal_met,
+                    "days_total": len(rows),
+                },
+                "daily": rows,
             },
-            "daily": rows,
-        }, indent=2, default=str)
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -1951,16 +1995,20 @@ def garmin_steps(days: int = 14) -> str:
             else:
                 streak = 0
 
-        return json.dumps({
-            "summary": {
-                "avg_steps": round(sum(steps_list) / len(steps_list), 0) if steps_list else None,
-                "days_goal_met": goal_met_days,
-                "days_total": len(rows),
-                "longest_goal_streak": max_streak,
-                "best_day": max(rows, key=lambda r: r["steps"] or 0)["calendar_date"] if rows else None,
+        return json.dumps(
+            {
+                "summary": {
+                    "avg_steps": round(sum(steps_list) / len(steps_list), 0) if steps_list else None,
+                    "days_goal_met": goal_met_days,
+                    "days_total": len(rows),
+                    "longest_goal_streak": max_streak,
+                    "best_day": max(rows, key=lambda r: r["steps"] or 0)["calendar_date"] if rows else None,
+                },
+                "daily": rows,
             },
-            "daily": rows,
-        }, indent=2, default=str)
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2006,14 +2054,18 @@ def garmin_calories(days: int = 14) -> str:
         totals = [r["total_cal"] for r in rows if r["total_cal"]]
         actives = [r["active_cal"] for r in rows if r["active_cal"]]
 
-        return json.dumps({
-            "summary": {
-                "avg_total_cal": round(sum(totals) / len(totals), 0) if totals else None,
-                "avg_active_cal": round(sum(actives) / len(actives), 0) if actives else None,
+        return json.dumps(
+            {
+                "summary": {
+                    "avg_total_cal": round(sum(totals) / len(totals), 0) if totals else None,
+                    "avg_active_cal": round(sum(actives) / len(actives), 0) if actives else None,
+                },
+                "daily": rows,
+                "food_log": consumed if consumed else [],
             },
-            "daily": rows,
-            "food_log": consumed if consumed else [],
-        }, indent=2, default=str)
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2043,17 +2095,19 @@ def garmin_blood_pressure(days: int = 90) -> str:
         )
 
         flagged = [
-            r for r in rows
-            if (r["systolic"] and r["systolic"] >= 140)
-            or (r["diastolic"] and r["diastolic"] >= 90)
+            r for r in rows if (r["systolic"] and r["systolic"] >= 140) or (r["diastolic"] and r["diastolic"] >= 90)
         ]
 
-        return json.dumps({
-            "total_readings": len(rows),
-            "elevated_readings": len(flagged),
-            "data": rows,
-            "note": "No blood pressure data recorded" if not rows else None,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "total_readings": len(rows),
+                "elevated_readings": len(flagged),
+                "data": rows,
+                "note": "No blood pressure data recorded" if not rows else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2073,11 +2127,15 @@ def garmin_goals() -> str:
             """SELECT goal_id, goal_type, goal_value, raw_json
                FROM goals""",
         )
-        return json.dumps({
-            "total_goals": len(rows),
-            "goals": rows,
-            "note": "No goals set" if not rows else None,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "total_goals": len(rows),
+                "goals": rows,
+                "note": "No goals set" if not rows else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2097,11 +2155,15 @@ def garmin_challenges() -> str:
             """SELECT id, challenge_type, raw_json
                FROM challenges""",
         )
-        return json.dumps({
-            "total_challenges": len(rows),
-            "challenges": rows,
-            "note": "No challenges found" if not rows else None,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "total_challenges": len(rows),
+                "challenges": rows,
+                "note": "No challenges found" if not rows else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2178,17 +2240,21 @@ def garmin_race_predictions(days: int = 30) -> str:
 
         latest = rows[-1] if rows else {}
 
-        return json.dumps({
-            "latest": {
-                "date": latest.get("calendar_date"),
-                "5k": latest.get("time_5k_fmt"),
-                "10k": latest.get("time_10k_fmt"),
-                "half_marathon": latest.get("time_half_fmt"),
-                "marathon": latest.get("time_marathon_fmt"),
+        return json.dumps(
+            {
+                "latest": {
+                    "date": latest.get("calendar_date"),
+                    "5k": latest.get("time_5k_fmt"),
+                    "10k": latest.get("time_10k_fmt"),
+                    "half_marathon": latest.get("time_half_fmt"),
+                    "marathon": latest.get("time_marathon_fmt"),
+                },
+                "trend": {"direction": trend, "5k_delta_sec": round(delta)},
+                "daily": rows,
             },
-            "trend": {"direction": trend, "5k_delta_sec": round(delta)},
-            "daily": rows,
-        }, indent=2, default=str)
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2216,15 +2282,21 @@ def garmin_endurance_score(days: int = 30) -> str:
 
         scores = [r["overall_score"] for r in rows if r["overall_score"]]
         if len(scores) >= 2:
-            trend = "improving" if scores[-1] > scores[0] + 10 else "declining" if scores[-1] < scores[0] - 10 else "stable"
+            trend = (
+                "improving" if scores[-1] > scores[0] + 10 else "declining" if scores[-1] < scores[0] - 10 else "stable"
+            )
         else:
             trend = "insufficient data"
 
-        return json.dumps({
-            "latest": rows[-1] if rows else {},
-            "trend": trend,
-            "daily": rows,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "latest": rows[-1] if rows else {},
+                "trend": trend,
+                "daily": rows,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2249,10 +2321,14 @@ def garmin_hill_score(days: int = 30) -> str:
                ORDER BY calendar_date""",
             [start],
         )
-        return json.dumps({
-            "latest": rows[-1] if rows else {},
-            "daily": rows,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "latest": rows[-1] if rows else {},
+                "daily": rows,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2290,11 +2366,15 @@ def garmin_vo2max() -> str:
                ORDER BY start_time_local DESC""",
         )
 
-        return json.dumps({
-            "from_vo2max_table": vo2_table,
-            "from_activities": vo2_activities,
-            "note": "No VO2max data" if not vo2_table and not vo2_activities else None,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "from_vo2max_table": vo2_table,
+                "from_activities": vo2_activities,
+                "note": "No VO2max data" if not vo2_table and not vo2_activities else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2330,11 +2410,15 @@ def garmin_health_snapshot() -> str:
                     entry["data"] = r["raw_json"]
             parsed.append(entry)
 
-        return json.dumps({
-            "total_snapshots": len(parsed),
-            "snapshots": parsed,
-            "note": "No health snapshots taken" if not parsed else None,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "total_snapshots": len(parsed),
+                "snapshots": parsed,
+                "note": "No health snapshots taken" if not parsed else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 
@@ -2355,11 +2439,15 @@ def garmin_gear() -> str:
                       brand, model, date_begin
                FROM gear""",
         )
-        return json.dumps({
-            "total_gear": len(rows),
-            "gear": rows,
-            "note": "No gear tracked" if not rows else None,
-        }, indent=2, default=str)
+        return json.dumps(
+            {
+                "total_gear": len(rows),
+                "gear": rows,
+                "note": "No gear tracked" if not rows else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -3,11 +3,16 @@ Garmin MCP server — exposes health and activity data via FastMCP tools.
 """
 
 import json
+import logging
+import math
+import threading
 from datetime import date, timedelta
 
 from mcp.server.fastmcp import FastMCP
 
-from .db import get_connection, init_db, query
+from .db import DB_PATH, get_connection, init_db, query, query_readonly
+
+log = logging.getLogger(__name__)
 
 mcp = FastMCP("garmin")
 
@@ -34,8 +39,10 @@ def garmin_schema() -> str:
         result = {}
         for t in tables:
             table_name = t["name"]
-            cols = query(conn, f"PRAGMA table_info({table_name})")
-            row_count = query(conn, f"SELECT COUNT(*) AS cnt FROM {table_name}")[0]["cnt"]
+            if not table_name.isidentifier():
+                continue
+            cols = query(conn, f"PRAGMA table_info([{table_name}])")
+            row_count = query(conn, f"SELECT COUNT(*) AS cnt FROM [{table_name}]")[0]["cnt"]
             result[table_name] = {
                 "columns": [c["name"] for c in cols],
                 "row_count": row_count,
@@ -51,24 +58,19 @@ def garmin_schema() -> str:
 
 
 @mcp.tool()
-def garmin_query(sql: str) -> str:
-    """Run a custom SELECT query against the Garmin database. Only SELECT statements are allowed."""
-    normalized = sql.strip().lstrip(";").strip().upper()
-    if not normalized.startswith("SELECT"):
-        return json.dumps({"error": "Only SELECT statements are permitted."})
-    # Block dangerous keywords anywhere in the query
-    blocked = ["DROP", "DELETE", "INSERT", "UPDATE", "ALTER", "CREATE", "ATTACH", "DETACH", "PRAGMA"]
-    for keyword in blocked:
-        if keyword in normalized.split("'")[0]:  # ignore keywords inside string literals
-            return json.dumps({"error": f"'{keyword}' is not permitted in queries."})
-    conn = get_connection()
+def garmin_query(sql: str, limit: int = 1000) -> str:
+    """Run a read-only SELECT query against the Garmin database.
+
+    The database is opened in SQLite read-only mode at the engine level,
+    so writes, ATTACH, and schema changes are impossible regardless of
+    the SQL content.  Results are capped at *limit* rows (default 1000).
+    """
     try:
-        rows = query(conn, sql)
+        rows = query_readonly(sql, limit=limit)
         return json.dumps(rows, indent=2, default=str)
     except Exception as exc:
-        return json.dumps({"error": str(exc)})
-    finally:
-        conn.close()
+        log.exception("garmin_query failed")
+        return json.dumps({"error": "Query failed. Check that your SQL is a valid SELECT statement."})
 
 
 # ---------------------------------------------------------------------------
@@ -415,16 +417,2032 @@ def garmin_trends(metric: str, period: str = "month") -> str:
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool()
-def garmin_sync() -> str:
-    """Trigger an incremental sync to fetch the latest Garmin data."""
-    try:
-        from .sync import incremental_sync
+_sync_lock = threading.Lock()
 
-        result = incremental_sync()
-        return json.dumps({"status": "success", "result": result}, indent=2, default=str)
+
+def _run_incremental_sync() -> dict:
+    """Run the browser-based sync in a thread. Internal helper."""
+    import concurrent.futures
+
+    def _go():
+        from .sync import incremental_sync
+        return incremental_sync()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_go)
+        return future.result(timeout=300)
+
+
+def _get_data_freshness() -> dict:
+    """Return data freshness info from the database."""
+    from datetime import datetime, timezone
+
+    today = str(date.today())
+    conn = get_connection()
+    try:
+        freshness = query(
+            conn,
+            """SELECT 'daily_summary' AS source, MAX(calendar_date) AS latest FROM daily_summary
+               UNION ALL SELECT 'sleep', MAX(calendar_date) FROM sleep
+               UNION ALL SELECT 'hrv', MAX(calendar_date) FROM hrv
+               UNION ALL SELECT 'activity', MAX(DATE(start_time_local)) FROM activity
+                          WHERE start_time_local IS NOT NULL
+               ORDER BY latest DESC""",
+        )
+
+        last_sync = query(
+            conn,
+            """SELECT sync_date, sync_type, records_upserted, status
+               FROM sync_log ORDER BY created_at DESC LIMIT 1""",
+        )
+
+        latest_date = freshness[0]["latest"] if freshness and freshness[0]["latest"] else None
+
+        # Calculate how long ago the last sync was
+        last_sync_ago = None
+        if last_sync and last_sync[0].get("sync_date"):
+            try:
+                sync_dt = datetime.fromisoformat(last_sync[0]["sync_date"])
+                now = datetime.now(timezone.utc)
+                if sync_dt.tzinfo is None:
+                    sync_dt = sync_dt.replace(tzinfo=timezone.utc)
+                delta = now - sync_dt
+                hours = delta.total_seconds() / 3600
+                if hours < 1:
+                    last_sync_ago = f"{int(delta.total_seconds() / 60)} minutes ago"
+                elif hours < 24:
+                    last_sync_ago = f"{hours:.1f} hours ago"
+                else:
+                    last_sync_ago = f"{delta.days} days ago"
+            except (ValueError, TypeError):
+                pass
+
+        return {
+            "today": today,
+            "latest_data_date": latest_date,
+            "is_stale": latest_date is None or latest_date < today,
+            "freshness_by_table": {r["source"]: r["latest"] for r in freshness},
+            "last_sync": last_sync[0] if last_sync else None,
+            "last_sync_ago": last_sync_ago,
+        }
+    finally:
+        conn.close()
+
+
+def _do_sync() -> dict:
+    """Acquire the lock and sync. Returns sync result or error dict."""
+    if not _sync_lock.acquire(blocking=False):
+        return {"status": "error", "error": "A sync is already in progress. Try again later."}
+    try:
+        return {"status": "success", "result": _run_incremental_sync()}
     except Exception as exc:
-        return json.dumps({"status": "error", "error": str(exc)})
+        log.exception("sync failed")
+        return {"status": "error", "error": "Sync failed. Check server logs."}
+    finally:
+        _sync_lock.release()
+
+
+@mcp.tool()
+def garmin_sync(refresh: bool = True) -> str:
+    """Sync the latest data from Garmin Connect.
+
+    Always shows when the last sync happened before doing anything.
+    Set refresh=False to just check the status without syncing.
+
+    Use this when:
+    - You just finished a run/ride and want to see the new data
+    - You want to make sure today's health data is loaded
+    - The data looks outdated
+    """
+    status = _get_data_freshness()
+
+    if not refresh:
+        if status["is_stale"]:
+            status["hint"] = "Data is not current. Call garmin_sync() to refresh."
+        return json.dumps(status, indent=2, default=str)
+
+    sync_result = _do_sync()
+    status["sync"] = sync_result
+
+    # Refresh freshness info after sync
+    if sync_result.get("status") == "success":
+        status.update(_get_data_freshness())
+        status["sync"] = sync_result
+
+    return json.dumps(status, indent=2, default=str)
+
+
+# ---------------------------------------------------------------------------
+# garmin_today
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_today() -> str:
+    """Complete snapshot of today's health: daily summary, last night's sleep,
+    training readiness, HRV status, body battery, and most recent activity.
+    Ideal as conversation context — call this first to ground any health question.
+    """
+    today = str(date.today())
+    yesterday = str(date.today() - timedelta(days=1))
+    conn = get_connection()
+    try:
+        daily = query(
+            conn,
+            """SELECT total_steps, resting_heart_rate, average_stress_level,
+                      max_stress_level, body_battery_highest, body_battery_lowest,
+                      body_battery_at_wake, average_spo2, lowest_spo2,
+                      avg_waking_respiration, total_kilocalories, active_kilocalories,
+                      moderate_intensity_minutes, vigorous_intensity_minutes,
+                      floors_ascended, sedentary_seconds, active_seconds
+               FROM daily_summary WHERE calendar_date = ?""",
+            [today],
+        )
+
+        sleep = query(
+            conn,
+            """SELECT ROUND(sleep_time_seconds / 3600.0, 2) AS sleep_hours,
+                      ROUND(deep_sleep_seconds / 60.0, 0) AS deep_min,
+                      ROUND(light_sleep_seconds / 60.0, 0) AS light_min,
+                      ROUND(rem_sleep_seconds / 60.0, 0) AS rem_min,
+                      ROUND(awake_sleep_seconds / 60.0, 0) AS awake_min,
+                      average_spo2, lowest_spo2, avg_sleep_stress,
+                      sleep_score_feedback, sleep_score_insight
+               FROM sleep WHERE calendar_date = ?""",
+            [today],
+        )
+
+        tr = query(
+            conn,
+            """SELECT score, level, feedback_short,
+                      hrv_factor_percent, hrv_factor_feedback, hrv_weekly_average,
+                      sleep_history_factor_percent, sleep_history_factor_feedback,
+                      stress_history_factor_percent, stress_history_factor_feedback,
+                      acwr_factor_percent, acwr_factor_feedback
+               FROM training_readiness WHERE calendar_date = ?""",
+            [today],
+        )
+
+        hrv = query(
+            conn,
+            """SELECT weekly_avg, last_night_avg, last_night_5min_high,
+                      status, baseline_low, baseline_upper
+               FROM hrv WHERE calendar_date = ?""",
+            [today],
+        )
+
+        last_activity = query(
+            conn,
+            """SELECT activity_name AS name, activity_type AS type,
+                      start_time_local AS date,
+                      ROUND(duration_seconds / 60.0, 1) AS duration_min,
+                      ROUND(distance_meters / 1000.0, 2) AS distance_km,
+                      ROUND(average_hr, 0) AS avg_hr,
+                      ROUND(training_load, 1) AS training_load,
+                      location_name AS location
+               FROM activity ORDER BY start_time_local DESC LIMIT 1""",
+        )
+
+        fitness = query(
+            conn,
+            """SELECT chronological_age, fitness_age
+               FROM fitness_age WHERE calendar_date = ?""",
+            [today],
+        )
+
+        result = {
+            "date": today,
+            "daily": daily[0] if daily else {},
+            "last_night_sleep": sleep[0] if sleep else {},
+            "training_readiness": tr[0] if tr else {},
+            "hrv": hrv[0] if hrv else {},
+            "fitness_age": fitness[0] if fitness else {},
+            "last_activity": last_activity[0] if last_activity else {},
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_activity_detail
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_activity_detail(activity_id: int = 0, last: bool = False) -> str:
+    """Deep-dive into a single activity.
+
+    Pass activity_id, or set last=True for the most recent activity.
+    Returns the activity summary plus splits, HR zones, weather, and
+    exercise sets (if available).
+    """
+    conn = get_connection()
+    try:
+        if last or activity_id == 0:
+            rows = query(conn, "SELECT activity_id FROM activity ORDER BY start_time_local DESC LIMIT 1")
+            if not rows:
+                return json.dumps({"error": "No activities found."})
+            activity_id = rows[0]["activity_id"]
+
+        activity = query(
+            conn,
+            """SELECT activity_id, activity_name, activity_type, start_time_local,
+                      ROUND(duration_seconds / 60.0, 1) AS duration_min,
+                      ROUND(distance_meters / 1000.0, 2) AS distance_km,
+                      calories, ROUND(average_hr, 0) AS avg_hr, ROUND(max_hr, 0) AS max_hr,
+                      ROUND(elevation_gain, 0) AS elevation_gain_m,
+                      ROUND(avg_power, 0) AS avg_power_w,
+                      ROUND(training_load, 1) AS training_load,
+                      aerobic_training_effect, anaerobic_training_effect,
+                      vo2max_value, ROUND(avg_cadence, 0) AS avg_cadence,
+                      ROUND(avg_respiration, 1) AS avg_respiration,
+                      location_name
+               FROM activity WHERE activity_id = ?""",
+            [activity_id],
+        )
+        if not activity:
+            return json.dumps({"error": f"Activity {activity_id} not found."})
+
+        splits = query(
+            conn,
+            """SELECT split_number, ROUND(distance_meters, 0) AS distance_m,
+                      ROUND(duration_seconds, 0) AS duration_sec,
+                      ROUND(average_speed, 3) AS avg_speed,
+                      ROUND(average_hr, 0) AS avg_hr, ROUND(max_hr, 0) AS max_hr,
+                      ROUND(elevation_gain, 1) AS elev_gain,
+                      ROUND(avg_cadence, 0) AS avg_cadence
+               FROM activity_splits WHERE activity_id = ?
+               ORDER BY split_number""",
+            [activity_id],
+        )
+
+        hr_zones = query(
+            conn,
+            """SELECT ROUND(zone1_seconds / 60.0, 1) AS zone1_min,
+                      ROUND(zone2_seconds / 60.0, 1) AS zone2_min,
+                      ROUND(zone3_seconds / 60.0, 1) AS zone3_min,
+                      ROUND(zone4_seconds / 60.0, 1) AS zone4_min,
+                      ROUND(zone5_seconds / 60.0, 1) AS zone5_min
+               FROM activity_hr_zones WHERE activity_id = ?""",
+            [activity_id],
+        )
+
+        weather = query(
+            conn,
+            """SELECT temperature, apparent_temperature, humidity,
+                      wind_speed, wind_direction, weather_type
+               FROM activity_weather WHERE activity_id = ?""",
+            [activity_id],
+        )
+
+        exercise_sets = query(
+            conn,
+            """SELECT set_number, exercise_name, exercise_category,
+                      reps, weight, ROUND(duration_seconds, 0) AS duration_sec
+               FROM activity_exercise_sets WHERE activity_id = ?
+               ORDER BY set_number""",
+            [activity_id],
+        )
+
+        result = {
+            "activity": activity[0],
+            "splits": splits if splits else [],
+            "hr_zones": hr_zones[0] if hr_zones else {},
+            "weather": weather[0] if weather else {},
+            "exercise_sets": [s for s in exercise_sets if s.get("exercise_name")] if exercise_sets else [],
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_sleep
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_sleep(start_date: str = "", days: int = 7) -> str:
+    """Per-night sleep breakdown with stages, SpO2, stress, and Garmin feedback.
+
+    Returns each night individually (not averages) for pattern analysis.
+    """
+    if not start_date:
+        start_date = str(date.today() - timedelta(days=days - 1))
+    end_date = str(date.today())
+
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      ROUND(sleep_time_seconds / 3600.0, 2) AS total_hours,
+                      ROUND(deep_sleep_seconds / 60.0, 0) AS deep_min,
+                      ROUND(light_sleep_seconds / 60.0, 0) AS light_min,
+                      ROUND(rem_sleep_seconds / 60.0, 0) AS rem_min,
+                      ROUND(awake_sleep_seconds / 60.0, 0) AS awake_min,
+                      awake_count,
+                      CASE WHEN sleep_time_seconds > 0
+                           THEN ROUND(deep_sleep_seconds * 100.0 / sleep_time_seconds, 1)
+                           ELSE 0 END AS deep_pct,
+                      CASE WHEN sleep_time_seconds > 0
+                           THEN ROUND(rem_sleep_seconds * 100.0 / sleep_time_seconds, 1)
+                           ELSE 0 END AS rem_pct,
+                      average_spo2, lowest_spo2,
+                      average_hr_sleep AS avg_hr,
+                      average_respiration AS avg_resp,
+                      avg_sleep_stress,
+                      sleep_score_feedback AS feedback,
+                      sleep_score_insight AS insight
+               FROM sleep
+               WHERE calendar_date BETWEEN ? AND ?
+               ORDER BY calendar_date""",
+            [start_date, end_date],
+        )
+        return json.dumps({"period": {"start": start_date, "end": end_date}, "nights": rows}, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_training_load  (CTL / ATL / TSB)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_training_load() -> str:
+    """Compute professional training periodization metrics from activity history.
+
+    Returns:
+    - CTL (Chronic Training Load, 42-day EWMA) — long-term fitness proxy
+    - ATL (Acute Training Load, 7-day EWMA) — short-term fatigue
+    - TSB (Training Stress Balance = CTL - ATL) — form / readiness
+    - Weekly volume summary (hours, km, sessions, load)
+    - Training load distribution by sport
+    """
+    conn = get_connection()
+    try:
+        activities = query(
+            conn,
+            """SELECT DATE(start_time_local) AS activity_date,
+                      activity_type,
+                      COALESCE(training_load, 0) AS load,
+                      ROUND(duration_seconds / 3600.0, 2) AS hours,
+                      ROUND(distance_meters / 1000.0, 2) AS km
+               FROM activity
+               WHERE start_time_local IS NOT NULL
+               ORDER BY start_time_local""",
+        )
+        if not activities:
+            return json.dumps({"error": "No activities found."})
+
+        # Build daily load map
+        daily_load: dict[str, float] = {}
+        for a in activities:
+            d = a["activity_date"]
+            daily_load[d] = daily_load.get(d, 0) + (a["load"] or 0)
+
+        # Date range from first activity to today
+        first_date = date.fromisoformat(activities[0]["activity_date"])
+        today = date.today()
+        days_range = (today - first_date).days + 1
+
+        # Compute EWMA
+        ctl = 0.0
+        atl = 0.0
+        ctl_decay = 2.0 / (42 + 1)
+        atl_decay = 2.0 / (7 + 1)
+        timeline = []
+
+        for i in range(days_range):
+            d = str(first_date + timedelta(days=i))
+            load = daily_load.get(d, 0)
+            ctl = ctl * (1 - ctl_decay) + load * ctl_decay
+            atl = atl * (1 - atl_decay) + load * atl_decay
+            # Only emit weekly points + last 14 days for conciseness
+            remaining = days_range - i
+            if remaining <= 14 or i % 7 == 0:
+                timeline.append({
+                    "date": d,
+                    "ctl": round(ctl, 1),
+                    "atl": round(atl, 1),
+                    "tsb": round(ctl - atl, 1),
+                })
+
+        # Weekly volume (last 12 weeks)
+        twelve_weeks_ago = str(today - timedelta(weeks=12))
+        weekly = query(
+            conn,
+            """SELECT strftime('%%Y-W%%W', start_time_local) AS week,
+                      COUNT(*) AS sessions,
+                      ROUND(SUM(duration_seconds) / 3600.0, 1) AS hours,
+                      ROUND(SUM(distance_meters) / 1000.0, 1) AS km,
+                      ROUND(SUM(COALESCE(training_load, 0)), 0) AS total_load,
+                      GROUP_CONCAT(DISTINCT activity_type) AS sports
+               FROM activity
+               WHERE start_time_local >= ?
+               GROUP BY week ORDER BY week""",
+            [twelve_weeks_ago],
+        )
+
+        # Load by sport (all time)
+        by_sport = query(
+            conn,
+            """SELECT activity_type AS sport,
+                      COUNT(*) AS sessions,
+                      ROUND(SUM(duration_seconds) / 3600.0, 1) AS total_hours,
+                      ROUND(SUM(distance_meters) / 1000.0, 1) AS total_km,
+                      ROUND(SUM(COALESCE(training_load, 0)), 0) AS total_load,
+                      ROUND(AVG(COALESCE(training_load, 0)), 0) AS avg_load_per_session
+               FROM activity
+               GROUP BY activity_type
+               ORDER BY total_load DESC""",
+        )
+
+        current = timeline[-1] if timeline else {}
+        result = {
+            "current": {
+                "date": current.get("date"),
+                "ctl_fitness": current.get("ctl"),
+                "atl_fatigue": current.get("atl"),
+                "tsb_form": current.get("tsb"),
+                "interpretation": (
+                    "FRESH — ready to race/test" if current.get("tsb", 0) > 15
+                    else "OPTIMAL — good training balance" if current.get("tsb", 0) > 0
+                    else "FATIGUED — absorbing training load" if current.get("tsb", 0) > -15
+                    else "OVERREACHING — need recovery"
+                ),
+            },
+            "timeline": timeline,
+            "weekly_volume_12w": weekly,
+            "load_by_sport": by_sport,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_compare
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_compare(
+    period1_start: str,
+    period1_end: str,
+    period2_start: str,
+    period2_end: str,
+) -> str:
+    """Side-by-side comparison of two date ranges across all health metrics.
+
+    Useful for week-over-week, month-over-month, or year-over-year analysis.
+    Returns deltas and percentage changes for every metric.
+    """
+    conn = get_connection()
+    try:
+        def _fetch_period(start: str, end: str) -> dict:
+            daily = query(
+                conn,
+                """SELECT ROUND(AVG(total_steps),0) AS steps,
+                          ROUND(AVG(resting_heart_rate),1) AS rhr,
+                          ROUND(AVG(average_stress_level),1) AS stress,
+                          ROUND(AVG(body_battery_highest),1) AS bb_high,
+                          ROUND(AVG(body_battery_lowest),1) AS bb_low,
+                          ROUND(AVG(average_spo2),1) AS spo2,
+                          ROUND(AVG(avg_waking_respiration),1) AS respiration,
+                          ROUND(AVG(total_kilocalories),0) AS calories,
+                          ROUND(AVG(active_kilocalories),0) AS active_cal,
+                          ROUND(AVG(floors_ascended),1) AS floors,
+                          ROUND(AVG(moderate_intensity_minutes + vigorous_intensity_minutes),0) AS intensity_min
+                   FROM daily_summary WHERE calendar_date BETWEEN ? AND ?""",
+                [start, end],
+            )
+            sleep = query(
+                conn,
+                """SELECT ROUND(AVG(sleep_time_seconds)/3600.0,2) AS sleep_hrs,
+                          ROUND(AVG(deep_sleep_seconds)/60.0,0) AS deep_min,
+                          ROUND(AVG(rem_sleep_seconds)/60.0,0) AS rem_min,
+                          ROUND(AVG(avg_sleep_stress),1) AS sleep_stress
+                   FROM sleep WHERE calendar_date BETWEEN ? AND ?""",
+                [start, end],
+            )
+            tr = query(
+                conn,
+                """SELECT ROUND(AVG(score),1) AS readiness
+                   FROM training_readiness WHERE calendar_date BETWEEN ? AND ?""",
+                [start, end],
+            )
+            hrv = query(
+                conn,
+                """SELECT ROUND(AVG(weekly_avg),1) AS hrv_avg
+                   FROM hrv WHERE calendar_date BETWEEN ? AND ?""",
+                [start, end],
+            )
+            acts = query(
+                conn,
+                """SELECT COUNT(*) AS sessions,
+                          ROUND(SUM(duration_seconds)/3600.0,1) AS hours,
+                          ROUND(SUM(COALESCE(training_load,0)),0) AS load
+                   FROM activity WHERE DATE(start_time_local) BETWEEN ? AND ?""",
+                [start, end],
+            )
+            return {
+                "period": f"{start} to {end}",
+                **(daily[0] if daily else {}),
+                **(sleep[0] if sleep else {}),
+                **(tr[0] if tr else {}),
+                **(hrv[0] if hrv else {}),
+                **(acts[0] if acts else {}),
+            }
+
+        p1 = _fetch_period(period1_start, period1_end)
+        p2 = _fetch_period(period2_start, period2_end)
+
+        # Compute deltas
+        deltas = {}
+        for key in p1:
+            if key == "period":
+                continue
+            v1 = p1.get(key)
+            v2 = p2.get(key)
+            if v1 is not None and v2 is not None and isinstance(v1, (int, float)) and isinstance(v2, (int, float)):
+                diff = round(v2 - v1, 2)
+                pct = round((diff / v1) * 100, 1) if v1 != 0 else None
+                deltas[key] = {"period1": v1, "period2": v2, "delta": diff, "pct_change": pct}
+
+        return json.dumps({"period1": p1, "period2": p2, "changes": deltas}, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_records
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_records() -> str:
+    """All personal records (PRs) with activity details and dates."""
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT pr.display_name AS activity,
+                      pr.activity_type AS sport,
+                      pr.pr_type,
+                      pr.value,
+                      pr.pr_date,
+                      a.activity_name,
+                      a.location_name AS location
+               FROM personal_record pr
+               LEFT JOIN activity a ON pr.activity_id = a.activity_id
+               ORDER BY pr.pr_date DESC""",
+        )
+
+        # Translate pr_type codes to human-readable names
+        pr_names = {
+            "1": "Longest Activity (min)",
+            "2": "Fastest 1 km (sec)",
+            "3": "Fastest 5K (sec)",
+            "4": "Fastest 10K (sec)",
+            "7": "Longest Distance (m)",
+            "8": "Longest Ride (m)",
+            "9": "Most Elevation (m)",
+            "10": "Best 20-min Power (W)",
+            "11": "Longest Climb (m)",
+            "12": "Best Half Marathon (sec)",
+            "13": "Best Marathon (sec)",
+            "14": "Best Triathlon (sec)",
+            "15": "Best VO2max",
+            "16": "Lowest RHR",
+            "17": "Longest Swim (m)",
+            "18": "Fastest 100m Swim (sec)",
+            "20": "Fastest 400m Swim (sec)",
+            "22": "Fastest 1000m Swim (sec)",
+            "23": "Fastest 1500m Swim (sec)",
+        }
+
+        for r in rows:
+            code = str(r.get("pr_type", ""))
+            r["record_name"] = pr_names.get(code, f"Type {code}")
+
+        return json.dumps(rows, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_fitness_age
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_fitness_age(period: str = "month") -> str:
+    """Fitness age vs chronological age trajectory over time.
+
+    Shows the gap between biological fitness and real age, aggregated by
+    week or month.  A widening gap means you're getting fitter relative
+    to your age; a narrowing gap means fitness is declining.
+    """
+    if period not in ("week", "month"):
+        return json.dumps({"error": "period must be 'week' or 'month'."})
+
+    group_expr = (
+        "strftime('%Y-W%W', calendar_date)" if period == "week"
+        else "strftime('%Y-%m', calendar_date)"
+    )
+
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            f"""SELECT {group_expr} AS period,
+                       ROUND(AVG(chronological_age), 1) AS chrono_age,
+                       ROUND(AVG(fitness_age), 1) AS fitness_age,
+                       ROUND(AVG(chronological_age) - AVG(fitness_age), 1) AS gap_years,
+                       ROUND(MIN(fitness_age), 1) AS best_fitness_age
+                FROM fitness_age
+                WHERE fitness_age IS NOT NULL
+                GROUP BY {group_expr}
+                ORDER BY period""",
+        )
+
+        current = rows[-1] if rows else {}
+        best = min(rows, key=lambda r: r["fitness_age"]) if rows else {}
+
+        result = {
+            "current": {
+                "period": current.get("period"),
+                "fitness_age": current.get("fitness_age"),
+                "chrono_age": current.get("chrono_age"),
+                "gap": current.get("gap_years"),
+            },
+            "all_time_best": {
+                "period": best.get("period"),
+                "fitness_age": best.get("best_fitness_age"),
+            },
+            "timeline": rows,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_hrv — enriched with baseline context and status streaks
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_hrv(days: int = 30) -> str:
+    """HRV (Heart Rate Variability) with clinical context.
+
+    Unlike raw HRV numbers, this returns your personal baseline range,
+    how many consecutive days you've been BALANCED vs UNBALANCED,
+    trend direction, and whether current values are above/below baseline.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, weekly_avg, last_night_avg,
+                      last_night_5min_high, status, baseline_low, baseline_upper
+               FROM hrv WHERE calendar_date >= ? ORDER BY calendar_date""",
+            [start],
+        )
+        if not rows:
+            return json.dumps({"error": "No HRV data found."})
+
+        # Compute status streak (consecutive days of current status)
+        current_status = rows[-1]["status"]
+        streak = 0
+        for r in reversed(rows):
+            if r["status"] == current_status:
+                streak += 1
+            else:
+                break
+
+        # Trend: compare last 7 days vs prior 7 days
+        avgs = [r["weekly_avg"] for r in rows if r["weekly_avg"] is not None]
+        if len(avgs) >= 14:
+            recent_7 = sum(avgs[-7:]) / 7
+            prior_7 = sum(avgs[-14:-7]) / 7
+            trend_pct = round((recent_7 - prior_7) / prior_7 * 100, 1) if prior_7 else 0
+            trend = "improving" if trend_pct > 3 else "declining" if trend_pct < -3 else "stable"
+        elif len(avgs) >= 2:
+            trend_pct = 0.0
+            trend = "insufficient data"
+        else:
+            trend_pct = 0.0
+            trend = "insufficient data"
+
+        latest = rows[-1]
+        result = {
+            "current": {
+                "date": latest["calendar_date"],
+                "weekly_avg": latest["weekly_avg"],
+                "last_night_avg": latest["last_night_avg"],
+                "last_night_5min_high": latest["last_night_5min_high"],
+                "status": latest["status"],
+                "baseline_low": latest["baseline_low"],
+                "baseline_upper": latest["baseline_upper"],
+                "position": (
+                    "ABOVE baseline" if latest["weekly_avg"] and latest["baseline_upper"] and latest["weekly_avg"] > latest["baseline_upper"]
+                    else "BELOW baseline" if latest["weekly_avg"] and latest["baseline_low"] and latest["weekly_avg"] < latest["baseline_low"]
+                    else "WITHIN baseline"
+                ),
+            },
+            "status_streak": {"status": current_status, "consecutive_days": streak},
+            "trend": {"direction": trend, "pct_change_7d": trend_pct},
+            "daily": rows,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_body_battery — charge/drain patterns with sleep correlation
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_body_battery(days: int = 14) -> str:
+    """Body battery with charge efficiency and drain analysis.
+
+    Returns per-day values enriched with: how much you charged overnight
+    vs how much you drained during the day, wake-up charge level,
+    and whether sleep quality (deep sleep) correlated with better charging.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT d.calendar_date,
+                      d.body_battery_highest AS high,
+                      d.body_battery_lowest AS low,
+                      d.body_battery_at_wake AS at_wake,
+                      d.body_battery_during_sleep AS sleep_charge,
+                      d.body_battery_highest - d.body_battery_lowest AS daily_range,
+                      s.deep_sleep_seconds,
+                      ROUND(s.sleep_time_seconds / 3600.0, 2) AS sleep_hours,
+                      s.avg_sleep_stress
+               FROM daily_summary d
+               LEFT JOIN sleep s ON d.calendar_date = s.calendar_date
+               WHERE d.calendar_date >= ?
+               ORDER BY d.calendar_date""",
+            [start],
+        )
+
+        # Flag critical days (wake < 40 or low < 15)
+        critical_days = [
+            r["calendar_date"] for r in rows
+            if (r["at_wake"] is not None and r["at_wake"] < 40)
+            or (r["low"] is not None and r["low"] < 15)
+        ]
+
+        # Average wake value
+        wakes = [r["at_wake"] for r in rows if r["at_wake"] is not None]
+        avg_wake = round(sum(wakes) / len(wakes), 1) if wakes else None
+
+        result = {
+            "summary": {
+                "avg_wake_battery": avg_wake,
+                "critical_days_count": len(critical_days),
+                "critical_days": critical_days,
+            },
+            "daily": rows,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_stress — time-in-zone breakdown, not just averages
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_stress(days: int = 14) -> str:
+    """Stress with time-in-zone breakdown (low/medium/high).
+
+    Goes beyond the average — shows how many hours per day you spent
+    in each stress zone, plus max stress spikes and the stress qualifier.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      average_stress_level AS avg_stress,
+                      max_stress_level AS max_stress,
+                      ROUND(low_stress_seconds / 3600.0, 1) AS low_stress_hrs,
+                      ROUND(medium_stress_seconds / 3600.0, 1) AS med_stress_hrs,
+                      ROUND(high_stress_seconds / 3600.0, 1) AS high_stress_hrs,
+                      stress_qualifier
+               FROM daily_summary
+               WHERE calendar_date >= ? AND average_stress_level IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        # Averages across period
+        avg_vals = [r["avg_stress"] for r in rows if r["avg_stress"] is not None]
+        high_hrs = [r["high_stress_hrs"] for r in rows if r["high_stress_hrs"] is not None]
+
+        result = {
+            "summary": {
+                "period_avg_stress": round(sum(avg_vals) / len(avg_vals), 1) if avg_vals else None,
+                "avg_daily_high_stress_hrs": round(sum(high_hrs) / len(high_hrs), 1) if high_hrs else None,
+                "highest_day": max(rows, key=lambda r: r["avg_stress"] or 0)["calendar_date"] if rows else None,
+                "lowest_day": min(rows, key=lambda r: r["avg_stress"] or 999)["calendar_date"] if rows else None,
+            },
+            "daily": rows,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_heart_rate — RHR trend with 7-day moving avg context
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_heart_rate(days: int = 30) -> str:
+    """Resting heart rate with trend analysis and anomaly detection.
+
+    Returns daily RHR plus a rolling 7-day average. Flags days where RHR
+    jumped >5 bpm above your 7-day average (a sign of illness, overtraining,
+    or poor recovery per sports science literature).
+    """
+    # Fetch extra days for the rolling average
+    start = str(date.today() - timedelta(days=days + 7))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, resting_heart_rate AS rhr,
+                      min_heart_rate AS min_hr, max_heart_rate AS max_hr
+               FROM daily_summary
+               WHERE calendar_date >= ? AND resting_heart_rate IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+        if not rows:
+            return json.dumps({"error": "No heart rate data found."})
+
+        # Compute 7-day rolling average and flag anomalies
+        output = []
+        for i, r in enumerate(rows):
+            window = [rows[j]["rhr"] for j in range(max(0, i - 6), i + 1) if rows[j]["rhr"]]
+            avg_7d = round(sum(window) / len(window), 1) if window else None
+            rhr = r["rhr"]
+            elevated = rhr and avg_7d and (rhr - avg_7d > 5)
+            output.append({
+                "date": r["calendar_date"],
+                "rhr": rhr,
+                "min_hr": r["min_hr"],
+                "max_hr": r["max_hr"],
+                "avg_7d": avg_7d,
+                "elevated": elevated,
+            })
+
+        # Trim to requested days
+        cutoff = str(date.today() - timedelta(days=days - 1))
+        output = [r for r in output if r["date"] >= cutoff]
+
+        elevated_days = [r["date"] for r in output if r.get("elevated")]
+        rhrs = [r["rhr"] for r in output if r["rhr"]]
+
+        result = {
+            "summary": {
+                "current_rhr": output[-1]["rhr"] if output else None,
+                "period_avg": round(sum(rhrs) / len(rhrs), 1) if rhrs else None,
+                "period_min": min(rhrs) if rhrs else None,
+                "period_max": max(rhrs) if rhrs else None,
+                "elevated_days": elevated_days,
+            },
+            "daily": output,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_spo2 — with clinical threshold flags
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_spo2(days: int = 14) -> str:
+    """Blood oxygen (SpO2) with clinical threshold analysis.
+
+    Flags days where average SpO2 dropped below 95% (clinical concern)
+    or nocturnal lows dropped below 80% (possible sleep apnea indicator).
+    Includes both daily_summary and dedicated spo2 table data.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      average_spo2 AS avg_spo2,
+                      lowest_spo2 AS min_spo2,
+                      latest_spo2 AS latest,
+                      CASE WHEN average_spo2 < 95 THEN 1 ELSE 0 END AS below_normal,
+                      CASE WHEN lowest_spo2 < 80 THEN 1 ELSE 0 END AS critical_low
+               FROM daily_summary
+               WHERE calendar_date >= ? AND average_spo2 IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        avgs = [r["avg_spo2"] for r in rows if r["avg_spo2"]]
+        below_count = sum(1 for r in rows if r["below_normal"])
+        critical_count = sum(1 for r in rows if r["critical_low"])
+
+        result = {
+            "summary": {
+                "period_avg": round(sum(avgs) / len(avgs), 1) if avgs else None,
+                "days_below_95pct": below_count,
+                "days_with_critical_low": critical_count,
+                "recommendation": (
+                    "URGENT: Frequent critical lows — consider a sleep apnea screening"
+                    if critical_count > 3
+                    else "WATCH: Consistently below 95% — monitor and consult if persistent"
+                    if below_count > len(rows) * 0.5
+                    else "NORMAL"
+                ),
+            },
+            "daily": rows,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_body_composition — weight trend with context
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_body_composition() -> str:
+    """Weight, BMI, and body composition history with trend analysis."""
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      ROUND(weight / 1000.0, 1) AS weight_kg,
+                      ROUND(bmi, 1) AS bmi,
+                      ROUND(body_fat, 1) AS body_fat_pct,
+                      ROUND(body_water, 1) AS body_water_pct,
+                      ROUND(bone_mass / 1000.0, 2) AS bone_mass_kg,
+                      ROUND(muscle_mass / 1000.0, 1) AS muscle_mass_kg
+               FROM weight
+               WHERE weight IS NOT NULL
+               ORDER BY calendar_date DESC""",
+        )
+        if not rows:
+            return json.dumps({"error": "No weight data found."})
+
+        latest = rows[0]
+        result = {
+            "latest": latest,
+            "total_entries": len(rows),
+            "history": rows,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_devices — connected hardware
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_devices() -> str:
+    """Connected Garmin devices with type and last sync time."""
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT display_name, device_type, last_sync
+               FROM device ORDER BY last_sync DESC""",
+        )
+        return json.dumps(rows, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_week_summary — current week vs goals
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_week_summary() -> str:
+    """Current week's health totals vs goals, with daily breakdown.
+
+    Shows steps, intensity minutes, floors, and calories for each day
+    of the current week, plus totals vs weekly targets.
+    """
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+    start = str(monday)
+    end = str(today)
+
+    conn = get_connection()
+    try:
+        days = query(
+            conn,
+            """SELECT calendar_date,
+                      total_steps, daily_step_goal,
+                      moderate_intensity_minutes + vigorous_intensity_minutes AS intensity_min,
+                      intensity_minutes_goal,
+                      floors_ascended, floors_ascended_goal,
+                      total_kilocalories, active_kilocalories,
+                      resting_heart_rate, average_stress_level,
+                      body_battery_highest, body_battery_lowest
+               FROM daily_summary
+               WHERE calendar_date BETWEEN ? AND ?
+               ORDER BY calendar_date""",
+            [start, end],
+        )
+
+        activities = query(
+            conn,
+            """SELECT activity_name AS name, activity_type AS type,
+                      ROUND(duration_seconds / 60.0, 1) AS duration_min,
+                      ROUND(distance_meters / 1000.0, 2) AS distance_km,
+                      ROUND(training_load, 0) AS load
+               FROM activity
+               WHERE DATE(start_time_local) BETWEEN ? AND ?
+               ORDER BY start_time_local""",
+            [start, end],
+        )
+
+        # Compute totals
+        total_steps = sum(d["total_steps"] or 0 for d in days)
+        total_intensity = sum(d["intensity_min"] or 0 for d in days)
+        total_floors = sum(d["floors_ascended"] or 0 for d in days)
+        step_goal = (days[0]["daily_step_goal"] or 0) * 7 if days else 0
+        intensity_goal = (days[0]["intensity_minutes_goal"] or 0) if days else 0
+
+        result = {
+            "week": f"{start} to {end}",
+            "days_elapsed": len(days),
+            "totals": {
+                "steps": total_steps,
+                "step_goal_weekly": step_goal,
+                "step_pct": round(total_steps / step_goal * 100, 0) if step_goal else None,
+                "intensity_min": total_intensity,
+                "intensity_goal_weekly": intensity_goal,
+                "intensity_pct": round(total_intensity / intensity_goal * 100, 0) if intensity_goal else None,
+                "floors": round(total_floors, 1),
+            },
+            "activities_this_week": activities,
+            "daily": days,
+        }
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_recovery — post-activity recovery signature (unique)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_recovery(days_after: int = 3) -> str:
+    """Analyze how your body recovers after hard training sessions.
+
+    For each activity with training_load > 80, shows RHR and HRV for
+    the following days. Reveals your personal recovery curve and
+    identifies which sports/intensities hit you hardest.
+
+    This is unique — no other Garmin MCP computes recovery signatures.
+    """
+    conn = get_connection()
+    try:
+        activities = query(
+            conn,
+            """SELECT activity_id, activity_name, activity_type,
+                      DATE(start_time_local) AS activity_date,
+                      ROUND(training_load, 0) AS load,
+                      ROUND(duration_seconds / 60.0, 0) AS duration_min,
+                      ROUND(average_hr, 0) AS avg_hr
+               FROM activity
+               WHERE training_load > 80 AND start_time_local IS NOT NULL
+               ORDER BY start_time_local DESC
+               LIMIT 20""",
+        )
+        if not activities:
+            return json.dumps({"error": "No high-load activities found."})
+
+        results = []
+        for a in activities:
+            d = a["activity_date"]
+            recovery_days = []
+            for offset in range(days_after + 1):
+                check = str(date.fromisoformat(d) + timedelta(days=offset))
+                row = query(
+                    conn,
+                    """SELECT d.resting_heart_rate AS rhr, h.weekly_avg AS hrv,
+                              d.body_battery_at_wake AS bb_wake, d.average_stress_level AS stress
+                       FROM daily_summary d
+                       LEFT JOIN hrv h ON d.calendar_date = h.calendar_date
+                       WHERE d.calendar_date = ?""",
+                    [check],
+                )
+                if row:
+                    recovery_days.append({"day": f"+{offset}", "date": check, **row[0]})
+
+            # Compute recovery delta
+            if len(recovery_days) >= 2 and recovery_days[0].get("rhr") and recovery_days[-1].get("rhr"):
+                rhr_delta = recovery_days[-1]["rhr"] - recovery_days[0]["rhr"]
+            else:
+                rhr_delta = None
+
+            results.append({
+                "activity": a["activity_name"],
+                "type": a["activity_type"],
+                "date": d,
+                "load": a["load"],
+                "duration_min": a["duration_min"],
+                "avg_hr": a["avg_hr"],
+                "rhr_delta_after": rhr_delta,
+                "recovery": recovery_days,
+            })
+
+        # Aggregate: avg recovery by sport type
+        by_sport: dict[str, list] = {}
+        for r in results:
+            sport = r["type"]
+            if sport not in by_sport:
+                by_sport[sport] = []
+            if r["rhr_delta_after"] is not None:
+                by_sport[sport].append(r["rhr_delta_after"])
+
+        sport_summary = {
+            sport: {
+                "avg_rhr_impact": round(sum(deltas) / len(deltas), 1),
+                "sessions": len(deltas),
+            }
+            for sport, deltas in by_sport.items() if deltas
+        }
+
+        return json.dumps({
+            "recovery_by_sport": sport_summary,
+            "sessions": results,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_training_status — productive / detraining / recovery / etc
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_training_status(days: int = 90) -> str:
+    """Training status history (Productive, Recovery, Detraining, Unproductive, etc).
+
+    Shows how Garmin classified your training state each day, with a
+    breakdown of how many days you spent in each status and when
+    transitions happened. Useful for spotting detraining before it deepens.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, status
+               FROM training_status
+               WHERE calendar_date >= ?
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        # Count days per status
+        counts: dict[str, int] = {}
+        for r in rows:
+            s = r["status"] or "UNKNOWN"
+            counts[s] = counts.get(s, 0) + 1
+
+        # Detect transitions (status changes)
+        transitions = []
+        prev = None
+        for r in rows:
+            s = r["status"] or "UNKNOWN"
+            if s != prev and prev is not None:
+                transitions.append({"date": r["calendar_date"], "from": prev, "to": s})
+            prev = s
+
+        current = rows[-1]["status"] if rows else None
+
+        return json.dumps({
+            "current_status": current,
+            "days_in_status": counts,
+            "transitions": transitions[-10:],
+            "daily": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_workouts — workout library and schedule
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_workouts() -> str:
+    """Workout library and upcoming schedule.
+
+    Returns saved workouts (training plans, custom workouts) and any
+    scheduled workout dates. Useful for understanding planned vs executed training.
+    """
+    conn = get_connection()
+    try:
+        workouts = query(
+            conn,
+            """SELECT workout_id, workout_name, sport_type,
+                      created_date, updated_date
+               FROM workouts
+               ORDER BY updated_date DESC""",
+        )
+
+        schedule = query(
+            conn,
+            """SELECT calendar_date, raw_json
+               FROM workout_schedule
+               ORDER BY calendar_date DESC""",
+        )
+
+        plans = query(
+            conn,
+            """SELECT id, raw_json FROM training_plans""",
+        )
+
+        return json.dumps({
+            "workout_library": workouts,
+            "scheduled": schedule,
+            "training_plans": plans,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_badges — achievements and milestones
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_badges() -> str:
+    """Earned badges and achievements with dates.
+
+    Tracks milestones like distance PRs, consistency streaks, and
+    special event completions. Shows progression over time.
+    """
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT badge_name, badge_category, earned_date, earned_number
+               FROM earned_badges
+               ORDER BY earned_date DESC""",
+        )
+
+        # Group by category
+        by_category: dict[str, list] = {}
+        for r in rows:
+            cat = r["badge_category"] or "general"
+            if cat not in by_category:
+                by_category[cat] = []
+            by_category[cat].append(r)
+
+        return json.dumps({
+            "total_badges": len(rows),
+            "badges": rows,
+            "by_category": {k: len(v) for k, v in by_category.items()},
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_hydration — fluid intake tracking
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_hydration(days: int = 30) -> str:
+    """Daily hydration intake vs goals.
+
+    Tracks fluid intake, compares against Garmin's calculated goal
+    (which factors in activity, weather, and body weight), and flags
+    days with significant under-hydration.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      goal_ml, intake_ml,
+                      CASE WHEN goal_ml > 0
+                           THEN ROUND(intake_ml * 100.0 / goal_ml, 0)
+                           ELSE NULL END AS pct_of_goal
+               FROM hydration
+               WHERE calendar_date >= ?
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        tracked = [r for r in rows if r["intake_ml"] and r["intake_ml"] > 0]
+
+        return json.dumps({
+            "days_tracked": len(tracked),
+            "days_total": len(rows),
+            "data": rows if tracked else [],
+            "note": "No hydration data logged" if not tracked else None,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_respiration — breathing rate trends
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_respiration(days: int = 14) -> str:
+    """Waking respiration rate with min/max range.
+
+    Elevated respiration at rest can indicate illness, stress, or
+    cardiovascular strain. Normal adult range is 12-20 breaths/min.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      avg_waking_respiration AS avg_waking,
+                      highest_respiration AS max_resp,
+                      lowest_respiration AS min_resp
+               FROM daily_summary
+               WHERE calendar_date >= ? AND avg_waking_respiration IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        avgs = [r["avg_waking"] for r in rows if r["avg_waking"]]
+        elevated = [r["calendar_date"] for r in rows if r["avg_waking"] and r["avg_waking"] > 20]
+
+        return json.dumps({
+            "summary": {
+                "period_avg": round(sum(avgs) / len(avgs), 1) if avgs else None,
+                "elevated_days": elevated,
+            },
+            "daily": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_intensity_minutes — moderate + vigorous with goal tracking
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_intensity_minutes(days: int = 30) -> str:
+    """Weekly intensity minutes vs the WHO-recommended 150 min/week.
+
+    Breaks down moderate vs vigorous minutes (vigorous counts double per
+    WHO guidelines). Shows weekly totals and goal attainment.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT strftime('%%Y-W%%W', calendar_date) AS week,
+                      SUM(moderate) AS moderate_min,
+                      SUM(vigorous) AS vigorous_min,
+                      SUM(moderate + vigorous) AS total_min,
+                      SUM(moderate + vigorous * 2) AS who_equivalent_min,
+                      MAX(goal) AS weekly_goal
+               FROM intensity_minutes
+               WHERE calendar_date >= ?
+               GROUP BY week
+               ORDER BY week""",
+            [start],
+        )
+
+        return json.dumps({
+            "who_target": "150 min/week (moderate) or 75 min/week (vigorous)",
+            "weekly": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_floors — floors climbed with goal tracking
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_floors(days: int = 14) -> str:
+    """Daily floors climbed vs goal, with ascent/descent breakdown."""
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      ROUND(ascended, 1) AS floors_up,
+                      ROUND(descended, 1) AS floors_down,
+                      ROUND(goal, 0) AS goal,
+                      CASE WHEN goal > 0
+                           THEN ROUND(ascended * 100.0 / goal, 0)
+                           ELSE NULL END AS pct_of_goal
+               FROM floors
+               WHERE calendar_date >= ?
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        ups = [r["floors_up"] for r in rows if r["floors_up"]]
+        goal_met = sum(1 for r in rows if r["pct_of_goal"] and r["pct_of_goal"] >= 100)
+
+        return json.dumps({
+            "summary": {
+                "avg_floors_day": round(sum(ups) / len(ups), 1) if ups else None,
+                "days_goal_met": goal_met,
+                "days_total": len(rows),
+            },
+            "daily": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_steps — daily steps with goal and streak tracking
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_steps(days: int = 14) -> str:
+    """Daily step count with goal attainment and streaks.
+
+    Shows steps per day, percentage of goal, and identifies the longest
+    consecutive streak of meeting your step goal.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT d.calendar_date,
+                      d.total_steps AS steps,
+                      d.daily_step_goal AS goal,
+                      ROUND(d.total_distance_meters / 1000.0, 2) AS distance_km,
+                      CASE WHEN d.daily_step_goal > 0
+                           THEN ROUND(d.total_steps * 100.0 / d.daily_step_goal, 0)
+                           ELSE NULL END AS pct_of_goal
+               FROM daily_summary d
+               WHERE d.calendar_date >= ? AND d.total_steps IS NOT NULL
+               ORDER BY d.calendar_date""",
+            [start],
+        )
+
+        steps_list = [r["steps"] for r in rows if r["steps"]]
+        goal_met_days = sum(1 for r in rows if r["pct_of_goal"] and r["pct_of_goal"] >= 100)
+
+        # Longest goal streak
+        streak = 0
+        max_streak = 0
+        for r in rows:
+            if r["pct_of_goal"] and r["pct_of_goal"] >= 100:
+                streak += 1
+                max_streak = max(max_streak, streak)
+            else:
+                streak = 0
+
+        return json.dumps({
+            "summary": {
+                "avg_steps": round(sum(steps_list) / len(steps_list), 0) if steps_list else None,
+                "days_goal_met": goal_met_days,
+                "days_total": len(rows),
+                "longest_goal_streak": max_streak,
+                "best_day": max(rows, key=lambda r: r["steps"] or 0)["calendar_date"] if rows else None,
+            },
+            "daily": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_calories — energy balance tracking
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_calories(days: int = 14) -> str:
+    """Daily calorie breakdown: total, active, BMR, and consumed (if logged).
+
+    Combines daily_summary calorie data with the dedicated calories table
+    for a complete energy picture.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date,
+                      ROUND(total_kilocalories, 0) AS total_cal,
+                      ROUND(active_kilocalories, 0) AS active_cal,
+                      ROUND(bmr_kilocalories, 0) AS bmr_cal,
+                      ROUND(remaining_kilocalories, 0) AS remaining_cal
+               FROM daily_summary
+               WHERE calendar_date >= ? AND total_kilocalories IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        # Check dedicated calories table for consumed data
+        consumed = query(
+            conn,
+            """SELECT calendar_date, consumed, remaining
+               FROM calories
+               WHERE calendar_date >= ? AND consumed > 0
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        totals = [r["total_cal"] for r in rows if r["total_cal"]]
+        actives = [r["active_cal"] for r in rows if r["active_cal"]]
+
+        return json.dumps({
+            "summary": {
+                "avg_total_cal": round(sum(totals) / len(totals), 0) if totals else None,
+                "avg_active_cal": round(sum(actives) / len(actives), 0) if actives else None,
+            },
+            "daily": rows,
+            "food_log": consumed if consumed else [],
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_blood_pressure — if tracked via compatible device
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_blood_pressure(days: int = 90) -> str:
+    """Blood pressure readings (systolic/diastolic/pulse) if tracked.
+
+    Requires a compatible Garmin blood pressure monitor. Flags readings
+    outside normal ranges (>140/90 mmHg per AHA guidelines).
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, systolic, diastolic, pulse
+               FROM blood_pressure
+               WHERE calendar_date >= ?
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        flagged = [
+            r for r in rows
+            if (r["systolic"] and r["systolic"] >= 140)
+            or (r["diastolic"] and r["diastolic"] >= 90)
+        ]
+
+        return json.dumps({
+            "total_readings": len(rows),
+            "elevated_readings": len(flagged),
+            "data": rows,
+            "note": "No blood pressure data recorded" if not rows else None,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_goals — active goals and progress
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_goals() -> str:
+    """Active fitness goals and their current progress."""
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT goal_id, goal_type, goal_value, raw_json
+               FROM goals""",
+        )
+        return json.dumps({
+            "total_goals": len(rows),
+            "goals": rows,
+            "note": "No goals set" if not rows else None,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_challenges — active and completed challenges
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_challenges() -> str:
+    """Garmin Connect challenges (active and completed)."""
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT id, challenge_type, raw_json
+               FROM challenges""",
+        )
+        return json.dumps({
+            "total_challenges": len(rows),
+            "challenges": rows,
+            "note": "No challenges found" if not rows else None,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_user_profile — athlete profile info
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_user_profile() -> str:
+    """User profile and settings stored in Garmin Connect."""
+    conn = get_connection()
+    try:
+        rows = query(conn, "SELECT key, raw_json FROM user_profile")
+        result = {}
+        for r in rows:
+            try:
+                result[r["key"]] = json.loads(r["raw_json"]) if r["raw_json"] else None
+            except (json.JSONDecodeError, TypeError):
+                result[r["key"]] = r["raw_json"]
+        return json.dumps(result, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_race_predictions — predicted finish times with trend
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_race_predictions(days: int = 30) -> str:
+    """Predicted race finish times (5K, 10K, half marathon, marathon).
+
+    Shows daily predictions with human-readable times and trend direction.
+    A rising prediction time means declining fitness; falling means improving.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, time_5k, time_10k,
+                      time_half_marathon, time_marathon
+               FROM race_predictions
+               WHERE calendar_date >= ? AND time_5k IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        def _fmt_time(secs: float | None) -> str | None:
+            if not secs:
+                return None
+            m, s = divmod(int(secs), 60)
+            h, m = divmod(m, 60)
+            return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+        for r in rows:
+            r["time_5k_fmt"] = _fmt_time(r["time_5k"])
+            r["time_10k_fmt"] = _fmt_time(r["time_10k"])
+            r["time_half_fmt"] = _fmt_time(r["time_half_marathon"])
+            r["time_marathon_fmt"] = _fmt_time(r["time_marathon"])
+
+        # Trend: first vs last 5K prediction
+        if len(rows) >= 2:
+            first_5k = rows[0]["time_5k"]
+            last_5k = rows[-1]["time_5k"]
+            delta = last_5k - first_5k
+            trend = "IMPROVING (faster)" if delta < -10 else "DECLINING (slower)" if delta > 10 else "STABLE"
+        else:
+            delta = 0
+            trend = "insufficient data"
+
+        latest = rows[-1] if rows else {}
+
+        return json.dumps({
+            "latest": {
+                "date": latest.get("calendar_date"),
+                "5k": latest.get("time_5k_fmt"),
+                "10k": latest.get("time_10k_fmt"),
+                "half_marathon": latest.get("time_half_fmt"),
+                "marathon": latest.get("time_marathon_fmt"),
+            },
+            "trend": {"direction": trend, "5k_delta_sec": round(delta)},
+            "daily": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_endurance_score — endurance and VO2max tracking
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_endurance_score(days: int = 30) -> str:
+    """Endurance score and VO2max with classification and trend."""
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, overall_score, classification,
+                      vo2_max_precise
+               FROM endurance_score
+               WHERE calendar_date >= ? AND overall_score IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+
+        scores = [r["overall_score"] for r in rows if r["overall_score"]]
+        if len(scores) >= 2:
+            trend = "improving" if scores[-1] > scores[0] + 10 else "declining" if scores[-1] < scores[0] - 10 else "stable"
+        else:
+            trend = "insufficient data"
+
+        return json.dumps({
+            "latest": rows[-1] if rows else {},
+            "trend": trend,
+            "daily": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_hill_score — hill/climb fitness
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_hill_score(days: int = 30) -> str:
+    """Hill score with endurance and strength sub-scores."""
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, overall_score,
+                      endurance_score, strength_score
+               FROM hill_score
+               WHERE calendar_date >= ? AND overall_score IS NOT NULL
+               ORDER BY calendar_date""",
+            [start],
+        )
+        return json.dumps({
+            "latest": rows[-1] if rows else {},
+            "daily": rows,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_vo2max — VO2max history by sport
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_vo2max() -> str:
+    """VO2max estimates from activities and the dedicated vo2max table.
+
+    Pulls from both the activity-level VO2max estimates and the
+    standalone vo2max tracking table.
+    """
+    conn = get_connection()
+    try:
+        # Dedicated table
+        vo2_table = query(
+            conn,
+            """SELECT calendar_date, sport, value
+               FROM vo2max
+               WHERE value IS NOT NULL
+               ORDER BY calendar_date DESC""",
+        )
+
+        # From activities
+        vo2_activities = query(
+            conn,
+            """SELECT DATE(start_time_local) AS date, activity_type,
+                      vo2max_value, activity_name
+               FROM activity
+               WHERE vo2max_value IS NOT NULL AND start_time_local IS NOT NULL
+               ORDER BY start_time_local DESC""",
+        )
+
+        return json.dumps({
+            "from_vo2max_table": vo2_table,
+            "from_activities": vo2_activities,
+            "note": "No VO2max data" if not vo2_table and not vo2_activities else None,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_health_snapshot — on-demand health measurements
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_health_snapshot() -> str:
+    """On-demand health snapshot readings (2-minute wrist measurements).
+
+    These are manual measurements taken via the watch's Health Snapshot
+    feature, capturing HR, HRV, SpO2, stress, and respiration simultaneously.
+    """
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, raw_json
+               FROM health_snapshot
+               ORDER BY calendar_date DESC""",
+        )
+
+        parsed = []
+        for r in rows:
+            entry = {"date": r["calendar_date"]}
+            if r["raw_json"]:
+                try:
+                    entry["data"] = json.loads(r["raw_json"])
+                except (json.JSONDecodeError, TypeError):
+                    entry["data"] = r["raw_json"]
+            parsed.append(entry)
+
+        return json.dumps({
+            "total_snapshots": len(parsed),
+            "snapshots": parsed,
+            "note": "No health snapshots taken" if not parsed else None,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_gear — equipment tracking (shoes, bikes, etc)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_gear() -> str:
+    """Tracked gear/equipment (shoes, bikes, etc) with usage stats."""
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT gear_id, gear_type, display_name,
+                      brand, model, date_begin
+               FROM gear""",
+        )
+        return json.dumps({
+            "total_gear": len(rows),
+            "gear": rows,
+            "note": "No gear tracked" if not rows else None,
+        }, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_daily_events — notable daily events
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_daily_events(days: int = 7) -> str:
+    """Daily events detected by your Garmin (stress spikes, body battery events, etc)."""
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, raw_json
+               FROM daily_events
+               WHERE calendar_date >= ?
+               ORDER BY calendar_date DESC""",
+            [start],
+        )
+
+        parsed = []
+        for r in rows:
+            entry = {"date": r["calendar_date"]}
+            if r["raw_json"]:
+                try:
+                    entry["events"] = json.loads(r["raw_json"])
+                except (json.JSONDecodeError, TypeError):
+                    entry["events"] = r["raw_json"]
+            parsed.append(entry)
+
+        return json.dumps(parsed, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_activity_types — all known activity type definitions
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_activity_types() -> str:
+    """All Garmin activity type definitions with IDs and parent categories."""
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT type_id, type_key, parent_type_id
+               FROM activity_types
+               ORDER BY type_key""",
+        )
+        return json.dumps(rows, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_hr_zones — heart rate zone definitions
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_hr_zones() -> str:
+    """Heart rate zone definitions configured in your Garmin profile."""
+    conn = get_connection()
+    try:
+        rows = query(conn, "SELECT id, raw_json FROM hr_zones")
+        parsed = []
+        for r in rows:
+            entry = {"id": r["id"]}
+            if r["raw_json"]:
+                try:
+                    entry["zones"] = json.loads(r["raw_json"])
+                except (json.JSONDecodeError, TypeError):
+                    entry["zones"] = r["raw_json"]
+            parsed.append(entry)
+        return json.dumps(parsed, indent=2, default=str)
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/garmin_mcp/sync.py
+++ b/garmin_mcp/sync.py
@@ -72,6 +72,7 @@ def incremental_sync(target_date: str = None) -> dict:
         email=email,
         password=password,
         profile_dir=PROFILE_DIR,
+        headless=True,
         engine="auto",
         session_file=SESSION_FILE,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "garmin-givemydata"
-version = "0.1.7"
+version = "0.1.8"
 description = "Get your Garmin Connect data back. Browser-based extraction + 47-table SQLite database + MCP server for AI analysis."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- **MCP Server: 6 → 44 tools** covering health metrics, training performance, daily overview, profile/devices, and data sync
- **Security hardening**: read-only SQL, sync lock, sanitized errors, result limits
- **Bug fix**: weight date storage (#13), headless sync
- **README reorganized**: Quick Start first, collapsible sections, accurate MCP config per install method

## MCP Tools Added (38 new)

**Training & Performance** (unique — no other Garmin MCP offers these):
- `garmin_training_load` — CTL/ATL/TSB professional periodization metrics
- `garmin_recovery` — post-workout recovery signatures by sport
- `garmin_compare` — side-by-side period comparison with deltas and % changes

**Health Metrics** (each enriched with trend analysis, anomaly detection, clinical thresholds):
- `garmin_heart_rate`, `garmin_hrv`, `garmin_sleep`, `garmin_stress`, `garmin_body_battery`, `garmin_spo2`, `garmin_respiration`, `garmin_steps`, `garmin_floors`, `garmin_calories`, `garmin_intensity_minutes`, `garmin_hydration`, `garmin_blood_pressure`

**Daily Overview:**
- `garmin_today`, `garmin_week_summary`

**Training:**
- `garmin_activity_detail`, `garmin_race_predictions`, `garmin_endurance_score`, `garmin_hill_score`, `garmin_vo2max`, `garmin_training_status`, `garmin_fitness_age`, `garmin_records`

**Profile & Devices:**
- `garmin_user_profile`, `garmin_devices`, `garmin_gear`, `garmin_badges`, `garmin_body_composition`, `garmin_workouts`, `garmin_goals`, `garmin_challenges`, `garmin_health_snapshot`, `garmin_daily_events`, `garmin_activity_types`, `garmin_hr_zones`

**Sync improved:**
- `garmin_sync` now shows last sync time before syncing, `refresh=False` for status-only

## Security Fixes

- `garmin_query` uses SQLite read-only mode (`?mode=ro`) — writes, ATTACH, schema changes impossible at engine level (replaces bypassable keyword blocklist)
- ATTACH/DETACH blocked before connection opens (prevents zero-byte file creation)
- Table identifiers bracket-quoted in `garmin_schema`
- `threading.Lock` prevents concurrent sync/browser instances
- Error messages sanitized — no internal paths leaked to clients
- Result limit (default 1000 rows) via `fetchmany()` prevents memory exhaustion

## Bug Fixes

- **Weight date storage (#13)**: entries from Garmin Index Scale stored as raw Unix timestamps (`1743345400`) instead of proper dates (`2025-03-30`). Fixed timestamp conversion to handle both milliseconds and seconds. Users with existing bad data should delete `garmin.db` and re-sync.
- **Headless sync**: `garmin_sync` via MCP runs Camoufox headlessly in a thread pool — no browser window, no Playwright async/sync conflict
- `.mcp.json` added to `.gitignore` (contains user-specific local paths)

## Bump

`0.1.7` → `0.1.8`