### PR TITLE
fix: follow up issue #13 data ingestion and parsing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,6 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     labels:
-      - ci
+      - dependencies
     commit-message:
       prefix: "ci"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ export_test/
 fit/
 test_everything.py
 tests/
+debug/
 dist/
 *.egg-info/
 *.db-shm

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist/
 *.db-wal
 garmin_session.json
 .mcp.json
+.codex
+.codex/
+downloaded_files/

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add the MCP server to Claude Code, Claude Desktop, or any MCP client. The config
 }
 ```
 
-**Git clone** — use absolute paths to the venv:
+**Git clone** — use absolute paths to the venv and set `GARMIN_DATA_DIR` so the MCP server finds your database:
 
 ```json
 {
@@ -80,11 +80,16 @@ Add the MCP server to Claude Code, Claude Desktop, or any MCP client. The config
     "garmin": {
       "command": "/absolute/path/to/garmin-givemydata/venv/bin/python",
       "args": ["/absolute/path/to/garmin-givemydata/run_mcp.py"],
-      "cwd": "/absolute/path/to/garmin-givemydata"
+      "cwd": "/absolute/path/to/garmin-givemydata",
+      "env": {
+        "GARMIN_DATA_DIR": "/absolute/path/to/garmin-givemydata"
+      }
     }
   }
 }
 ```
+
+> **Note:** `GARMIN_DATA_DIR` tells the MCP server where `garmin.db` lives. Without it, the server falls back to `~/.garmin-givemydata/` which may not be where your data is if you cloned to a custom location.
 
 Save this as:
 - **Claude Code:** `.mcp.json` in your project root, or `~/.claude/settings.json` under `mcpServers` for global access
@@ -110,7 +115,10 @@ Restart your client and run `/mcp` to approve the server. Then ask:
     "garmin": {
       "command": "C:\\Users\\jane\\code\\garmin-givemydata\\venv\\Scripts\\python.exe",
       "args": ["C:\\Users\\jane\\code\\garmin-givemydata\\run_mcp.py"],
-      "cwd": "C:\\Users\\jane\\code\\garmin-givemydata"
+      "cwd": "C:\\Users\\jane\\code\\garmin-givemydata",
+      "env": {
+        "GARMIN_DATA_DIR": "C:\\Users\\jane\\code\\garmin-givemydata"
+      }
     }
   }
 }

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -28,6 +28,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from seleniumbase import Driver
 
 from .endpoints import (
+    activities_search_url,
     activity_detail_endpoints,
     daily_graphql,
     daily_rest,
@@ -900,11 +901,24 @@ class GarminClient:
         s_date = start_date or (date.fromisoformat(today) - timedelta(days=30)).isoformat()
 
         all_results = {}
+        fetched_activity_ids = []
+
+        def _remember_activity_ids(data):
+            if not isinstance(data, list):
+                return
+            for activity in data:
+                if not isinstance(activity, dict):
+                    continue
+                aid = activity.get("activityId")
+                if aid:
+                    fetched_activity_ids.append(aid)
 
         def _process_batch(batch_result, cal_date=None):
             for name, result in batch_result.items():
                 if result.get("status") != 200 or not result.get("data"):
                     continue
+                if name in ("activities", "activities_range"):
+                    _remember_activity_ids(result["data"])
                 if on_batch:
                     on_batch(name, result["data"], cal_date=cal_date)
                 else:
@@ -930,13 +944,11 @@ class GarminClient:
         full = self._fetch_batch(full_rest, full_gql)
         _process_batch(full)
 
-        # 2b. Paginate through ALL activities
+        # 2b. Paginate remaining activities within the date range
         page_start = 100
         while True:
             act_result = self._fetch_batch(
-                {
-                    f"activities_page_{page_start}": f"/gc-api/activitylist-service/activities/search/activities?limit=100&start={page_start}"
-                },
+                {f"activities_page_{page_start}": activities_search_url(s_date, e_date, offset=page_start)},
                 {},
             )
             page_data = act_result.get(f"activities_page_{page_start}", {})
@@ -946,6 +958,7 @@ class GarminClient:
             if not isinstance(activities_page, list) or len(activities_page) == 0:
                 break
             print(f"    Activities page: fetched {len(activities_page)} more (offset {page_start})")
+            _remember_activity_ids(activities_page)
             if on_batch:
                 for a in activities_page:
                     on_batch("activities", a)
@@ -1021,22 +1034,21 @@ class GarminClient:
                         all_results[base_name] = {"status": 200, "data": [entry]}
 
         # 5. Per-activity detail data
-        activity_ids = []
+        activity_ids = list(dict.fromkeys(fetched_activity_ids))
 
-        for name_key, result in all_results.items():
-            if name_key in ("activities", "activities_range"):
-                data = result.get("data", [])
-                if isinstance(data, list):
-                    for a in data:
-                        aid = a.get("activityId")
-                        if aid:
-                            activity_ids.append(aid)
+        if not activity_ids:
+            for name_key, result in all_results.items():
+                if name_key in ("activities", "activities_range"):
+                    data = result.get("data", [])
+                    if isinstance(data, list):
+                        for a in data:
+                            aid = a.get("activityId")
+                            if aid:
+                                activity_ids.append(aid)
 
         if not activity_ids and on_batch:
             try:
-                act_data = self.api_fetch(
-                    "/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0"
-                )
+                act_data = self.api_fetch(activities_search_url(s_date, e_date, limit=1000))
                 if isinstance(act_data, list):
                     all_api_ids = [a.get("activityId") for a in act_data if a.get("activityId")]
                     activity_ids = [aid for aid in all_api_ids if aid not in (known_activity_ids or set())]

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -18,7 +18,7 @@ import sys
 import time
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -117,6 +117,7 @@ class GarminClient:
         self._xvfb_proc = None
         self._xvfb_display = None
         self._xvfb_prev_display = None
+        self._save_raw_enabled = False
 
     # ── Display management ───────────────────────────────────────
 
@@ -368,20 +369,28 @@ class GarminClient:
                 print("Already logged in (session restored)")
                 self._save_session()
                 return True
-            log.debug("On app page but no CSRF — session invalid, proceeding with login")
+            # If we are on a connect page but CSRF failed, don't clear cookies yet.
+            # Just try one navigation to /modern/ to see if it wakes up.
+            log.debug("On app page but no CSRF — attempting to refresh context")
             try:
-                self._uc_navigate(SSO_LOGIN_URL, 12)
+                self._uc_navigate("https://connect.garmin.com/modern/", 12)
                 time.sleep(3)
+                if self._post_login_setup():
+                    print("Already logged in (session restored after refresh)")
+                    self._save_session()
+                    return True
             except Exception:
                 pass
 
         print("Logging in...")
 
-        try:
-            self._driver.delete_all_cookies()
-            log.debug("Cleared stale cookies")
-        except Exception as e:
-            log.debug("Cookie clear error: %s", e)
+        # Only clear cookies if we are on the SSO login page (fresh login needed)
+        if self._is_on_login_page():
+            try:
+                self._driver.delete_all_cookies()
+                log.debug("Cleared stale cookies for fresh login")
+            except Exception as e:
+                log.debug("Cookie clear error: %s", e)
 
         for attempt in range(3):
             try:
@@ -735,6 +744,43 @@ class GarminClient:
             return bytes(result["data"])
         return None
 
+    # ── Save raw debug data ─────────────────────────────────────
+
+    def _save_raw(self, name: str, data):
+        """Save raw JSON response under the ``debug/raw`` directory (next to browser_profile)."""
+        if not self.profile_dir:
+            return
+        raw_dir = self.profile_dir.parent / "debug" / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = name.replace("/", "_").replace("?", "_").replace("=", "_").replace(":", "_")
+        try:
+            payload = json.dumps(data, indent=2, sort_keys=True)
+            file_path = raw_dir / f"{safe_name}.json"
+
+            if file_path.exists():
+                try:
+                    if file_path.read_text() == payload:
+                        return
+                except Exception:
+                    pass
+
+                suffix = 2
+                while True:
+                    candidate = raw_dir / f"{safe_name}__{suffix}.json"
+                    if not candidate.exists():
+                        file_path = candidate
+                        break
+                    try:
+                        if candidate.read_text() == payload:
+                            return
+                    except Exception:
+                        pass
+                    suffix += 1
+
+            file_path.write_text(payload)
+        except Exception as e:
+            log.debug("Could not save raw data: %s", e)
+
     # ── Batch fetching ───────────────────────────────────────────
 
     def _fetch_batch(self, rest: dict, gql: dict) -> dict:
@@ -802,6 +848,15 @@ class GarminClient:
         if result and "error" in result:
             log.warning("_fetch_batch JS error: %s", result["error"])
             return {}
+
+        # Save raw payloads and failures for later replay/debugging.
+        if self._save_raw_enabled and result:
+            for name, res in result.items():
+                if res.get("status") == 200 and res.get("data") is not None:
+                    self._save_raw(name, res["data"])
+                else:
+                    self._save_raw(name, res)
+
         return result or {}
 
     def _date_chunks(self, start: str, end: str, max_days: int = 28) -> list:
@@ -822,6 +877,7 @@ class GarminClient:
         end_date: Optional[str] = None,
         on_batch=None,
         known_activity_ids: Optional[set] = None,
+        save_raw: bool = False,
     ) -> dict:
         """Fetch all data from Garmin Connect.
 
@@ -831,8 +887,13 @@ class GarminClient:
             ``on_batch(endpoint_name, data, cal_date=None)`` called after each
             successful fetch.
         known_activity_ids : set, optional
-            Activity IDs that already have detail data — these will be skipped.
+            Activity IDs that already have detail data (splits, HR zones, weather).
+            These will be skipped during per-activity detail fetching.
+        save_raw : bool, default False
+            Whether to save raw JSON responses under the ``debug/raw`` directory
+            (next to ``browser_profile``).
         """
+        self._save_raw_enabled = save_raw
         today = target_date or date.today().isoformat()
         e_date = end_date or today
         s_date = start_date or (date.fromisoformat(today) - timedelta(days=30)).isoformat()

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -43,6 +43,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_PROFILE_DIR = Path.home() / ".garmin-client" / "browser_profile"
 
+CONNECT_URL = "https://connect.garmin.com/app/"
 SSO_LOGIN_URL = (
     "https://sso.garmin.com/portal/sso/en-US/sign-in"
     "?clientId=GarminConnect"
@@ -354,9 +355,9 @@ class GarminClient:
     def login(self, timeout_ms: int = 600000) -> bool:
         self._launch_browser()
 
-        log.debug("Navigating to connect.garmin.com/modern/")
+        log.debug("Navigating to %s", CONNECT_URL)
         try:
-            self._uc_navigate("https://connect.garmin.com/modern/", 12)
+            self._uc_navigate(CONNECT_URL, 12)
         except Exception as e:
             log.debug("Initial navigation error (expected for fresh profile): %s", e)
         time.sleep(3)
@@ -373,7 +374,7 @@ class GarminClient:
             # Just try one navigation to /modern/ to see if it wakes up.
             log.debug("On app page but no CSRF — attempting to refresh context")
             try:
-                self._uc_navigate("https://connect.garmin.com/modern/", 12)
+                self._uc_navigate(CONNECT_URL, 12)
                 time.sleep(3)
                 if self._post_login_setup():
                     print("Already logged in (session restored after refresh)")
@@ -543,7 +544,7 @@ class GarminClient:
             if mfa_prompted and poll > 0 and poll % 30 == 0:
                 log.debug("Stuck on SSO after MFA — trying to navigate to app...")
                 try:
-                    self._driver.get("https://connect.garmin.com/modern/")
+                    self._driver.get(CONNECT_URL)
                     time.sleep(2)
                     url = self._driver.current_url
                     if "connect.garmin.com" in url and "sso.garmin.com" not in url:
@@ -625,7 +626,7 @@ class GarminClient:
         if "/modern/" not in current:
             log.debug("Navigating to /modern/ for CSRF (was on %s)", current)
             try:
-                self._driver.get("https://connect.garmin.com/modern/")
+                self._driver.get(CONNECT_URL)
             except Exception:
                 pass
             time.sleep(3)
@@ -679,7 +680,7 @@ class GarminClient:
         except Exception:
             return
         if "connect.garmin.com" not in current or "sso.garmin.com" in current:
-            self._driver.get("https://connect.garmin.com/modern/")
+            self._driver.get(CONNECT_URL)
             time.sleep(2)
 
     # ── Public API ───────────────────────────────────────────────

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -18,7 +18,7 @@ import sys
 import time
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By

--- a/garmin_client/endpoints.py
+++ b/garmin_client/endpoints.py
@@ -52,7 +52,7 @@ def full_range_rest(display_name: str, start_date: str, end_date: str) -> dict:
         "vo2max_trend": f"/gc-api/metrics-service/metrics/maxmet/daily/{start_date}/{end_date}",
         "personal_records": f"/gc-api/personalrecord-service/personalrecord/prs/{dn}",
         "personal_record_types": f"/gc-api/personalrecord-service/personalrecordtype/prtypes/{dn}",
-        "lactate_threshold": f"/gc-api/biometric-service/biometric/latestLactateThreshold",
+        "lactate_threshold": "/gc-api/biometric-service/biometric/latestLactateThreshold",
     }
 
 

--- a/garmin_client/endpoints.py
+++ b/garmin_client/endpoints.py
@@ -52,6 +52,7 @@ def full_range_rest(display_name: str, start_date: str, end_date: str) -> dict:
         "vo2max_trend": f"/gc-api/metrics-service/metrics/maxmet/daily/{start_date}/{end_date}",
         "personal_records": f"/gc-api/personalrecord-service/personalrecord/prs/{dn}",
         "personal_record_types": f"/gc-api/personalrecord-service/personalrecordtype/prtypes/{dn}",
+        "lactate_threshold": f"/gc-api/biometric-service/biometric/latestLactateThreshold",
     }
 
 
@@ -68,7 +69,6 @@ def full_range_graphql(display_name: str, start_date: str, end_date: str) -> dic
         "vo2max_cycling": f'query{{vo2MaxScalar(startDate:"{start_date}", endDate:"{end_date}", sport:"CYCLING")}}',
         "weight": f'query{{weightScalar(startDate:"{start_date}", endDate:"{end_date}")}}',
         "blood_pressure": f'query{{bloodPressureScalar(startDate:"{start_date}", endDate:"{end_date}")}}',
-        "activities_range": f'query{{activitiesScalar(displayName:"{dn}", startTimestampLocal:"{start_date}T00:00:00.00", endTimestampLocal:"{end_date}T23:59:59.99")}}',
         "activity_stats_all": f'query{{activityStatsScalar(aggregation:"daily", startDate:"{start_date}", endDate:"{end_date}", activityType:"all")}}',
         "activity_stats_running": f'query{{activityStatsScalar(aggregation:"daily", startDate:"{start_date}", endDate:"{end_date}", activityType:"running")}}',
         "activity_stats_cycling": f'query{{activityStatsScalar(aggregation:"daily", startDate:"{start_date}", endDate:"{end_date}", activityType:"cycling")}}',
@@ -119,12 +119,14 @@ def daily_rest(display_name: str, date: str) -> dict:
         "intensity_minutes": f"/gc-api/wellness-service/wellness/daily/im/{date}",
         "hydration": f"/gc-api/usersummary-service/usersummary/hydration/allData/{date}",
         "body_battery_events": f"/gc-api/wellness-service/wellness/bodyBattery/events/{date}",
+        "nutrition_meals": f"/gc-api/nutrition-service/meals/{date}",
         "fitness_age": f"/gc-api/fitnessage-service/fitnessage/{date}",
         "wellness_activity": f"/gc-api/wellnessactivity-service/activity/summary/{date}",
         "daily_movement": f"/gc-api/wellness-service/wellness/dailyMovement?calendarDate={date}",
         "endurance_score": f"/gc-api/metrics-service/metrics/endurancescore?calendarDate={date}",
         "hill_score": f"/gc-api/metrics-service/metrics/hillscore?calendarDate={date}",
         "race_predictions": f"/gc-api/metrics-service/metrics/racepredictions/daily/{dn}?fromCalendarDate={date}&toCalendarDate={date}",
+        "hrv_timeline": f"/gc-api/hrv-service/hrv/{date}",
     }
 
 

--- a/garmin_client/endpoints.py
+++ b/garmin_client/endpoints.py
@@ -40,13 +40,17 @@ def profile_graphql(display_name: str) -> dict:
     }
 
 
+def activities_search_url(start_date: str, end_date: str, limit: int = 100, offset: int = 0) -> str:
+    """Build the activities search URL with date filtering."""
+    return f"/gc-api/activitylist-service/activities/search/activities?limit={limit}&start={offset}&startDate={start_date}&endDate={end_date}"
+
+
 def full_range_rest(display_name: str, start_date: str, end_date: str) -> dict:
     """REST endpoints that support full date ranges."""
     dn = display_name
     return {
-        # Note: this returns max ~20-100 activities per page. Pagination
-        # is handled in client.py fetch_all() to get ALL activities.
-        "activities": "/gc-api/activitylist-service/activities/search/activities?limit=100&start=0",
+        # Pagination is handled in client.py fetch_all().
+        "activities": activities_search_url(start_date, end_date),
         "weight_range": f"/gc-api/weight-service/weight/dateRange?startDate={start_date}&endDate={end_date}",
         "weight_latest": f"/gc-api/weight-service/weight/latest?date={end_date}",
         "vo2max_trend": f"/gc-api/metrics-service/metrics/maxmet/daily/{start_date}/{end_date}",

--- a/garmin_givemydata.py
+++ b/garmin_givemydata.py
@@ -274,7 +274,9 @@ examples:
         help="Download FIT files only, skip health data sync",
     )
     fit_group.add_argument(
-        "--latest", action="store_true", help="Download only the latest FIT file (use with --fit-only)"
+        "--latest",
+        action="store_true",
+        help="Fetch only today's data (or download only the latest FIT file with --fit-only)",
     )
     fit_group.add_argument(
         "--date", type=str, help="Download FIT file for a specific date YYYY-MM-DD (use with --fit-only)"
@@ -403,6 +405,11 @@ examples:
         mode = "full"
         start = (today - timedelta(days=365 * 10)).isoformat()
         end = today.isoformat()
+    elif args.latest and not args.fit_only:
+        mode = "incremental"
+        start = today.isoformat()
+        end = today.isoformat()
+        print(f"Fetching latest data for {today.isoformat()}")
     elif args.days:
         mode = "range"
         start = (today - timedelta(days=args.days)).isoformat()

--- a/garmin_givemydata.py
+++ b/garmin_givemydata.py
@@ -251,7 +251,9 @@ examples:
     fetch_group.add_argument("--full", action="store_true", help="Force full historical fetch")
     fetch_group.add_argument("--days", type=int, help="Fetch last N days")
     fetch_group.add_argument("--since", type=str, help="Fetch from date (YYYY-MM-DD)")
-    fetch_group.add_argument("--save-raw", action="store_true", help="Save raw JSON responses to debug/raw for debugging")
+    fetch_group.add_argument(
+        "--save-raw", action="store_true", help="Save raw JSON responses to debug/raw for debugging"
+    )
     fetch_group.add_argument(
         "--no-files",
         action="store_true",

--- a/garmin_givemydata.py
+++ b/garmin_givemydata.py
@@ -121,6 +121,7 @@ def fetch_direct_to_db(
     conn,
     start_date: str,
     end_date: str,
+    save_raw: bool = False,
 ) -> None:
     """Fetch data and save each batch directly to SQLite."""
     counts = {}
@@ -157,6 +158,7 @@ def fetch_direct_to_db(
             end_date=end_date,
             on_batch=on_batch,
             known_activity_ids=known_activity_ids,
+            save_raw=save_raw,
         )
     else:
         # Calculate total chunks for progress reporting
@@ -184,6 +186,7 @@ def fetch_direct_to_db(
                 end_date=chunk_end.isoformat(),
                 on_batch=on_batch,
                 known_activity_ids=known_activity_ids,
+                save_raw=save_raw,
             )
 
             new_total = sum(counts.values())
@@ -248,6 +251,7 @@ examples:
     fetch_group.add_argument("--full", action="store_true", help="Force full historical fetch")
     fetch_group.add_argument("--days", type=int, help="Fetch last N days")
     fetch_group.add_argument("--since", type=str, help="Fetch from date (YYYY-MM-DD)")
+    fetch_group.add_argument("--save-raw", action="store_true", help="Save raw JSON responses to debug/raw for debugging")
     fetch_group.add_argument(
         "--no-files",
         action="store_true",
@@ -519,7 +523,7 @@ examples:
             print("Login failed!")
             sys.exit(1)
 
-        fetch_direct_to_db(client, conn, start, end)
+        fetch_direct_to_db(client, conn, start, end, save_raw=args.save_raw)
 
         # Report actual row counts from the database (not upsert operations)
         tables = db_query(

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -223,6 +223,8 @@ CREATE TABLE IF NOT EXISTS wellness_activity (
 CREATE TABLE IF NOT EXISTS training_status (
     calendar_date   TEXT PRIMARY KEY,
     status          TEXT,
+    acute_load      REAL,
+    chronic_load    REAL,
     raw_json        TEXT
 );
 
@@ -356,14 +358,26 @@ CREATE TABLE IF NOT EXISTS vo2max (
     PRIMARY KEY (calendar_date, sport)
 );
 
+CREATE TABLE IF NOT EXISTS lactate_threshold (
+    calendar_date       TEXT PRIMARY KEY,
+    speed               REAL,
+    heart_rate          INTEGER,
+    heart_rate_cycling  INTEGER,
+    rowing_speed        REAL,
+    heart_rate_rowing   INTEGER,
+    raw_json            TEXT
+);
+
 CREATE TABLE IF NOT EXISTS weight (
-    calendar_date   TEXT PRIMARY KEY,
+    timestamp       INTEGER PRIMARY KEY,
+    calendar_date   TEXT,
     weight          REAL,
     bmi             REAL,
     body_fat        REAL,
     body_water      REAL,
     bone_mass       REAL,
     muscle_mass     REAL,
+    source          TEXT,
     raw_json        TEXT
 );
 
@@ -430,6 +444,9 @@ CREATE TABLE IF NOT EXISTS device (
     device_type     TEXT,
     application_key TEXT,
     last_sync       TEXT,
+    software_version TEXT,
+    battery_status  TEXT,
+    battery_voltage REAL,
     raw_json        TEXT
 );
 
@@ -594,19 +611,186 @@ CREATE INDEX IF NOT EXISTS idx_endurance_date ON endurance_score (calendar_date)
 CREATE INDEX IF NOT EXISTS idx_hill_date ON hill_score (calendar_date);
 CREATE INDEX IF NOT EXISTS idx_race_pred_date ON race_predictions (calendar_date);
 CREATE INDEX IF NOT EXISTS idx_act_splits ON activity_splits (activity_id);
+CREATE TABLE IF NOT EXISTS running_dynamics (
+    activity_id     INTEGER PRIMARY KEY,
+    avg_gct         REAL,
+    avg_gct_balance REAL,
+    avg_vert_osc    REAL,
+    avg_vert_ratio  REAL,
+    avg_stride_len  REAL,
+    raw_json        TEXT
+);
+
+CREATE TABLE IF NOT EXISTS load_focus (
+    calendar_date   TEXT PRIMARY KEY,
+    anaerobic       REAL,
+    high_aerobic    REAL,
+    low_aerobic     REAL,
+    focus_status    TEXT,
+    raw_json        TEXT
+);
+
+CREATE TABLE IF NOT EXISTS hrv_timeline (
+    calendar_date   TEXT PRIMARY KEY,
+    reading_count   INTEGER,
+    raw_json        TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_act_weather ON activity_weather (activity_id);
 """
+
+
+def migrate_training_status_table(conn: sqlite3.Connection) -> None:
+    """Migrate the training_status table to include acute and chronic load columns."""
+    cursor = conn.execute("PRAGMA table_info(training_status)")
+    cols = {row["name"] for row in cursor.fetchall()}
+
+    if "acute_load" not in cols:
+        log.info("Migrating training_status table...")
+        try:
+            conn.execute("ALTER TABLE training_status ADD COLUMN acute_load REAL")
+            conn.execute("ALTER TABLE training_status ADD COLUMN chronic_load REAL")
+        except Exception as e:
+            log.debug("Migration note: %s", e)
 
 
 def init_db(conn: sqlite3.Connection) -> None:
     """Create all tables and indexes if they do not already exist."""
     conn.executescript(_SCHEMA_SQL)
+    migrate_weight_table(conn)
+    migrate_device_table(conn)
+    migrate_training_status_table(conn)
+    cleanup_invalid_rows(conn)
+    backfill_hrv_timeline_counts(conn)
+    backfill_calories_from_daily_summaries(conn)
     conn.commit()
+
+
+def migrate_device_table(conn: sqlite3.Connection) -> None:
+    """Migrate the device table to include battery and software fields if missing."""
+    cursor = conn.execute("PRAGMA table_info(device)")
+    cols = {row["name"] for row in cursor.fetchall()}
+
+    if "battery_status" not in cols:
+        log.info("Migrating device table...")
+        try:
+            conn.execute("ALTER TABLE device ADD COLUMN software_version TEXT")
+            conn.execute("ALTER TABLE device ADD COLUMN battery_status TEXT")
+            conn.execute("ALTER TABLE device ADD COLUMN battery_voltage REAL")
+        except Exception as e:
+            log.debug("Migration note: %s", e)
+
+
+def migrate_weight_table(conn: sqlite3.Connection) -> None:
+    """Migrate the weight table to include the 'source' column and 'timestamp' PK if needed."""
+    cursor = conn.execute("PRAGMA table_info(weight)")
+    cols = {row["name"] for row in cursor.fetchall()}
+
+    # Check if we need to migrate (either missing 'source' or wrong PK)
+    # The new schema has 'timestamp' as PK.
+    cursor = conn.execute("PRAGMA index_list(weight)")
+    is_legacy = "timestamp" not in cols
+
+    if is_legacy:
+        log.info("Migrating weight table to new schema...")
+        conn.executescript(
+            """
+            ALTER TABLE weight RENAME TO weight_old;
+            CREATE TABLE weight (
+                timestamp       INTEGER PRIMARY KEY,
+                calendar_date   TEXT,
+                weight          REAL,
+                bmi             REAL,
+                body_fat        REAL,
+                body_water      REAL,
+                bone_mass       REAL,
+                muscle_mass     REAL,
+                source          TEXT,
+                raw_json        TEXT
+            );
+            -- Use rowid as a millisecond offset to the date-based timestamp
+            -- to ensure uniqueness for same-day legacy entries.
+            INSERT INTO weight (timestamp, calendar_date, weight, bmi, body_fat, body_water, bone_mass, muscle_mass, source, raw_json)
+            SELECT
+                COALESCE(
+                    json_extract(raw_json, '$.date'),
+                    json_extract(raw_json, '$.timestampGMT'),
+                    (CAST(strftime('%s', calendar_date) AS INTEGER) * 1000) + rowid
+                ) as timestamp,
+                calendar_date, weight, bmi, body_fat, body_water, bone_mass, muscle_mass,
+                json_extract(raw_json, '$.sourceType'),
+                raw_json
+            FROM weight_old
+            WHERE weight IS NOT NULL
+            ON CONFLICT(timestamp) DO NOTHING;
+            DROP TABLE weight_old;
+            """
+        )
 
 
 # ---------------------------------------------------------------------------
 # Upsert helpers — one per table
 # ---------------------------------------------------------------------------
+
+
+def upsert_hrv_timeline(conn: sqlite3.Connection, record: dict, cal_date: str = None) -> None:
+    d = cal_date or record.get("calendarDate")
+    if not d:
+        return
+    readings = record.get("hrvReadings")
+    if not isinstance(readings, list):
+        readings = record.get("hrvValues", [])
+    conn.execute(
+        "INSERT OR REPLACE INTO hrv_timeline (calendar_date, reading_count, raw_json) VALUES (?, ?, ?)",
+        (d, len(readings) if isinstance(readings, list) else 0, json.dumps(record)),
+    )
+
+
+def upsert_lactate_threshold(conn: sqlite3.Connection, record: dict) -> None:
+    d = record.get("calendarDate")
+    if not d:
+        return
+    d = str(d)[:10]
+    conn.execute(
+        """INSERT INTO lactate_threshold
+           (calendar_date, speed, heart_rate, heart_rate_cycling, rowing_speed, heart_rate_rowing, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(calendar_date) DO UPDATE SET
+             speed = COALESCE(excluded.speed, lactate_threshold.speed),
+             heart_rate = COALESCE(excluded.heart_rate, lactate_threshold.heart_rate),
+             heart_rate_cycling = COALESCE(excluded.heart_rate_cycling, lactate_threshold.heart_rate_cycling),
+             rowing_speed = COALESCE(excluded.rowing_speed, lactate_threshold.rowing_speed),
+             heart_rate_rowing = COALESCE(excluded.heart_rate_rowing, lactate_threshold.heart_rate_rowing),
+             raw_json = excluded.raw_json""",
+        (
+            d,
+            record.get("speed"),
+            record.get("hearRate") or record.get("heartRate"),
+            record.get("heartRateCycling"),
+            record.get("rowSpeed"),
+            record.get("heartRateRowing"),
+            json.dumps(record),
+        ),
+    )
+
+
+def upsert_running_dynamics(conn: sqlite3.Connection, aid: int, record: dict) -> None:
+    # Running dynamics are usually in summaryDTO for activity details
+    summary = record.get("summaryDTO") or record
+    conn.execute(
+        """INSERT OR REPLACE INTO running_dynamics
+           (activity_id, avg_gct, avg_gct_balance, avg_vert_osc, avg_vert_ratio, avg_stride_len, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (
+            aid,
+            summary.get("groundContactTime"),
+            summary.get("groundContactBalance"),
+            summary.get("verticalOscillation"),
+            summary.get("verticalRatio"),
+            summary.get("strideLength"),
+            json.dumps(record),
+        ),
+    )
 
 
 def upsert_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
@@ -692,6 +876,88 @@ def upsert_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
             "raw_json": json.dumps(record),
         },
     )
+    upsert_calories_from_daily_summary(conn, record)
+
+
+def upsert_calories_from_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
+    d = record.get("calendarDate")
+    total = record.get("totalKilocalories")
+    active = record.get("activeKilocalories")
+    bmr = record.get("bmrKilocalories")
+    remaining = record.get("remainingKilocalories")
+    if not d or all(v is None for v in (total, active, bmr, remaining)):
+        return
+    conn.execute(
+        """
+        INSERT INTO calories (calendar_date, total, active, bmr, consumed, remaining, raw_json)
+        VALUES (?, ?, ?, ?, NULL, ?, ?)
+        ON CONFLICT(calendar_date) DO UPDATE SET
+            total = excluded.total,
+            active = excluded.active,
+            bmr = excluded.bmr,
+            remaining = COALESCE(excluded.remaining, calories.remaining),
+            consumed = COALESCE(calories.consumed, excluded.consumed),
+            raw_json = CASE
+                WHEN calories.consumed IS NOT NULL THEN calories.raw_json
+                ELSE excluded.raw_json
+            END
+        """,
+        (
+            d,
+            total,
+            active,
+            bmr,
+            remaining,
+            json.dumps(record),
+        ),
+    )
+
+
+def backfill_calories_from_daily_summaries(conn: sqlite3.Connection) -> None:
+    """Populate missing calories rows from already-synced daily summaries."""
+    conn.execute(
+        """
+        INSERT INTO calories (calendar_date, total, active, bmr, consumed, remaining, raw_json)
+        SELECT
+            ds.calendar_date,
+            ds.total_kilocalories,
+            ds.active_kilocalories,
+            ds.bmr_kilocalories,
+            NULL,
+            ds.remaining_kilocalories,
+            ds.raw_json
+        FROM daily_summary ds
+        LEFT JOIN calories c ON c.calendar_date = ds.calendar_date
+        WHERE c.calendar_date IS NULL
+          AND (
+              ds.total_kilocalories IS NOT NULL OR
+              ds.active_kilocalories IS NOT NULL OR
+              ds.bmr_kilocalories IS NOT NULL OR
+              ds.remaining_kilocalories IS NOT NULL
+          )
+        """
+    )
+
+
+def cleanup_invalid_rows(conn: sqlite3.Connection) -> None:
+    """Remove rows created by earlier permissive parsers."""
+    conn.execute(
+        "DELETE FROM hrv WHERE calendar_date IS NULL OR TRIM(calendar_date) = ''"
+    )
+
+
+def backfill_hrv_timeline_counts(conn: sqlite3.Connection) -> None:
+    """Recompute reading_count from stored raw_json for existing HRV timeline rows."""
+    conn.execute(
+        """
+        UPDATE hrv_timeline
+        SET reading_count = COALESCE(
+            json_array_length(json_extract(raw_json, '$.hrvReadings')),
+            json_array_length(json_extract(raw_json, '$.hrvValues')),
+            0
+        )
+        """
+    )
 
 
 def upsert_sleep(conn: sqlite3.Connection, record: dict) -> None:
@@ -743,6 +1009,9 @@ def upsert_sleep(conn: sqlite3.Connection, record: dict) -> None:
 
 
 def upsert_activity(conn: sqlite3.Connection, record: dict) -> None:
+    if not isinstance(record, dict) or not record.get("activityId"):
+        return
+
     activity_type_dict: dict = record.get("activityType") or {}
     activity_type_key: str | None = activity_type_dict.get("typeKey")
     activity_type_id: int | None = activity_type_dict.get("typeId")
@@ -1094,28 +1363,50 @@ def upsert_weight(conn: sqlite3.Connection, record: dict, cal_date: str = None) 
     from datetime import datetime
 
     d = cal_date or record.get("calendarDate")
+    ts = record.get("date")
 
     # The "date" field from weight endpoints is a Unix timestamp in
-    # milliseconds (e.g. 1743345400000), not a calendar date string.
-    # Convert it properly instead of storing the raw integer.
-    if not d:
-        ts = record.get("date")
-        if isinstance(ts, (int, float)):
-            # Garmin uses milliseconds; values > 1e10 are ms timestamps
-            if ts > 1e10:
-                ts = ts / 1000
-            d = datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
-        elif isinstance(ts, str) and ts[:4].isdigit() and "-" in ts:
-            d = ts[:10]
+    # milliseconds (e.g. 1743345400000).
+    if isinstance(ts, (int, float)):
+        # Garmin uses milliseconds; values > 1e10 are ms timestamps
+        if ts > 1e10:
+            actual_ts = int(ts)
+            ts_seconds = ts / 1000
+        else:
+            actual_ts = int(ts * 1000)
+            ts_seconds = ts
+        if not d:
+            d = datetime.fromtimestamp(ts_seconds).strftime("%Y-%m-%d")
+    elif isinstance(ts, str) and ts[:4].isdigit() and "-" in ts:
+        d = ts[:10]
+        # Try to parse string date back to timestamp if missing
+        try:
+            actual_ts = int(datetime.fromisoformat(ts).timestamp() * 1000)
+        except Exception:
+            actual_ts = None
+    else:
+        actual_ts = None
 
     if not d:
         return
     d = str(d)[:10]
+
+    # If we have no timestamp at all, we fall back to day-level resolution
+    # but use a dummy timestamp to avoid primary key conflicts.
+    if actual_ts is None:
+        try:
+            actual_ts = int(datetime.fromisoformat(d).timestamp() * 1000)
+        except Exception:
+            return
+
+    source = record.get("sourceType") or record.get("source")
+
     conn.execute(
         """INSERT OR REPLACE INTO weight
-           (calendar_date, weight, bmi, body_fat, body_water, bone_mass, muscle_mass, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+           (timestamp, calendar_date, weight, bmi, body_fat, body_water, bone_mass, muscle_mass, source, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
+            actual_ts,
             d,
             record.get("weight"),
             record.get("bmi"),
@@ -1123,6 +1414,7 @@ def upsert_weight(conn: sqlite3.Connection, record: dict, cal_date: str = None) 
             record.get("bodyWater"),
             record.get("boneMass"),
             record.get("muscleMass"),
+            source,
             json.dumps(record),
         ),
     )
@@ -1161,9 +1453,16 @@ def upsert_calories(conn: sqlite3.Connection, record: dict) -> None:
     if not d:
         return
     conn.execute(
-        """INSERT OR REPLACE INTO calories
+        """INSERT INTO calories
            (calendar_date, total, active, bmr, consumed, remaining, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(calendar_date) DO UPDATE SET
+               total = COALESCE(excluded.total, calories.total),
+               active = COALESCE(excluded.active, calories.active),
+               bmr = COALESCE(excluded.bmr, calories.bmr),
+               consumed = COALESCE(excluded.consumed, calories.consumed),
+               remaining = COALESCE(excluded.remaining, calories.remaining),
+               raw_json = excluded.raw_json""",
         (
             d,
             record.get("totalKilocalories"),
@@ -1373,11 +1672,46 @@ def upsert_wellness_activity(conn, record, cal_date=None):
 
 def upsert_training_status(conn, record, cal_date=None):
     d = cal_date or record.get("calendarDate") or record.get("date")
-    if d:
-        conn.execute(
-            "INSERT OR REPLACE INTO training_status (calendar_date, status, raw_json) VALUES (?, ?, ?)",
-            (d, record.get("trainingStatus") or record.get("status"), json.dumps(record)),
-        )
+
+    # Extract from nested structure if present
+    status = None
+    acute = None
+    chronic = None
+
+    # Option 1: Top-level fields (rare in new API)
+    status = record.get("trainingStatus") or record.get("status")
+
+    # Option 2: Nested latestTrainingStatusData (common in modern API)
+    # The keys inside latestTrainingStatusData are device IDs
+    nested = record.get("latestTrainingStatusData")
+    if isinstance(nested, dict) and nested:
+        # Get the first device's data (usually there's only one primary)
+        device_data = next(iter(nested.values()))
+        if isinstance(device_data, dict):
+            status = device_data.get("trainingStatusFeedbackPhrase") or device_data.get("trainingStatus")
+            if not d:
+                d = device_data.get("calendarDate")
+
+            # Extract load
+            acute_dto = device_data.get("acuteTrainingLoadDTO")
+            if isinstance(acute_dto, dict):
+                acute = acute_dto.get("dailyTrainingLoadAcute")
+                chronic = acute_dto.get("dailyTrainingLoadChronic")
+
+    if not d:
+        return
+
+    # Garmin's numeric codes do not match the old hard-coded enum guess.
+    # Prefer the explicit phrase when Garmin provides it; otherwise preserve
+    # the numeric code as-is instead of silently mislabeling the row.
+    if isinstance(status, int):
+        status = f"STATUS_{status}"
+
+    conn.execute(
+        """INSERT OR REPLACE INTO training_status (calendar_date, status, acute_load, chronic_load, raw_json)
+           VALUES (?, ?, ?, ?, ?)""",
+        (d, status, acute, chronic, json.dumps(record)),
+    )
 
 
 def upsert_health_status(conn, record, cal_date=None):
@@ -1467,14 +1801,18 @@ def upsert_device(conn, record):
         return
     conn.execute(
         """INSERT OR REPLACE INTO device
-           (device_id, display_name, device_type, application_key, last_sync, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?)""",
+           (device_id, display_name, device_type, application_key, last_sync,
+            software_version, battery_status, battery_voltage, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             device_id,
             record.get("displayName"),
             record.get("deviceTypeSimpleName"),
             record.get("applicationKey"),
             record.get("lastSync"),
+            record.get("softwareVersion"),
+            record.get("batteryStatus"),
+            record.get("batteryVoltage"),
             json.dumps(record),
         ),
     )
@@ -1549,11 +1887,18 @@ def upsert_hr_zones(conn, record):
 
 def _unwrap_gql_data(data):
     """Unwrap GraphQL response: {data: {scalarName: [...]}} → [...]"""
-    if isinstance(data, dict) and "data" in data and len(data) == 1:
+    if not isinstance(data, dict):
+        return data
+
+    # Handle { data: { scalar: ... } }
+    if "data" in data and isinstance(data["data"], dict):
         data = data["data"]
-    if isinstance(data, dict) and len(data) == 1:
+
+    # If it's a single-key dict, return the value (the actual scalar content)
+    if len(data) == 1:
         inner = list(data.values())[0]
-        return inner if isinstance(inner, list) else [inner] if isinstance(inner, dict) else data
+        return inner if inner is not None else []
+
     return data
 
 
@@ -1563,6 +1908,103 @@ def _ensure_list(data) -> list:
         return data
     if isinstance(data, dict):
         return [data]
+    return []
+
+
+def _extract_activity_records(data: Any) -> list[dict]:
+    """Normalize activity payloads and drop wrapper/error objects."""
+    if not data:
+        return []
+    if isinstance(data, list):
+        return [rec for rec in data if isinstance(rec, dict) and rec.get("activityId")]
+    if not isinstance(data, dict):
+        return []
+    if data.get("errors") and not data.get("data"):
+        return []
+    if isinstance(data.get("activityList"), list):
+        return _extract_activity_records(data["activityList"])
+    activities_for_day = data.get("ActivitiesForDay")
+    if isinstance(activities_for_day, dict) and isinstance(activities_for_day.get("payload"), list):
+        return _extract_activity_records(activities_for_day["payload"])
+    if "data" in data:
+        return _extract_activity_records(data["data"])
+    if data.get("activityId"):
+        return [data]
+    return []
+
+
+def _extract_weight_records(data: Any) -> list[dict]:
+    """Normalize weight payloads from REST and GraphQL endpoints."""
+    if not data:
+        return []
+    if isinstance(data, list):
+        records: list[dict] = []
+        for item in data:
+            records.extend(_extract_weight_records(item))
+        return records
+    if not isinstance(data, dict):
+        return []
+    if data.get("errors") and not data.get("data"):
+        return []
+    if "data" in data:
+        return _extract_weight_records(data["data"])
+    if isinstance(data.get("dailyWeightSummaries"), list):
+        records: list[dict] = []
+        for summary in data["dailyWeightSummaries"]:
+            if isinstance(summary, dict):
+                records.extend(_extract_weight_records(summary.get("allWeightMetrics")))
+        return records
+    if isinstance(data.get("dateWeightList"), list):
+        return _extract_weight_records(data["dateWeightList"])
+    if isinstance(data.get("allWeightMetrics"), list):
+        return _extract_weight_records(data["allWeightMetrics"])
+    if any(key in data for key in ("weight", "calendarDate", "date")):
+        return [data]
+    return []
+
+
+def _extract_calories_records(data: Any, cal_date: str = None) -> list[dict]:
+    """Normalize calorie payloads from GraphQL and nutrition endpoints."""
+    if not data:
+        return []
+    if isinstance(data, list):
+        records: list[dict] = []
+        for item in data:
+            records.extend(_extract_calories_records(item, cal_date))
+        return records
+    if not isinstance(data, dict):
+        return []
+    if data.get("errors") and not data.get("data"):
+        return []
+    if "data" in data:
+        return _extract_calories_records(data["data"], cal_date)
+
+    record_date = data.get("calendarDate") or data.get("mealDate") or data.get("date") or cal_date
+    if any(
+        key in data
+        for key in (
+            "totalKilocalories",
+            "activeKilocalories",
+            "bmrKilocalories",
+            "consumedKilocalories",
+            "remainingKilocalories",
+        )
+    ) and record_date:
+        return [{**data, "calendarDate": record_date}]
+
+    for key in ("mealSummaries", "meals", "dailyMeals", "items"):
+        meals = data.get(key)
+        if isinstance(meals, list):
+            meal_calories = []
+            for meal in meals:
+                if not isinstance(meal, dict):
+                    continue
+                value = meal.get("calories") or meal.get("kilocalories") or meal.get("totalKilocalories")
+                if isinstance(value, (int, float)):
+                    meal_calories.append(float(value))
+            if meal_calories and record_date:
+                return [{**data, "calendarDate": record_date, "consumedKilocalories": sum(meal_calories)}]
+
     return []
 
 
@@ -1607,6 +2049,7 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
             for rec in records:
                 upsert_sleep(conn, rec)
                 count += 1
+
 
         elif name == "heart_rate" or name == "heart_rate_detail":
             for rec in records:
@@ -1704,12 +2147,12 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
                 count += 1
 
         elif name == "activities" or name == "activities_range":
-            for rec in records:
+            for rec in _extract_activity_records(data):
                 upsert_activity(conn, rec)
                 count += 1
 
         elif name in ("weight_range", "weight_latest", "weight", "weight_range_rest", "weight_first", "goal_weight"):
-            for rec in records:
+            for rec in _extract_weight_records(data):
                 upsert_weight(conn, rec, cal_date)
                 count += 1
 
@@ -1723,13 +2166,18 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
                 upsert_vo2max(conn, rec, "CYCLING")
                 count += 1
 
+        elif name == "lactate_threshold":
+            for rec in records:
+                upsert_lactate_threshold(conn, rec)
+                count += 1
+
         elif name in ("blood_pressure", "blood_pressure_rest"):
             for rec in records:
                 upsert_blood_pressure(conn, rec)
                 count += 1
 
-        elif name == "calories":
-            for rec in records:
+        elif name in ("calories", "nutrition_meals"):
+            for rec in _extract_calories_records(data, cal_date):
                 upsert_calories(conn, rec)
                 count += 1
 
@@ -1767,6 +2215,15 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
                         hrv_records = v
                         break
             for rec in hrv_records:
+                if not isinstance(rec, dict):
+                    continue
+                if rec.get("heartRateVariabilityScalar") is None and not any(
+                    rec.get(k)
+                    for k in ("calendarDate", "startTimestampLocal", "weeklyAvg", "lastNight", "status")
+                ):
+                    continue
+                if not rec.get("calendarDate") and not rec.get("startTimestampLocal"):
+                    continue
                 upsert_hrv(conn, rec)
                 count += 1
 
@@ -1891,7 +2348,14 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
                         "UPDATE activity SET raw_json = ? WHERE activity_id = ?",
                         (_json.dumps(rec), aid),
                     )
+                    # Extract running dynamics if present
+                    upsert_running_dynamics(conn, aid, rec)
                     count += 1
+
+        elif name == "hrv_timeline":
+            for rec in records:
+                upsert_hrv_timeline(conn, rec, cal_date)
+                count += 1
 
         elif name == "activity_exercise_sets":
             aid = int(cal_date) if cal_date else None

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -643,15 +643,23 @@ CREATE INDEX IF NOT EXISTS idx_act_weather ON activity_weather (activity_id);
 def migrate_training_status_table(conn: sqlite3.Connection) -> None:
     """Migrate the training_status table to include acute and chronic load columns."""
     cursor = conn.execute("PRAGMA table_info(training_status)")
-    cols = {row["name"] for row in cursor.fetchall()}
-
+    cols = {row[1] for row in cursor.fetchall()}
+    missing_cols = []
     if "acute_load" not in cols:
-        log.info("Migrating training_status table...")
-        try:
-            conn.execute("ALTER TABLE training_status ADD COLUMN acute_load REAL")
-            conn.execute("ALTER TABLE training_status ADD COLUMN chronic_load REAL")
-        except Exception as e:
-            log.debug("Migration note: %s", e)
+        missing_cols.append("acute_load")
+    if "chronic_load" not in cols:
+        missing_cols.append("chronic_load")
+
+    if missing_cols:
+        log.info(
+            "Migrating training_status table, adding columns: %s",
+            ", ".join(missing_cols),
+        )
+        for col in missing_cols:
+            try:
+                conn.execute(f"ALTER TABLE training_status ADD COLUMN {col} REAL")
+            except sqlite3.OperationalError as e:
+                log.debug("Migration note (training_status.%s): %s", col, e)
 
 
 def init_db(conn: sqlite3.Connection) -> None:
@@ -669,26 +677,35 @@ def init_db(conn: sqlite3.Connection) -> None:
 def migrate_device_table(conn: sqlite3.Connection) -> None:
     """Migrate the device table to include battery and software fields if missing."""
     cursor = conn.execute("PRAGMA table_info(device)")
-    cols = {row["name"] for row in cursor.fetchall()}
+    cols = {row[1] for row in cursor.fetchall()}
+    missing_defs = [
+        ("software_version", "TEXT"),
+        ("battery_status", "TEXT"),
+        ("battery_voltage", "REAL"),
+    ]
+    missing_cols = [name for name, _ in missing_defs if name not in cols]
 
-    if "battery_status" not in cols:
-        log.info("Migrating device table...")
-        try:
-            conn.execute("ALTER TABLE device ADD COLUMN software_version TEXT")
-            conn.execute("ALTER TABLE device ADD COLUMN battery_status TEXT")
-            conn.execute("ALTER TABLE device ADD COLUMN battery_voltage REAL")
-        except Exception as e:
-            log.debug("Migration note: %s", e)
+    if missing_cols:
+        log.info(
+            "Migrating device table, adding columns: %s",
+            ", ".join(missing_cols),
+        )
+        for name, col_type in missing_defs:
+            if name in cols:
+                continue
+            try:
+                conn.execute(f"ALTER TABLE device ADD COLUMN {name} {col_type}")
+            except sqlite3.OperationalError as e:
+                log.debug("Migration note (device.%s): %s", name, e)
 
 
 def migrate_weight_table(conn: sqlite3.Connection) -> None:
     """Migrate the weight table to include the 'source' column and 'timestamp' PK if needed."""
     cursor = conn.execute("PRAGMA table_info(weight)")
-    cols = {row["name"] for row in cursor.fetchall()}
+    cols = {row[1] for row in cursor.fetchall()}
 
     # Check if we need to migrate (either missing 'source' or wrong PK)
     # The new schema has 'timestamp' as PK.
-    cursor = conn.execute("PRAGMA index_list(weight)")
     is_legacy = "timestamp" not in cols
 
     if is_legacy:
@@ -726,6 +743,14 @@ def migrate_weight_table(conn: sqlite3.Connection) -> None:
             DROP TABLE weight_old;
             """
         )
+        return
+
+    if "source" not in cols:
+        log.info("Migrating weight table, adding missing source column")
+        try:
+            conn.execute("ALTER TABLE weight ADD COLUMN source TEXT")
+        except sqlite3.OperationalError as e:
+            log.debug("Migration note (weight.source): %s", e)
 
 
 # ---------------------------------------------------------------------------
@@ -941,9 +966,7 @@ def backfill_calories_from_daily_summaries(conn: sqlite3.Connection) -> None:
 
 def cleanup_invalid_rows(conn: sqlite3.Connection) -> None:
     """Remove rows created by earlier permissive parsers."""
-    conn.execute(
-        "DELETE FROM hrv WHERE calendar_date IS NULL OR TRIM(calendar_date) = ''"
-    )
+    conn.execute("DELETE FROM hrv WHERE calendar_date IS NULL OR TRIM(calendar_date) = ''")
 
 
 def backfill_hrv_timeline_counts(conn: sqlite3.Connection) -> None:
@@ -1980,16 +2003,19 @@ def _extract_calories_records(data: Any, cal_date: str = None) -> list[dict]:
         return _extract_calories_records(data["data"], cal_date)
 
     record_date = data.get("calendarDate") or data.get("mealDate") or data.get("date") or cal_date
-    if any(
-        key in data
-        for key in (
-            "totalKilocalories",
-            "activeKilocalories",
-            "bmrKilocalories",
-            "consumedKilocalories",
-            "remainingKilocalories",
+    if (
+        any(
+            key in data
+            for key in (
+                "totalKilocalories",
+                "activeKilocalories",
+                "bmrKilocalories",
+                "consumedKilocalories",
+                "remainingKilocalories",
+            )
         )
-    ) and record_date:
+        and record_date
+    ):
         return [{**data, "calendarDate": record_date}]
 
     for key in ("mealSummaries", "meals", "dailyMeals", "items"):
@@ -2049,7 +2075,6 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
             for rec in records:
                 upsert_sleep(conn, rec)
                 count += 1
-
 
         elif name == "heart_rate" or name == "heart_rate_detail":
             for rec in records:
@@ -2218,8 +2243,7 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
                 if not isinstance(rec, dict):
                     continue
                 if rec.get("heartRateVariabilityScalar") is None and not any(
-                    rec.get(k)
-                    for k in ("calendarDate", "startTimestampLocal", "weeklyAvg", "lastNight", "status")
+                    rec.get(k) for k in ("calendarDate", "startTimestampLocal", "weeklyAvg", "lastNight", "status")
                 ):
                     continue
                 if not rec.get("calendarDate") and not rec.get("startTimestampLocal"):

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -668,9 +668,33 @@ def init_db(conn: sqlite3.Connection) -> None:
     migrate_weight_table(conn)
     migrate_device_table(conn)
     migrate_training_status_table(conn)
-    cleanup_invalid_rows(conn)
-    backfill_hrv_timeline_counts(conn)
-    backfill_calories_from_daily_summaries(conn)
+
+    # Only run cleanup/backfill when there are rows that actually need it.
+    needs_cleanup = conn.execute(
+        "SELECT 1 FROM hrv WHERE calendar_date IS NULL OR TRIM(calendar_date) = '' LIMIT 1"
+    ).fetchone()
+    if needs_cleanup:
+        cleanup_invalid_rows(conn)
+
+    needs_hrv_backfill = conn.execute(
+        "SELECT 1 FROM hrv_timeline WHERE reading_count IS NULL OR reading_count = 0 LIMIT 1"
+    ).fetchone()
+    if needs_hrv_backfill:
+        backfill_hrv_timeline_counts(conn)
+
+    needs_cal_backfill = conn.execute(
+        """SELECT 1 FROM daily_summary ds
+           LEFT JOIN calories c ON c.calendar_date = ds.calendar_date
+           WHERE c.calendar_date IS NULL
+             AND (ds.total_kilocalories IS NOT NULL
+                  OR ds.active_kilocalories IS NOT NULL
+                  OR ds.bmr_kilocalories IS NOT NULL
+                  OR ds.remaining_kilocalories IS NOT NULL)
+           LIMIT 1"""
+    ).fetchone()
+    if needs_cal_backfill:
+        backfill_calories_from_daily_summaries(conn)
+
     conn.commit()
 
 
@@ -790,6 +814,8 @@ def upsert_lactate_threshold(conn: sqlite3.Connection, record: dict) -> None:
         (
             d,
             record.get("speed"),
+            # Garmin's lactate threshold endpoint actually sends "hearRate" (missing 't')
+            # in some firmware versions.  We check for both spellings.
             record.get("hearRate") or record.get("heartRate"),
             record.get("heartRateCycling"),
             record.get("rowSpeed"),

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -543,7 +543,6 @@ def garmin_sync(refresh: bool = True) -> str:
 # garmin_today
 # ---------------------------------------------------------------------------
 
-
 @mcp.tool()
 def garmin_today() -> str:
     """Complete snapshot of today's health: daily summary, last night's sleep,
@@ -617,11 +616,19 @@ def garmin_today() -> str:
             [today],
         )
 
+        ts = query(
+            conn,
+            """SELECT status, acute_load, chronic_load
+               FROM training_status WHERE calendar_date = ?""",
+            [today],
+        )
+
         result = {
             "date": today,
             "daily": daily[0] if daily else {},
             "last_night_sleep": sleep[0] if sleep else {},
             "training_readiness": tr[0] if tr else {},
+            "training_status": ts[0] if ts else {},
             "hrv": hrv[0] if hrv else {},
             "fitness_age": fitness[0] if fitness else {},
             "last_activity": last_activity[0] if last_activity else {},
@@ -712,12 +719,20 @@ def garmin_activity_detail(activity_id: int = 0, last: bool = False) -> str:
             [activity_id],
         )
 
+        dynamics = query(
+            conn,
+            """SELECT avg_gct, avg_gct_balance, avg_vert_osc, avg_vert_ratio, avg_stride_len
+               FROM running_dynamics WHERE activity_id = ?""",
+            [activity_id],
+        )
+
         result = {
             "activity": activity[0],
             "splits": splits if splits else [],
             "hr_zones": hr_zones[0] if hr_zones else {},
             "weather": weather[0] if weather else {},
             "exercise_sets": [s for s in exercise_sets if s.get("exercise_name")] if exercise_sets else [],
+            "running_dynamics": dynamics[0] if dynamics else {},
         }
         return json.dumps(result, indent=2, default=str)
     finally:
@@ -1419,16 +1434,18 @@ def garmin_body_composition() -> str:
     try:
         rows = query(
             conn,
-            """SELECT calendar_date,
+            """SELECT timestamp,
+                      calendar_date,
                       ROUND(weight / 1000.0, 1) AS weight_kg,
                       ROUND(bmi, 1) AS bmi,
                       ROUND(body_fat, 1) AS body_fat_pct,
                       ROUND(body_water, 1) AS body_water_pct,
                       ROUND(bone_mass / 1000.0, 2) AS bone_mass_kg,
-                      ROUND(muscle_mass / 1000.0, 1) AS muscle_mass_kg
+                      ROUND(muscle_mass / 1000.0, 1) AS muscle_mass_kg,
+                      source
                FROM weight
                WHERE weight IS NOT NULL
-               ORDER BY calendar_date DESC""",
+               ORDER BY timestamp DESC""",
         )
         if not rows:
             return json.dumps({"error": "No weight data found."})
@@ -1655,7 +1672,7 @@ def garmin_training_status(days: int = 90) -> str:
     try:
         rows = query(
             conn,
-            """SELECT calendar_date, status
+            """SELECT calendar_date, status, acute_load, chronic_load
                FROM training_status
                WHERE calendar_date >= ?
                ORDER BY calendar_date""",

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -543,6 +543,7 @@ def garmin_sync(refresh: bool = True) -> str:
 # garmin_today
 # ---------------------------------------------------------------------------
 
+
 @mcp.tool()
 def garmin_today() -> str:
     """Complete snapshot of today's health: daily summary, last night's sleep,

--- a/garmin_mcp/sync.py
+++ b/garmin_mcp/sync.py
@@ -14,7 +14,7 @@ from garmin_mcp.db import get_connection, init_db, save_to_db
 logger = logging.getLogger(__name__)
 
 
-def incremental_sync(target_date: str = None) -> dict:
+def incremental_sync(target_date: str = None, save_raw: bool = False) -> dict:
     """Fetch today's data from Garmin and save directly to the database.
 
     Parameters
@@ -22,6 +22,9 @@ def incremental_sync(target_date: str = None) -> dict:
     target_date:
         ISO date string (``YYYY-MM-DD``) to treat as "today".  Defaults to
         the actual current date.
+    save_raw:
+        Whether to save raw JSON responses under the ``debug/raw`` directory
+        (next to ``browser_profile``).
 
     Returns
     -------
@@ -100,6 +103,7 @@ def incremental_sync(target_date: str = None) -> dict:
             end_date=today,
             on_batch=on_batch,
             known_activity_ids=known_activity_ids,
+            save_raw=save_raw,
         )
     finally:
         client.close()


### PR DESCRIPTION
## Summary

Follow-up for #13.

`v0.1.8` fixed the weight date-format bug, but users still reported missing weight rows, empty calories, empty body battery payloads, and bad activity rows. This PR focuses on the collector and normalization path that `v0.1.8` did not change.

## What changed since v0.1.8

### Collector changes
- Remove the `activities_range` GraphQL fetch from the sync path
- Add optional raw-response capture with `--save-raw`
- Preserve multiple raw captures instead of overwriting them
- Update Garmin Connect URL from `/modern/` to `/app/` (old one now 302-redirects)

### Ingestion and persistence fixes
- Reject wrapper and error payloads when ingesting activities
- Unwrap nested activity and weight payload shapes before insert
- Improve weight persistence to retain timestamp and source data
- Backfill and merge calories from daily summary data
- Extract training status from the newer nested Garmin payload shape
- Persist HRV timeline data and correct reading counts
- Persist lactate threshold data
- Extract running dynamics from activity detail payloads

### Code quality (Copilot review follow-ups)
- Gate startup backfill/cleanup routines — only run when rows actually need it
- Document Garmin's `hearRate` API typo in lactate threshold endpoint
- Remove unused import

## Local validation

- Incremental sync completes successfully
- Full re-authentication with MFA tested
- `ruff check` and `ruff format` pass
- All imports OK

Refs #13