### PR TITLE
fix(auth): replace Camoufox/Playwright with SeleniumBase UC Chrome

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -66,8 +66,8 @@ jobs:
 
             def caveats
               <<~EOS
-                To complete setup, install the browser driver:
-                  playwright install chromium
+                Google Chrome is required for authentication.
+                Install from: https://www.google.com/chrome/
 
                 Then run:
                   garmin-givemydata

--- a/README.md
+++ b/README.md
@@ -271,12 +271,15 @@ garmin-givemydata --export-tcx ./tcx           # TCX (for TrainingPeaks)
 
 </details>
 
-### Browser engines
+### Browser engine
 
-| Engine | Flag | Headless | Cloudflare bypass |
-|--------|------|----------|-------------------|
-| **Camoufox** (default) | none | Yes | Yes |
-| **Chrome** | `--chrome --visible` | Needs `--visible` for first login | Only with visible window |
+Uses SeleniumBase UC mode (undetected Chrome) for Cloudflare bypass. Requires Google Chrome installed.
+
+| Engine | Headless | Cloudflare bypass | Session lifetime |
+|--------|----------|-------------------|-----------------|
+| **SeleniumBase UC** (Chrome) | Yes (via Xvfb on Linux) | Yes | Weeks on stable IP |
+
+**Note:** `cf_clearance` is bound to your IP address. If your IP changes, the session expires regardless of profile state. For unattended use, run on a machine with a stable egress IP.
 
 <details>
 <summary>Where data is stored</summary>
@@ -341,7 +344,7 @@ fit/                   # Original FIT files (lossless)
 ```
 garmin-givemydata/
 ├── garmin_givemydata.py       # Main entry: smart sync (full or incremental)
-├── garmin_client/              # Playwright-based Garmin Connect client
+├── garmin_client/              # SeleniumBase-based Garmin Connect client
 │   ├── client.py               #   GarminClient (login, fetch, export)
 │   └── endpoints.py            #   API endpoint definitions
 ├── garmin_mcp/                 # MCP server + database layer
@@ -374,9 +377,9 @@ SQLite ──→ MCP server (AI queries via 44 tools)
 | Platform | Status | Notes |
 |----------|--------|-------|
 | **macOS** | Tested | Primary development platform |
-| **Linux (Ubuntu/Debian/Fedora)** | Supported | May need `playwright install-deps` for system libraries |
+| **Linux (Ubuntu/Debian/Fedora)** | Supported | Needs Chrome + optional `xvfb` for headless SSH |
 | **Windows 10/11** | Supported | Use PowerShell or Command Prompt |
-| **WSL2** | Supported | Works headless with Camoufox |
+| **WSL2** | Supported | Works headless with Xvfb |
 
 <details>
 <summary>Manual setup (if setup script doesn't work)</summary>
@@ -390,7 +393,7 @@ cd garmin-givemydata
 python3.12 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python -m playwright install chromium   # only for --chrome fallback
+# Chrome must be installed (https://www.google.com/chrome/)
 cp .env.example .env
 ```
 </details>
@@ -404,8 +407,7 @@ cd garmin-givemydata
 python3.12 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python -m playwright install chromium
-sudo python -m playwright install-deps chromium
+# Chrome must be installed (https://www.google.com/chrome/)
 cp .env.example .env
 ```
 </details>
@@ -419,8 +421,7 @@ cd garmin-givemydata
 python3.12 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python -m playwright install chromium
-sudo python -m playwright install-deps chromium
+# Chrome must be installed (https://www.google.com/chrome/)
 cp .env.example .env
 ```
 </details>
@@ -435,7 +436,7 @@ cd garmin-givemydata
 python -m venv venv
 venv\Scripts\Activate.ps1
 pip install -r requirements.txt
-python -m playwright install chromium
+# Chrome must be installed (https://www.google.com/chrome/)
 copy .env.example .env
 ```
 
@@ -451,15 +452,15 @@ If PowerShell blocks the activate script: `Set-ExecutionPolicy -ExecutionPolicy 
 
 **"Login failed"**: Delete the browser profile and run again. For pip/brew: `rm -rf ~/.garmin-givemydata/browser_profile`. For git clone: `rm -rf browser_profile/`.
 
-**Script crashed / "Execution context was destroyed"**: If using `--chrome --visible`, don't close the Chrome window. Run again.
+**Script crashed**: Don't close the Chrome window manually. The tool handles shutdown — killing Chrome mid-run corrupts the profile. Run again (stale locks are auto-cleaned).
 
 **"Python not found"**: Make sure Python 3.10+ is on your PATH. macOS: `brew install python@3.12`. Ubuntu: `sudo apt install python3.12 python3.12-venv`.
 
-**403 or session errors**: Session expired. Delete the browser profile and re-login.
+**403 or session errors**: Session expired (often from IP change — `cf_clearance` is IP-bound). Delete the browser profile and re-login.
 
-**Chrome doesn't open (Linux)**: Use the default Camoufox engine (no display needed), or install Xvfb: `sudo apt install xvfb && xvfb-run python garmin_givemydata.py`.
+**Chrome doesn't open (Linux/SSH)**: Install Xvfb: `sudo apt install xvfb`. The tool auto-spawns Xvfb at 1920x1080 when no display is available, or use `xvfb-run -a garmin-givemydata`.
 
-**Playwright install fails (Linux)**: `sudo python -m playwright install-deps`
+**Session rot over SSH**: Run under `systemd-run --user --scope` or `tmux`/`screen` so SSH disconnect doesn't SIGHUP the process. The tool installs signal handlers but a detached session is more reliable.
 
 **MCP server "failed to connect"**: Paths in `.mcp.json` must be **absolute**. Test: `<path>/venv/bin/python <path>/run_mcp.py`
 

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -88,58 +88,136 @@ class _ChromeEngine:
 
 
 class _CamoufoxEngine:
-    """Browser engine using Camoufox (custom Firefox) -- bypasses Cloudflare headless."""
+    """Browser engine using Camoufox (anti-detect Firefox) — bypasses Cloudflare headless.
+
+    Uses a persistent browser context (``user_data_dir``) so the full browser
+    state — cookies, localStorage, IndexedDB, cache, Cloudflare ``cf_clearance``,
+    and the generated fingerprint — is reused across runs. This is the key to
+    keeping long-lived Garmin sessions: Cloudflare pins clearance to a specific
+    fingerprint + storage combo, and any drift triggers a re-challenge.
+    """
+
+    def _resolve_headless(self, headless: bool):
+        """Pick the safest headless mode for the current platform.
+
+        On Linux we prefer Camoufox's built-in virtual display (Xvfb) because
+        plain ``headless=True`` is still fingerprintable. Falls back to regular
+        headless if Xvfb isn't installed.
+        """
+        if not headless:
+            return False
+        if sys.platform.startswith("linux"):
+            import shutil
+
+            if shutil.which("Xvfb"):
+                return "virtual"
+            log.info("Xvfb not found — falling back to plain headless. Install xvfb for better Cloudflare bypass.")
+        return True
+
+    def _build_kwargs(self, profile_dir: Path, headless: bool) -> dict:
+        return dict(
+            persistent_context=True,
+            user_data_dir=str(profile_dir),
+            humanize=True,
+            locale=["en-US"],
+            os="windows",
+            geoip=True,
+            headless=self._resolve_headless(headless),
+        )
 
     def launch(self, profile_dir: Path, headless: bool, session_file: Path = None):
-        """Launch Camoufox. Returns (context, page, None, browser)."""
+        """Launch Camoufox with a persistent context. Returns (context, page, None, cm)."""
         from camoufox.sync_api import Camoufox
 
-        browser = Camoufox(headless=headless).__enter__()
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        kwargs = self._build_kwargs(profile_dir, headless)
+
+        cm = Camoufox(**kwargs)
         try:
+            context = cm.__enter__()
+        except TypeError:
+            # Older Camoufox without persistent_context — degrade gracefully
+            log.warning("Camoufox is too old for persistent_context; upgrade with: pip install -U camoufox")
+            cm = Camoufox(headless=kwargs["headless"], humanize=True, locale=["en-US"], os="windows", geoip=True)
+            browser = cm.__enter__()
             page = browser.new_page()
+            self._load_legacy_session(page.context, session_file)
+            return (page.context, page, None, cm)
+
+        # With persistent_context=True, __enter__ returns a BrowserContext directly.
+        try:
+            page = context.pages[0] if context.pages else context.new_page()
         except Exception:
-            browser.close()
-            raise
-        context = page.context
-
-        # Load saved session cookies if available
-        if session_file and session_file.exists():
             try:
-                session = json.loads(session_file.read_text())
-                saved_at = session.get("saved_at", 0)
-                age_days = (time.time() - saved_at) / 86400
-                if age_days < 364 and session.get("cookies"):
-                    context.add_cookies(session["cookies"])
-                    log.info(
-                        "Loaded %d cookies from session (%.0f days old)",
-                        len(session["cookies"]),
-                        age_days,
-                    )
-            except Exception as e:
-                log.debug("Could not load session: %s", e)
+                cm.__exit__(None, None, None)
+            except Exception:
+                pass
+            raise
 
-        return (context, page, None, browser)
+        # Migration: if the persistent profile is fresh but a legacy session.json
+        # exists, import those cookies so users upgrading from <0.1.8 don't need
+        # to re-login once.
+        try:
+            profile_has_state = any(profile_dir.rglob("cookies.sqlite")) or any(profile_dir.rglob("places.sqlite"))
+        except Exception:
+            profile_has_state = False
+        if not profile_has_state:
+            self._load_legacy_session(context, session_file)
+
+        return (context, page, None, cm)
+
+    def _load_legacy_session(self, context, session_file: Path):
+        if not session_file or not session_file.exists():
+            return
+        try:
+            session = json.loads(session_file.read_text())
+            age_days = (time.time() - session.get("saved_at", 0)) / 86400
+            if age_days < 364 and session.get("cookies"):
+                context.add_cookies(session["cookies"])
+                log.info(
+                    "Migrated %d legacy cookies from session.json (%.0f days old)",
+                    len(session["cookies"]),
+                    age_days,
+                )
+        except Exception as e:
+            log.debug("Legacy session migration failed: %s", e)
 
     def has_valid_session(self, profile_dir: Path, session_file: Path) -> bool:
-        """Check if session JSON file exists with valid cookies."""
+        """Session is valid if either the persistent profile has auth state
+        or a legacy session.json file is present and fresh."""
+        try:
+            if profile_dir and profile_dir.exists():
+                if any(profile_dir.rglob("cookies.sqlite")):
+                    return True
+        except Exception:
+            pass
         if not session_file or not session_file.exists():
             return False
         try:
             session = json.loads(session_file.read_text())
             age_days = (time.time() - session.get("saved_at", 0)) / 86400
-            has_cookies = bool(session.get("cookies"))
-            return has_cookies and age_days < 364
+            return bool(session.get("cookies")) and age_days < 364
         except Exception:
             return False
 
     def save_session(self, page, session_file: Path):
-        """Save cookies to JSON file."""
+        """Export cookies to a portable JSON file.
+
+        Primary persistence is the user_data_dir profile; this JSON is an
+        extra, portable backup that also powers legacy-migration on upgrade.
+        """
         import os
 
         if not session_file:
             return
-        cookies = page.context.cookies()
-        garmin_cookies = [c for c in cookies if "garmin" in c.get("domain", "") or "cloudflare" in c.get("domain", "")]
+        try:
+            cookies = page.context.cookies()
+        except Exception as e:
+            log.debug("Could not read cookies for session export: %s", e)
+            return
+        garmin_cookies = [
+            c for c in cookies if "garmin" in c.get("domain", "") or "cloudflare" in c.get("domain", "")
+        ]
         if not garmin_cookies:
             return
         session = {"cookies": garmin_cookies, "saved_at": time.time()}
@@ -149,10 +227,20 @@ class _CamoufoxEngine:
         log.info("Session saved: %d cookies to %s", len(garmin_cookies), session_file)
 
     def close(self, context, playwright, browser_ref):
-        """Close Camoufox browser."""
-        if browser_ref:
+        """Close the Camoufox persistent context and shut down the browser.
+
+        ``browser_ref`` holds the Camoufox context manager; calling ``__exit__``
+        properly tears down the browser process AND the virtual display (if any).
+        """
+        if browser_ref is not None:
             try:
-                browser_ref.close()
+                browser_ref.__exit__(None, None, None)
+                return
+            except Exception:
+                pass
+        if context is not None:
+            try:
+                context.close()
             except Exception:
                 pass
 

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -97,33 +97,138 @@ class _CamoufoxEngine:
     and the generated fingerprint — is reused across runs. This is the key to
     keeping long-lived Garmin sessions: Cloudflare pins clearance to a specific
     fingerprint + storage combo, and any drift triggers a re-challenge.
+
+    On Linux headless servers, we deliberately avoid Camoufox's built-in
+    ``headless="virtual"`` mode: Camoufox hardcodes its Xvfb to a 1×1 pixel
+    screen (see ``camoufox/virtdisplay.py`` and daijro/camoufox#458), which
+    breaks rendering on complex sites and produces a distinctive viewport
+    fingerprint. Instead, when no ``$DISPLAY`` is present we spawn our own
+    Xvfb at a realistic desktop size (1280×1024×24) and launch Camoufox
+    non-headless against that display. This matches what ``xvfb-run`` users
+    already get on working setups and removes the known 1×1 footgun.
     """
 
-    def _resolve_headless(self, headless: bool):
-        """Pick the safest headless mode for the current platform.
+    # Realistic desktop size for our own Xvfb. 1280×1024 is the most common
+    # Linux desktop resolution in the Firefox ESR telemetry distribution, and
+    # matches what Camoufox's own fingerprint database samples from.
+    _XVFB_SCREEN = "1280x1024x24"
 
-        - If the caller wants a visible browser, always return ``False``.
-        - If an X display is already present (``$DISPLAY`` set — e.g. the
-          user is invoking us under ``xvfb-run`` or inside a real X session),
-          reuse it by returning ``False``. Camoufox's ``"virtual"`` mode
-          unconditionally spawns its own Xvfb via ``subprocess.Popen`` and
-          does not consult ``$DISPLAY``, so returning ``"virtual"`` here
-          would nest a second Xvfb inside the caller's — exactly the kind
-          of display-stack oddness that was flaky in issue #11.
-        - Otherwise on Linux, prefer Camoufox's built-in virtual display if
-          ``Xvfb`` is installed (stealthier than plain headless).
-        - Fall back to plain ``headless=True`` everywhere else.
+    def __init__(self):
+        self._xvfb_proc = None
+        self._xvfb_display = None
+        self._xvfb_prev_display = None
+
+    def _spawn_xvfb(self) -> Optional[str]:
+        """Spawn an Xvfb at a realistic size and return its ``:N`` display string.
+
+        Returns ``None`` on any failure so the caller can fall back to plain
+        headless. We pick a display number by probing ``/tmp/.X{n}-lock``.
+        """
+        import subprocess
+
+        xvfb = shutil.which("Xvfb")
+        if not xvfb:
+            return None
+
+        # Find a free display number. Avoid 0-9 which may be real displays.
+        chosen = None
+        for n in range(99, 200):
+            if not Path(f"/tmp/.X{n}-lock").exists():
+                chosen = n
+                break
+        if chosen is None:
+            log.debug("No free Xvfb display slots in :99-:199")
+            return None
+
+        display = f":{chosen}"
+        try:
+            self._xvfb_proc = subprocess.Popen(
+                [
+                    xvfb,
+                    display,
+                    "-screen", "0", self._XVFB_SCREEN,
+                    "-ac",
+                    "-nolisten", "tcp",
+                    "+extension", "RANDR",
+                    "+extension", "GLX",
+                    "+extension", "RENDER",
+                    "+extension", "COMPOSITE",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                close_fds=True,
+                start_new_session=True,
+            )
+        except Exception as e:
+            log.debug("Failed to spawn Xvfb: %s", e)
+            return None
+
+        # Give Xvfb a moment to create its lock file. If it dies immediately
+        # (e.g. missing libs), give up.
+        for _ in range(20):
+            if self._xvfb_proc.poll() is not None:
+                log.debug("Xvfb exited immediately, returncode=%s", self._xvfb_proc.returncode)
+                self._xvfb_proc = None
+                return None
+            if Path(f"/tmp/.X{chosen}-lock").exists():
+                break
+            time.sleep(0.1)
+
+        self._xvfb_display = display
+        log.info("Spawned Xvfb on %s (%s)", display, self._XVFB_SCREEN)
+        return display
+
+    def _resolve_display(self, headless: bool):
+        """Decide how to provide a display to Camoufox.
+
+        Returns a dict of extra kwargs to splice into the Camoufox constructor
+        AND has the side effect of exporting ``$DISPLAY`` when we spawn our
+        own Xvfb. The dict's ``headless`` key is authoritative.
         """
         if not headless:
-            return False
-        if sys.platform.startswith("linux"):
-            if _os.environ.get("DISPLAY"):
-                log.info("$DISPLAY is set — reusing existing X display instead of nesting Xvfb.")
-                return False
-            if shutil.which("Xvfb"):
-                return "virtual"
-            log.info("Xvfb not found — falling back to plain headless. Install xvfb for better Cloudflare bypass.")
-        return True
+            return {"headless": False}
+
+        if not sys.platform.startswith("linux"):
+            # macOS / Windows — plain headless is the only sensible option.
+            return {"headless": True}
+
+        if _os.environ.get("DISPLAY"):
+            log.info("$DISPLAY=%s is set — reusing it instead of spawning Xvfb.", _os.environ["DISPLAY"])
+            return {"headless": False}
+
+        # No display at all — try to spawn our own realistic-size Xvfb so we
+        # can launch Camoufox non-headless against it. This avoids Camoufox's
+        # 1×1 pixel virtual display (daijro/camoufox#458).
+        display = self._spawn_xvfb()
+        if display:
+            self._xvfb_prev_display = _os.environ.get("DISPLAY")
+            _os.environ["DISPLAY"] = display
+            return {"headless": False}
+
+        log.info(
+            "Could not start Xvfb (install it with `apt install xvfb` / `dnf install xorg-x11-server-Xvfb`)."
+            " Falling back to plain headless, which is more detectable."
+        )
+        return {"headless": True}
+
+    def _stop_xvfb(self) -> None:
+        """Restore $DISPLAY and stop any Xvfb we spawned."""
+        if self._xvfb_prev_display is None:
+            _os.environ.pop("DISPLAY", None)
+        else:
+            _os.environ["DISPLAY"] = self._xvfb_prev_display
+        self._xvfb_prev_display = None
+        self._xvfb_display = None
+        if self._xvfb_proc is not None:
+            try:
+                self._xvfb_proc.terminate()
+                try:
+                    self._xvfb_proc.wait(timeout=3)
+                except Exception:
+                    self._xvfb_proc.kill()
+            except Exception as e:
+                log.debug("Error stopping Xvfb: %s", e)
+            self._xvfb_proc = None
 
     def _build_kwargs(self, profile_dir: Path, headless: bool) -> dict:
         # NOTE: We intentionally do NOT pin ``locale`` or ``os`` here.
@@ -133,13 +238,14 @@ class _CamoufoxEngine:
         # otherwise randomized) produces internally inconsistent fingerprints
         # that Cloudflare's bot-score model readily flags. Letting Camoufox
         # auto-derive these from the IP gives a coherent profile.
-        return dict(
+        kwargs = dict(
             persistent_context=True,
             user_data_dir=str(profile_dir),
             humanize=True,
             geoip=True,
-            headless=self._resolve_headless(headless),
         )
+        kwargs.update(self._resolve_display(headless))
+        return kwargs
 
     def _cleanup_stale_locks(self, profile_dir: Path) -> None:
         """Remove Firefox profile lock files left behind by unclean exits.
@@ -164,39 +270,44 @@ class _CamoufoxEngine:
 
         profile_dir.mkdir(parents=True, exist_ok=True)
         self._cleanup_stale_locks(profile_dir)
-        kwargs = self._build_kwargs(profile_dir, headless)
 
         try:
-            cm = Camoufox(**kwargs)
-        except TypeError as e:
-            # Older Camoufox without persistent_context/geoip — degrade gracefully.
-            # The TypeError is raised at construction, not at __enter__.
-            log.warning(
-                "Camoufox is too old for persistent_context (%s); upgrade with: pip install -U 'camoufox>=0.4.11'",
-                e,
-            )
-            cm = Camoufox(headless=kwargs["headless"], humanize=True)
-            browser = cm.__enter__()
-            page = browser.new_page()
-            self._load_legacy_session(page.context, session_file)
-            return (page.context, page, None, cm)
+            kwargs = self._build_kwargs(profile_dir, headless)
 
-        try:
-            context = cm.__enter__()
-        except FileNotFoundError as e:
-            # Most common cause: geoip=True needs the MaxMind GeoLite2 DB,
-            # which is downloaded by ``python -m camoufox fetch`` — not by
-            # ``pip install``. Give the user an actionable message and retry
-            # once without geoip so the tool still works offline.
-            log.warning(
-                "Camoufox launch failed (%s). If this mentions a GeoLite DB, run: "
-                "python -m camoufox fetch   — retrying once without geoip.",
-                e,
-            )
-            retry_kwargs = dict(kwargs)
-            retry_kwargs.pop("geoip", None)
-            cm = Camoufox(**retry_kwargs)
-            context = cm.__enter__()
+            # Construct Camoufox. Older versions don't accept
+            # persistent_context/geoip and raise TypeError at construction.
+            try:
+                cm = Camoufox(**kwargs)
+            except TypeError as e:
+                log.warning(
+                    "Camoufox is too old for persistent_context (%s); "
+                    "upgrade with: pip install -U 'camoufox>=0.4.11'",
+                    e,
+                )
+                cm = Camoufox(headless=kwargs["headless"], humanize=True)
+                browser = cm.__enter__()
+                page = browser.new_page()
+                self._load_legacy_session(page.context, session_file)
+                return (page.context, page, None, cm)
+
+            try:
+                context = cm.__enter__()
+            except FileNotFoundError as e:
+                # geoip=True needs the MaxMind GeoLite2 DB, downloaded via
+                # ``python -m camoufox fetch`` — not by ``pip install``.
+                # Give an actionable message and retry once without geoip.
+                log.warning(
+                    "Camoufox launch failed (%s). If this mentions a GeoLite DB, run: "
+                    "python -m camoufox fetch   — retrying once without geoip.",
+                    e,
+                )
+                retry_kwargs = dict(kwargs)
+                retry_kwargs.pop("geoip", None)
+                cm = Camoufox(**retry_kwargs)
+                context = cm.__enter__()
+        except Exception:
+            self._stop_xvfb()
+            raise
 
         # With persistent_context=True, __enter__ returns a BrowserContext directly.
         try:
@@ -206,6 +317,7 @@ class _CamoufoxEngine:
                 cm.__exit__(None, None, None)
             except Exception:
                 pass
+            self._stop_xvfb()
             raise
 
         # Migration: if the persistent profile is fresh but a legacy session.json
@@ -277,22 +389,30 @@ class _CamoufoxEngine:
         log.info("Session saved: %d cookies to %s", len(garmin_cookies), session_file)
 
     def close(self, context, playwright, browser_ref):
-        """Close the Camoufox persistent context and shut down the browser.
+        """Close the Camoufox persistent context and any Xvfb we spawned.
 
         ``browser_ref`` holds the Camoufox context manager; calling ``__exit__``
-        properly tears down the browser process AND the virtual display (if any).
+        properly tears down the browser process. If we started our own Xvfb
+        in ``_resolve_display`` we stop it afterwards.
         """
-        if browser_ref is not None:
-            try:
-                browser_ref.__exit__(None, None, None)
-                return
-            except Exception:
-                pass
-        if context is not None:
-            try:
-                context.close()
-            except Exception:
-                pass
+        try:
+            if browser_ref is not None:
+                try:
+                    browser_ref.__exit__(None, None, None)
+                except Exception as e:
+                    log.debug("Camoufox __exit__ raised: %s", e)
+                    if context is not None:
+                        try:
+                            context.close()
+                        except Exception:
+                            pass
+            elif context is not None:
+                try:
+                    context.close()
+                except Exception:
+                    pass
+        finally:
+            self._stop_xvfb()
 
 
 class GarminClient:

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -20,9 +20,9 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from seleniumbase import Driver

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -141,13 +141,22 @@ class GarminClient:
         try:
             self._xvfb_proc = subprocess.Popen(
                 [
-                    xvfb, display,
-                    "-screen", "0", _XVFB_SCREEN,
-                    "-ac", "-nolisten", "tcp",
-                    "+extension", "RANDR",
-                    "+extension", "GLX",
-                    "+extension", "RENDER",
-                    "+extension", "COMPOSITE",
+                    xvfb,
+                    display,
+                    "-screen",
+                    "0",
+                    _XVFB_SCREEN,
+                    "-ac",
+                    "-nolisten",
+                    "tcp",
+                    "+extension",
+                    "RANDR",
+                    "+extension",
+                    "GLX",
+                    "+extension",
+                    "RENDER",
+                    "+extension",
+                    "COMPOSITE",
                 ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -393,9 +402,7 @@ class GarminClient:
         except Exception:
             log.error("Login form not found on page: %s", self._driver.current_url)
             try:
-                body = self._driver.execute_script(
-                    "return document.body?.innerText?.substring(0, 500)"
-                )
+                body = self._driver.execute_script("return document.body?.innerText?.substring(0, 500)")
                 print(f"Login form not found. Current URL: {self._driver.current_url}")
                 print(f"Page content: {body}")
             except Exception:
@@ -571,9 +578,7 @@ class GarminClient:
         time.sleep(1)
         for sel in mfa_selectors:
             try:
-                mfa_input = WebDriverWait(self._driver, 3).until(
-                    EC.presence_of_element_located((By.CSS_SELECTOR, sel))
-                )
+                mfa_input = WebDriverWait(self._driver, 3).until(EC.presence_of_element_located((By.CSS_SELECTOR, sel)))
                 mfa_input.click()
                 mfa_input.clear()
                 mfa_input.send_keys(code)
@@ -682,7 +687,8 @@ class GarminClient:
         """
         self._ensure_on_garmin()
         csrf = self._ensure_csrf()
-        return self._driver.execute_async_script("""
+        return self._driver.execute_async_script(
+            """
             var callback = arguments[arguments.length - 1];
             var url = arguments[0];
             var csrf = arguments[1];
@@ -696,13 +702,17 @@ class GarminClient:
                     return await resp.json();
                 } catch(e) { return null; }
             })().then(callback).catch(function() { callback(null); });
-        """, api_path, csrf)
+        """,
+            api_path,
+            csrf,
+        )
 
     def download_file(self, api_path: str) -> Optional[bytes]:
         """Download a binary file from a /gc-api endpoint. Returns bytes or None."""
         self._ensure_on_garmin()
         csrf = self._ensure_csrf()
-        result = self._driver.execute_async_script("""
+        result = self._driver.execute_async_script(
+            """
             var callback = arguments[arguments.length - 1];
             var url = arguments[0];
             var csrf = arguments[1];
@@ -717,7 +727,10 @@ class GarminClient:
                     return {status: 200, data: Array.from(new Uint8Array(buffer))};
                 } catch(e) { return {status: 'error'}; }
             })().then(callback).catch(function() { callback({status: 'error'}); });
-        """, api_path, csrf)
+        """,
+            api_path,
+            csrf,
+        )
         if result and result.get("status") == 200 and result.get("data"):
             return bytes(result["data"])
         return None
@@ -732,7 +745,8 @@ class GarminClient:
         rest_entries = list(rest.items())
         gql_entries = list(gql.items())
 
-        result = self._driver.execute_async_script("""
+        result = self._driver.execute_async_script(
+            """
             var callback = arguments[arguments.length - 1];
             var csrf = arguments[0];
             var restEntries = arguments[1];
@@ -779,7 +793,11 @@ class GarminClient:
                 }
                 return output;
             })().then(callback).catch(function(e) { callback({error: String(e)}); });
-        """, csrf, rest_entries, gql_entries)
+        """,
+            csrf,
+            rest_entries,
+            gql_entries,
+        )
 
         if result and "error" in result:
             log.warning("_fetch_batch JS error: %s", result["error"])

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -4,6 +4,8 @@ Garmin Connect Client using Playwright for authentication and data fetching.
 
 import json
 import logging
+import os as _os
+import shutil
 import sys
 import time
 from datetime import date, datetime, timedelta
@@ -100,49 +102,101 @@ class _CamoufoxEngine:
     def _resolve_headless(self, headless: bool):
         """Pick the safest headless mode for the current platform.
 
-        On Linux we prefer Camoufox's built-in virtual display (Xvfb) because
-        plain ``headless=True`` is still fingerprintable. Falls back to regular
-        headless if Xvfb isn't installed.
+        - If the caller wants a visible browser, always return ``False``.
+        - If an X display is already present (``$DISPLAY`` set — e.g. the
+          user is invoking us under ``xvfb-run`` or inside a real X session),
+          reuse it by returning ``False``. Camoufox's ``"virtual"`` mode
+          unconditionally spawns its own Xvfb via ``subprocess.Popen`` and
+          does not consult ``$DISPLAY``, so returning ``"virtual"`` here
+          would nest a second Xvfb inside the caller's — exactly the kind
+          of display-stack oddness that was flaky in issue #11.
+        - Otherwise on Linux, prefer Camoufox's built-in virtual display if
+          ``Xvfb`` is installed (stealthier than plain headless).
+        - Fall back to plain ``headless=True`` everywhere else.
         """
         if not headless:
             return False
         if sys.platform.startswith("linux"):
-            import shutil
-
+            if _os.environ.get("DISPLAY"):
+                log.info("$DISPLAY is set — reusing existing X display instead of nesting Xvfb.")
+                return False
             if shutil.which("Xvfb"):
                 return "virtual"
             log.info("Xvfb not found — falling back to plain headless. Install xvfb for better Cloudflare bypass.")
         return True
 
     def _build_kwargs(self, profile_dir: Path, headless: bool) -> dict:
+        # NOTE: We intentionally do NOT pin ``locale`` or ``os`` here.
+        # ``geoip=True`` derives timezone, locale, lat/lon, and country from the
+        # egress IP. Pinning ``locale=en-US`` while geoip picks a non-US timezone
+        # (or pinning ``os=windows`` while the rest of the fingerprint is
+        # otherwise randomized) produces internally inconsistent fingerprints
+        # that Cloudflare's bot-score model readily flags. Letting Camoufox
+        # auto-derive these from the IP gives a coherent profile.
         return dict(
             persistent_context=True,
             user_data_dir=str(profile_dir),
             humanize=True,
-            locale=["en-US"],
-            os="windows",
             geoip=True,
             headless=self._resolve_headless(headless),
         )
+
+    def _cleanup_stale_locks(self, profile_dir: Path) -> None:
+        """Remove Firefox profile lock files left behind by unclean exits.
+
+        After a crash, SIGKILL, or SSH disconnect, Firefox leaves
+        ``parent.lock`` / ``.parentlock`` / ``lock`` in ``user_data_dir`` and
+        the next ``launch_persistent_context`` call fails with
+        "Firefox is already running". We best-effort remove them.
+        """
+        for name in ("parent.lock", ".parentlock", "lock"):
+            p = profile_dir / name
+            try:
+                if p.exists() or p.is_symlink():
+                    p.unlink()
+                    log.debug("Removed stale profile lock: %s", p)
+            except Exception as e:
+                log.debug("Could not remove lock %s: %s", p, e)
 
     def launch(self, profile_dir: Path, headless: bool, session_file: Path = None):
         """Launch Camoufox with a persistent context. Returns (context, page, None, cm)."""
         from camoufox.sync_api import Camoufox
 
         profile_dir.mkdir(parents=True, exist_ok=True)
+        self._cleanup_stale_locks(profile_dir)
         kwargs = self._build_kwargs(profile_dir, headless)
 
-        cm = Camoufox(**kwargs)
         try:
-            context = cm.__enter__()
-        except TypeError:
-            # Older Camoufox without persistent_context — degrade gracefully
-            log.warning("Camoufox is too old for persistent_context; upgrade with: pip install -U camoufox")
-            cm = Camoufox(headless=kwargs["headless"], humanize=True, locale=["en-US"], os="windows", geoip=True)
+            cm = Camoufox(**kwargs)
+        except TypeError as e:
+            # Older Camoufox without persistent_context/geoip — degrade gracefully.
+            # The TypeError is raised at construction, not at __enter__.
+            log.warning(
+                "Camoufox is too old for persistent_context (%s); upgrade with: pip install -U 'camoufox>=0.4.11'",
+                e,
+            )
+            cm = Camoufox(headless=kwargs["headless"], humanize=True)
             browser = cm.__enter__()
             page = browser.new_page()
             self._load_legacy_session(page.context, session_file)
             return (page.context, page, None, cm)
+
+        try:
+            context = cm.__enter__()
+        except FileNotFoundError as e:
+            # Most common cause: geoip=True needs the MaxMind GeoLite2 DB,
+            # which is downloaded by ``python -m camoufox fetch`` — not by
+            # ``pip install``. Give the user an actionable message and retry
+            # once without geoip so the tool still works offline.
+            log.warning(
+                "Camoufox launch failed (%s). If this mentions a GeoLite DB, run: "
+                "python -m camoufox fetch   — retrying once without geoip.",
+                e,
+            )
+            retry_kwargs = dict(kwargs)
+            retry_kwargs.pop("geoip", None)
+            cm = Camoufox(**retry_kwargs)
+            context = cm.__enter__()
 
         # With persistent_context=True, __enter__ returns a BrowserContext directly.
         try:
@@ -206,8 +260,6 @@ class _CamoufoxEngine:
         Primary persistence is the user_data_dir profile; this JSON is an
         extra, portable backup that also powers legacy-migration on upgrade.
         """
-        import os
-
         if not session_file:
             return
         try:
@@ -215,14 +267,12 @@ class _CamoufoxEngine:
         except Exception as e:
             log.debug("Could not read cookies for session export: %s", e)
             return
-        garmin_cookies = [
-            c for c in cookies if "garmin" in c.get("domain", "") or "cloudflare" in c.get("domain", "")
-        ]
+        garmin_cookies = [c for c in cookies if "garmin" in c.get("domain", "")]
         if not garmin_cookies:
             return
         session = {"cookies": garmin_cookies, "saved_at": time.time()}
-        fd = os.open(str(session_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w") as f:
+        fd = _os.open(str(session_file), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+        with _os.fdopen(fd, "w") as f:
             json.dump(session, f, indent=2)
         log.info("Session saved: %d cookies to %s", len(garmin_cookies), session_file)
 

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -1,18 +1,31 @@
 """
-Garmin Connect Client using Playwright for authentication and data fetching.
+Garmin Connect Client using SeleniumBase (UC mode) for authentication and data fetching.
+
+Uses undetected-chromedriver via SeleniumBase to bypass Cloudflare bot detection
+on Garmin Connect.  All API calls go through the browser context via
+``execute_async_script`` so the TLS fingerprint, cookies, and CSRF tokens are
+always consistent — the only pattern confirmed working as of April 2026
+(see matin/garth#225).
 """
 
+import atexit
 import json
 import logging
 import os as _os
 import shutil
+import signal
 import sys
 import time
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
-from playwright.sync_api import BrowserContext, Page, sync_playwright
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from seleniumbase import Driver
 
 from .endpoints import (
     activity_detail_endpoints,
@@ -36,101 +49,85 @@ SSO_LOGIN_URL = (
     "&service=https%3A%2F%2Fconnect.garmin.com%2Fapp"
 )
 
-
-class _ChromeEngine:
-    """Browser engine using Playwright + system Chrome."""
-
-    def launch(self, profile_dir: Path, headless: bool, session_file: Path = None):
-        """Launch Chrome. Returns (context, page, playwright_instance, None)."""
-        pw = sync_playwright().start()
-
-        cookies_file = profile_dir / "Default" / "Cookies"
-        has_valid_session = cookies_file.exists() and cookies_file.stat().st_size > 1024
-        use_headless = headless and has_valid_session
-
-        if headless and not has_valid_session:
-            print("First login requires a visible browser (Cloudflare verification).")
-            print("Subsequent runs will be headless automatically.\n")
-
-        args = [
-            "--disable-blink-features=AutomationControlled",
-        ]
-        if use_headless:
-            args.append("--headless=new")
-
-        context = pw.chromium.launch_persistent_context(
-            user_data_dir=str(profile_dir),
-            headless=False,
-            channel="chrome",
-            args=args,
-            ignore_default_args=["--enable-automation"],
-            locale="en-US",
-            timezone_id="America/New_York",
-        )
-
-        page = context.pages[0] if context.pages else context.new_page()
-        page.add_init_script("Object.defineProperty(navigator, 'webdriver', {get: () => undefined});")
-
-        return (context, page, pw, None)
-
-    def has_valid_session(self, profile_dir: Path, session_file: Path) -> bool:
-        """Check Chrome cookie file exists and is >1024 bytes."""
-        cookies_file = profile_dir / "Default" / "Cookies"
-        return cookies_file.exists() and cookies_file.stat().st_size > 1024
-
-    def save_session(self, page, session_file: Path):
-        """No-op for Chrome -- persists via browser profile automatically."""
-
-    def close(self, context, playwright, browser_ref):
-        """Close Chrome context and Playwright."""
-        if context:
-            context.close()
-        if playwright:
-            playwright.stop()
+CSRF_TTL = 1800  # 30 minutes — re-read meta tag after this
+_XVFB_SCREEN = "1920x1080x24"
+_SENTINEL = ".garmin_clean_exit"
 
 
-class _CamoufoxEngine:
-    """Browser engine using Camoufox (anti-detect Firefox) — bypasses Cloudflare headless.
+# ─── Process lifecycle ───────────────────────────────────────────
 
-    Uses a persistent browser context (``user_data_dir``) so the full browser
-    state — cookies, localStorage, IndexedDB, cache, Cloudflare ``cf_clearance``,
-    and the generated fingerprint — is reused across runs. This is the key to
-    keeping long-lived Garmin sessions: Cloudflare pins clearance to a specific
-    fingerprint + storage combo, and any drift triggers a re-challenge.
 
-    On Linux headless servers, we deliberately avoid Camoufox's built-in
-    ``headless="virtual"`` mode: Camoufox hardcodes its Xvfb to a 1×1 pixel
-    screen (see ``camoufox/virtdisplay.py`` and daijro/camoufox#458), which
-    breaks rendering on complex sites and produces a distinctive viewport
-    fingerprint. Instead, when no ``$DISPLAY`` is present we spawn our own
-    Xvfb at a realistic desktop size (1280×1024×24) and launch Camoufox
-    non-headless against that display. This matches what ``xvfb-run`` users
-    already get on working setups and removes the known 1×1 footgun.
+class _ProcessLifecycle:
+    """Ensures clean browser shutdown on SIGHUP, SIGTERM, SIGINT, and atexit.
+
+    SSH disconnects send SIGHUP to the child process.  Without this handler
+    Chrome dies mid-IndexedDB-write and the profile state is torn — exactly
+    the failure mode that causes issue #11's session rot.
     """
 
-    # Realistic desktop size for our own Xvfb. 1280×1024 is the most common
-    # Linux desktop resolution in the Firefox ESR telemetry distribution, and
-    # matches what Camoufox's own fingerprint database samples from.
-    _XVFB_SCREEN = "1280x1024x24"
+    def __init__(self, cleanup_fn):
+        self._cleanup = cleanup_fn
+        self._cleaned = False
 
-    def __init__(self):
+    def install(self):
+        atexit.register(self._on_exit)
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            signal.signal(sig, self._on_signal)
+        if hasattr(signal, "SIGHUP"):
+            signal.signal(signal.SIGHUP, self._on_signal)
+
+    def _on_signal(self, signum, frame):
+        self._on_exit()
+        sys.exit(128 + signum)
+
+    def _on_exit(self):
+        if self._cleaned:
+            return
+        self._cleaned = True
+        try:
+            self._cleanup()
+        except Exception:
+            pass
+
+
+# ─── Garmin Client ───────────────────────────────────────────────
+
+
+class GarminClient:
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        profile_dir: Optional[Path] = None,
+        headless: bool = False,
+        session_file: Optional[Path] = None,
+        **_kwargs,  # absorb legacy engine= kwarg
+    ):
+        self.email = email
+        self.password = password
+        self.profile_dir = profile_dir or DEFAULT_PROFILE_DIR
+        self.profile_dir.mkdir(parents=True, exist_ok=True)
+        self.headless = headless
+        self.session_file = session_file
+        self._driver = None
+        self._csrf: Optional[str] = None
+        self._csrf_time: float = 0
+        self._display_name: Optional[str] = None
+        self._lifecycle: Optional[_ProcessLifecycle] = None
         self._xvfb_proc = None
         self._xvfb_display = None
         self._xvfb_prev_display = None
 
-    def _spawn_xvfb(self) -> Optional[str]:
-        """Spawn an Xvfb at a realistic size and return its ``:N`` display string.
+    # ── Display management ───────────────────────────────────────
 
-        Returns ``None`` on any failure so the caller can fall back to plain
-        headless. We pick a display number by probing ``/tmp/.X{n}-lock``.
-        """
+    def _spawn_xvfb(self) -> Optional[str]:
+        """Spawn Xvfb at a realistic size and return its ``:N`` display string."""
         import subprocess
 
         xvfb = shutil.which("Xvfb")
         if not xvfb:
             return None
 
-        # Find a free display number. Avoid 0-9 which may be real displays.
         chosen = None
         for n in range(99, 200):
             if not Path(f"/tmp/.X{n}-lock").exists():
@@ -144,11 +141,9 @@ class _CamoufoxEngine:
         try:
             self._xvfb_proc = subprocess.Popen(
                 [
-                    xvfb,
-                    display,
-                    "-screen", "0", self._XVFB_SCREEN,
-                    "-ac",
-                    "-nolisten", "tcp",
+                    xvfb, display,
+                    "-screen", "0", _XVFB_SCREEN,
+                    "-ac", "-nolisten", "tcp",
                     "+extension", "RANDR",
                     "+extension", "GLX",
                     "+extension", "RENDER",
@@ -163,11 +158,9 @@ class _CamoufoxEngine:
             log.debug("Failed to spawn Xvfb: %s", e)
             return None
 
-        # Give Xvfb a moment to create its lock file. If it dies immediately
-        # (e.g. missing libs), give up.
         for _ in range(20):
             if self._xvfb_proc.poll() is not None:
-                log.debug("Xvfb exited immediately, returncode=%s", self._xvfb_proc.returncode)
+                log.debug("Xvfb exited immediately, rc=%s", self._xvfb_proc.returncode)
                 self._xvfb_proc = None
                 return None
             if Path(f"/tmp/.X{chosen}-lock").exists():
@@ -175,41 +168,8 @@ class _CamoufoxEngine:
             time.sleep(0.1)
 
         self._xvfb_display = display
-        log.info("Spawned Xvfb on %s (%s)", display, self._XVFB_SCREEN)
+        log.info("Spawned Xvfb on %s (%s)", display, _XVFB_SCREEN)
         return display
-
-    def _resolve_display(self, headless: bool):
-        """Decide how to provide a display to Camoufox.
-
-        Returns a dict of extra kwargs to splice into the Camoufox constructor
-        AND has the side effect of exporting ``$DISPLAY`` when we spawn our
-        own Xvfb. The dict's ``headless`` key is authoritative.
-        """
-        if not headless:
-            return {"headless": False}
-
-        if not sys.platform.startswith("linux"):
-            # macOS / Windows — plain headless is the only sensible option.
-            return {"headless": True}
-
-        if _os.environ.get("DISPLAY"):
-            log.info("$DISPLAY=%s is set — reusing it instead of spawning Xvfb.", _os.environ["DISPLAY"])
-            return {"headless": False}
-
-        # No display at all — try to spawn our own realistic-size Xvfb so we
-        # can launch Camoufox non-headless against it. This avoids Camoufox's
-        # 1×1 pixel virtual display (daijro/camoufox#458).
-        display = self._spawn_xvfb()
-        if display:
-            self._xvfb_prev_display = _os.environ.get("DISPLAY")
-            _os.environ["DISPLAY"] = display
-            return {"headless": False}
-
-        log.info(
-            "Could not start Xvfb (install it with `apt install xvfb` / `dnf install xorg-x11-server-Xvfb`)."
-            " Falling back to plain headless, which is more detectable."
-        )
-        return {"headless": True}
 
     def _stop_xvfb(self) -> None:
         """Restore $DISPLAY and stop any Xvfb we spawned."""
@@ -230,372 +190,298 @@ class _CamoufoxEngine:
                 log.debug("Error stopping Xvfb: %s", e)
             self._xvfb_proc = None
 
-    def _build_kwargs(self, profile_dir: Path, headless: bool) -> dict:
-        # NOTE: We intentionally do NOT pin ``locale`` or ``os`` here.
-        # ``geoip=True`` derives timezone, locale, lat/lon, and country from the
-        # egress IP. Pinning ``locale=en-US`` while geoip picks a non-US timezone
-        # (or pinning ``os=windows`` while the rest of the fingerprint is
-        # otherwise randomized) produces internally inconsistent fingerprints
-        # that Cloudflare's bot-score model readily flags. Letting Camoufox
-        # auto-derive these from the IP gives a coherent profile.
-        kwargs = dict(
-            persistent_context=True,
-            user_data_dir=str(profile_dir),
-            humanize=True,
-            geoip=True,
-        )
-        kwargs.update(self._resolve_display(headless))
-        return kwargs
+    # ── Profile management ───────────────────────────────────────
 
-    def _cleanup_stale_locks(self, profile_dir: Path) -> None:
-        """Remove Firefox profile lock files left behind by unclean exits.
-
-        After a crash, SIGKILL, or SSH disconnect, Firefox leaves
-        ``parent.lock`` / ``.parentlock`` / ``lock`` in ``user_data_dir`` and
-        the next ``launch_persistent_context`` call fails with
-        "Firefox is already running". We best-effort remove them.
-        """
-        for name in ("parent.lock", ".parentlock", "lock"):
-            p = profile_dir / name
+    def _cleanup_stale_locks(self) -> None:
+        """Remove Chrome profile lock files left behind by unclean exits."""
+        for name in ("SingletonLock", "SingletonCookie", "SingletonSocket"):
+            p = self.profile_dir / name
             try:
                 if p.exists() or p.is_symlink():
                     p.unlink()
-                    log.debug("Removed stale profile lock: %s", p)
+                    log.debug("Removed stale Chrome lock: %s", p)
             except Exception as e:
                 log.debug("Could not remove lock %s: %s", p, e)
 
-    def launch(self, profile_dir: Path, headless: bool, session_file: Path = None):
-        """Launch Camoufox with a persistent context. Returns (context, page, None, cm)."""
-        from camoufox.sync_api import Camoufox
-
-        profile_dir.mkdir(parents=True, exist_ok=True)
-        self._cleanup_stale_locks(profile_dir)
-
+    def _write_sentinel(self) -> None:
+        """Write a clean-exit sentinel after successful browser shutdown."""
         try:
-            kwargs = self._build_kwargs(profile_dir, headless)
-
-            # Construct Camoufox. Older versions don't accept
-            # persistent_context/geoip and raise TypeError at construction.
-            try:
-                cm = Camoufox(**kwargs)
-            except TypeError as e:
-                log.warning(
-                    "Camoufox is too old for persistent_context (%s); "
-                    "upgrade with: pip install -U 'camoufox>=0.4.11'",
-                    e,
-                )
-                cm = Camoufox(headless=kwargs["headless"], humanize=True)
-                browser = cm.__enter__()
-                page = browser.new_page()
-                self._load_legacy_session(page.context, session_file)
-                return (page.context, page, None, cm)
-
-            try:
-                context = cm.__enter__()
-            except FileNotFoundError as e:
-                # geoip=True needs the MaxMind GeoLite2 DB, downloaded via
-                # ``python -m camoufox fetch`` — not by ``pip install``.
-                # Give an actionable message and retry once without geoip.
-                log.warning(
-                    "Camoufox launch failed (%s). If this mentions a GeoLite DB, run: "
-                    "python -m camoufox fetch   — retrying once without geoip.",
-                    e,
-                )
-                retry_kwargs = dict(kwargs)
-                retry_kwargs.pop("geoip", None)
-                cm = Camoufox(**retry_kwargs)
-                context = cm.__enter__()
+            (self.profile_dir / _SENTINEL).write_text(str(time.time()))
         except Exception:
-            self._stop_xvfb()
-            raise
+            pass
 
-        # With persistent_context=True, __enter__ returns a BrowserContext directly.
-        try:
-            page = context.pages[0] if context.pages else context.new_page()
-        except Exception:
+    def _check_sentinel(self) -> bool:
+        """Check if last exit was clean. Returns True if clean, False if dirty."""
+        sentinel = self.profile_dir / _SENTINEL
+        if sentinel.exists():
             try:
-                cm.__exit__(None, None, None)
+                sentinel.unlink()
             except Exception:
                 pass
-            self._stop_xvfb()
-            raise
+            return True
+        return False
 
-        # Migration: if the persistent profile is fresh but a legacy session.json
-        # exists, import those cookies so users upgrading from <0.1.8 don't need
-        # to re-login once.
-        try:
-            profile_has_state = any(profile_dir.rglob("cookies.sqlite")) or any(profile_dir.rglob("places.sqlite"))
-        except Exception:
-            profile_has_state = False
-        if not profile_has_state:
-            self._load_legacy_session(context, session_file)
-
-        return (context, page, None, cm)
-
-    def _load_legacy_session(self, context, session_file: Path):
-        if not session_file or not session_file.exists():
+    def _load_legacy_session(self) -> None:
+        """Import cookies from legacy session.json if profile is fresh."""
+        if not self.session_file or not self.session_file.exists():
+            return
+        default_dir = self.profile_dir / "Default"
+        if default_dir.exists() and any(default_dir.iterdir()):
             return
         try:
-            session = json.loads(session_file.read_text())
+            session = json.loads(self.session_file.read_text())
             age_days = (time.time() - session.get("saved_at", 0)) / 86400
-            if age_days < 364 and session.get("cookies"):
-                context.add_cookies(session["cookies"])
-                log.info(
-                    "Migrated %d legacy cookies from session.json (%.0f days old)",
-                    len(session["cookies"]),
-                    age_days,
-                )
+            if age_days >= 364 or not session.get("cookies"):
+                return
+            self._driver.get("https://connect.garmin.com")
+            time.sleep(1)
+            count = 0
+            for cookie in session["cookies"]:
+                if "expires" in cookie:
+                    cookie["expiry"] = int(cookie.pop("expires"))
+                cookie.pop("size", None)
+                try:
+                    self._driver.add_cookie(cookie)
+                    count += 1
+                except Exception:
+                    pass
+            log.info("Migrated %d legacy cookies from session.json", count)
         except Exception as e:
             log.debug("Legacy session migration failed: %s", e)
 
-    def has_valid_session(self, profile_dir: Path, session_file: Path) -> bool:
-        """Session is valid if either the persistent profile has auth state
-        or a legacy session.json file is present and fresh."""
-        try:
-            if profile_dir and profile_dir.exists():
-                if any(profile_dir.rglob("cookies.sqlite")):
-                    return True
-        except Exception:
-            pass
-        if not session_file or not session_file.exists():
-            return False
-        try:
-            session = json.loads(session_file.read_text())
-            age_days = (time.time() - session.get("saved_at", 0)) / 86400
-            return bool(session.get("cookies")) and age_days < 364
-        except Exception:
-            return False
-
-    def save_session(self, page, session_file: Path):
-        """Export cookies to a portable JSON file.
-
-        Primary persistence is the user_data_dir profile; this JSON is an
-        extra, portable backup that also powers legacy-migration on upgrade.
-        """
-        if not session_file:
+    def _save_session(self) -> None:
+        """Export Garmin cookies to JSON as a portable backup."""
+        if not self.session_file:
             return
         try:
-            cookies = page.context.cookies()
-        except Exception as e:
-            log.debug("Could not read cookies for session export: %s", e)
+            cookies = self._driver.get_cookies()
+        except Exception:
             return
         garmin_cookies = [c for c in cookies if "garmin" in c.get("domain", "")]
         if not garmin_cookies:
             return
         session = {"cookies": garmin_cookies, "saved_at": time.time()}
-        fd = _os.open(str(session_file), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+        fd = _os.open(str(self.session_file), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
         with _os.fdopen(fd, "w") as f:
             json.dump(session, f, indent=2)
-        log.info("Session saved: %d cookies to %s", len(garmin_cookies), session_file)
+        log.info("Session saved: %d cookies to %s", len(garmin_cookies), self.session_file)
 
-    def close(self, context, playwright, browser_ref):
-        """Close the Camoufox persistent context and any Xvfb we spawned.
+    # ── Browser launch ───────────────────────────────────────────
 
-        ``browser_ref`` holds the Camoufox context manager; calling ``__exit__``
-        properly tears down the browser process. If we started our own Xvfb
-        in ``_resolve_display`` we stop it afterwards.
-        """
+    def _launch_browser(self) -> None:
+        """Launch SeleniumBase UC Chrome with appropriate display settings."""
+        self._cleanup_stale_locks()
+
+        use_headless2 = False
+
+        if self.headless:
+            if sys.platform.startswith("linux") and not _os.environ.get("DISPLAY"):
+                # No display (SSH/server) — spawn Xvfb and run headed against it
+                # for better stealth than Chrome's headless mode.
+                display = self._spawn_xvfb()
+                if display:
+                    self._xvfb_prev_display = _os.environ.get("DISPLAY")
+                    _os.environ["DISPLAY"] = display
+                else:
+                    log.warning(
+                        "No display and Xvfb not found (apt install xvfb). "
+                        "Falling back to headless mode (more detectable)."
+                    )
+                    use_headless2 = True
+            else:
+                # Desktop or macOS/Windows — use Chrome's new headless mode
+                use_headless2 = True
+
+        driver_kwargs = dict(
+            uc=True,
+            user_data_dir=str(self.profile_dir),
+            locale_code="en-US",
+        )
+        if use_headless2:
+            driver_kwargs["headless2"] = True
+
         try:
-            if browser_ref is not None:
-                try:
-                    browser_ref.__exit__(None, None, None)
-                except Exception as e:
-                    log.debug("Camoufox __exit__ raised: %s", e)
-                    if context is not None:
-                        try:
-                            context.close()
-                        except Exception:
-                            pass
-            elif context is not None:
-                try:
-                    context.close()
-                except Exception:
-                    pass
-        finally:
+            self._driver = Driver(**driver_kwargs)
+        except Exception:
             self._stop_xvfb()
+            raise
 
+        self._driver.set_script_timeout(120)
 
-class GarminClient:
-    def __init__(
-        self,
-        email: str,
-        password: str,
-        profile_dir: Optional[Path] = None,
-        headless: bool = False,
-        engine: str = "auto",
-        session_file: Optional[Path] = None,
-    ):
-        self.email = email
-        self.password = password
-        self.profile_dir = profile_dir or DEFAULT_PROFILE_DIR
-        self.profile_dir.mkdir(parents=True, exist_ok=True)
-        self.headless = headless
-        self.session_file = session_file
-        self._playwright = None
-        self._browser_ref = None  # Camoufox browser reference
-        self._context: Optional[BrowserContext] = None
-        self._page: Optional[Page] = None
-        self._csrf: Optional[str] = None
-        self._display_name: Optional[str] = None
+        last_exit_clean = self._check_sentinel()
+        if not last_exit_clean:
+            log.info("Previous exit was unclean — profile may need warm-up")
 
-        # Select engine
-        if engine == "chrome":
-            self._engine = _ChromeEngine()
-        elif engine == "camoufox":
-            self._engine = _CamoufoxEngine()
-        else:  # auto
-            try:
-                from camoufox.sync_api import Camoufox  # noqa: F401
+        self._load_legacy_session()
 
-                self._engine = _CamoufoxEngine()
-            except ImportError:
-                self._engine = _ChromeEngine()
+        self._lifecycle = _ProcessLifecycle(self.close)
+        self._lifecycle.install()
 
-        engine_name = "Camoufox" if isinstance(self._engine, _CamoufoxEngine) else "Chrome"
-        log.info("Browser engine: %s", engine_name)
+        log.info("Browser engine: SeleniumBase UC (Chrome)")
+
+    # ── Browser helpers ──────────────────────────────────────────
+
+    def _uc_navigate(self, url: str, reconnect_time: int = 10) -> None:
+        """Navigate to a URL with Cloudflare bypass (disconnects CDP briefly)."""
+        self._driver.uc_open_with_reconnect(url, reconnect_time)
+        try:
+            WebDriverWait(self._driver, 15).until(
+                lambda d: d.execute_script("return document.readyState") == "complete"
+            )
+        except Exception:
+            pass
+
+    def _type_slowly(self, text: str, delay_s: float = 0.03) -> None:
+        """Type text with delays between keystrokes for stealth."""
+        actions = ActionChains(self._driver)
+        for char in text:
+            actions.send_keys(char)
+            actions.pause(delay_s)
+        actions.perform()
+
+    # ── Login flow ───────────────────────────────────────────────
 
     def login(self, timeout_ms: int = 600000) -> bool:
-        result = self._engine.launch(self.profile_dir, self.headless, self.session_file)
-        self._context, self._page, self._playwright, self._browser_ref = result
+        self._launch_browser()
 
         log.debug("Navigating to connect.garmin.com/modern/")
         try:
-            self._page.goto(
-                "https://connect.garmin.com/modern/",
-                wait_until="domcontentloaded",
-            )
+            self._uc_navigate("https://connect.garmin.com/modern/", 12)
         except Exception as e:
             log.debug("Initial navigation error (expected for fresh profile): %s", e)
         time.sleep(3)
 
-        log.debug("URL after initial navigation: %s", self._page.url)
+        log.debug("URL after initial navigation: %s", self._driver.current_url)
 
         if not self._is_on_login_page():
-            # Verify we actually have a valid session by trying to extract CSRF
             setup_ok = self._post_login_setup()
             if setup_ok:
                 print("Already logged in (session restored)")
-                self._engine.save_session(self._page, self.session_file)
+                self._save_session()
                 return True
-            # CSRF failed — page looks like app but session is invalid
-            # Navigate back to SSO for fresh login
             log.debug("On app page but no CSRF — session invalid, proceeding with login")
             try:
-                self._page.goto(SSO_LOGIN_URL, wait_until="domcontentloaded")
+                self._uc_navigate(SSO_LOGIN_URL, 12)
                 time.sleep(3)
             except Exception:
                 pass
 
         print("Logging in...")
 
-        # Clear stale SSO/Garmin cookies to prevent login loops
         try:
-            self._context.clear_cookies()
+            self._driver.delete_all_cookies()
             log.debug("Cleared stale cookies")
         except Exception as e:
             log.debug("Cookie clear error: %s", e)
 
-        # Navigate to SSO — may need retries on fresh profiles
         for attempt in range(3):
             try:
-                self._page.goto(SSO_LOGIN_URL, wait_until="domcontentloaded")
+                self._uc_navigate(SSO_LOGIN_URL, 12)
                 break
             except Exception as e:
                 log.debug("SSO navigation attempt %d error: %s", attempt + 1, e)
                 time.sleep(3)
 
         time.sleep(2)
-        log.debug("SSO page URL: %s", self._page.url)
+        log.debug("SSO page URL: %s", self._driver.current_url)
 
-        # Wait for login form to be ready
+        # Wait for login form
         try:
-            email_input = self._page.locator('input[name="email"]').first
-            email_input.wait_for(timeout=15000)
+            email_input = WebDriverWait(self._driver, 15).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, 'input[name="email"]'))
+            )
         except Exception:
-            log.error("Login form not found on page: %s", self._page.url)
-            # Dump page content for debugging
+            log.error("Login form not found on page: %s", self._driver.current_url)
             try:
-                body = self._page.evaluate("() => document.body?.innerText?.substring(0, 500)")
-                print(f"Login form not found. Current URL: {self._page.url}")
+                body = self._driver.execute_script(
+                    "return document.body?.innerText?.substring(0, 500)"
+                )
+                print(f"Login form not found. Current URL: {self._driver.current_url}")
                 print(f"Page content: {body}")
             except Exception:
-                print(f"Login form not found. Current URL: {self._page.url}")
+                print(f"Login form not found. Current URL: {self._driver.current_url}")
             print("Try running with --visible or deleting browser_profile/")
             return False
 
         email_input.click()
-        self._page.keyboard.type(self.email, delay=30)
+        self._type_slowly(self.email, delay_s=0.03)
 
-        pwd_input = self._page.locator('input[name="password"]').first
-        pwd_input.wait_for(timeout=5000)
-        pwd_input.click()
-        self._page.keyboard.type(self.password, delay=30)
-
-        # Auto-check "Remember Me" on login page
         try:
-            self._page.evaluate("""
-                () => {
-                    const cb = document.querySelector('input[name="remember"], input[id="remember"]');
-                    if (cb && !cb.checked) cb.click();
-                }
+            pwd_input = WebDriverWait(self._driver, 5).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, 'input[name="password"]'))
+            )
+        except Exception:
+            log.error("Password field not found")
+            return False
+
+        pwd_input.click()
+        self._type_slowly(self.password, delay_s=0.03)
+
+        # Auto-check "Remember Me"
+        try:
+            self._driver.execute_script("""
+                var cb = document.querySelector('input[name="remember"], input[id="remember"]');
+                if (cb && !cb.checked) cb.click();
             """)
         except Exception:
             pass
 
-        submit = self._page.locator('button[type="submit"], button:has-text("Sign In")').first
-        submit.click()
+        try:
+            submit = self._driver.find_element(By.CSS_SELECTOR, 'button[type="submit"]')
+            submit.click()
+        except Exception:
+            ActionChains(self._driver).send_keys(Keys.ENTER).perform()
+
         print("Credentials submitted, waiting for Garmin...")
 
-        # Poll until we leave SSO — handles both MFA and direct login
-        # The user can enter MFA in the browser OR via console (if interactive)
+        # Poll until we leave SSO
         max_polls = timeout_ms // 1000
         mfa_prompted = False
         mfa_code_thread = None
-        mfa_code_result = [None]  # mutable container for thread result
+        mfa_code_result = [None]
 
         for poll in range(max_polls):
             time.sleep(1)
-            url = self._page.url
+            try:
+                url = self._driver.current_url
+            except Exception:
+                continue
 
-            # Log URL periodically
             if poll % 5 == 0:
                 log.debug("Poll %d: URL = %s", poll, url)
 
-            # Success: we left SSO entirely
+            # Success: we left SSO
             if "connect.garmin.com" in url and "sso.garmin.com" not in url:
                 log.info("Login redirect detected: %s", url)
                 break
 
-            # Check if a NEW page/tab opened with the app (Garmin sometimes
-            # opens the app in a new tab after MFA)
-            for p in self._context.pages:
-                p_url = p.url
-                if "connect.garmin.com" in p_url and "sso.garmin.com" not in p_url:
-                    log.info("Found app in another tab: %s", p_url)
-                    self._page = p
-                    url = p_url
-                    break
+            # Check other tabs (Garmin sometimes opens app in a new tab after MFA)
+            handles = self._driver.window_handles
+            if len(handles) > 1:
+                original = self._driver.current_window_handle
+                for handle in handles:
+                    self._driver.switch_to.window(handle)
+                    p_url = self._driver.current_url
+                    if "connect.garmin.com" in p_url and "sso.garmin.com" not in p_url:
+                        log.info("Found app in another tab: %s", p_url)
+                        url = p_url
+                        break
+                else:
+                    self._driver.switch_to.window(original)
             if "connect.garmin.com" in url and "sso.garmin.com" not in url:
                 break
 
-            # After MFA prompted: only do lightweight URL checks, don't
-            # navigate or run JS that could disrupt the MFA page.
-            # The user will complete MFA in the browser — Garmin will
-            # redirect to connect.garmin.com automatically.
-
-            # MFA page detected — check URL AND check for MFA input fields on the page
+            # MFA detection
             is_mfa_page = "/mfa" in url.lower() or "verifymfa" in url.lower()
             if not is_mfa_page and not mfa_prompted and "sso.garmin.com" in url:
                 try:
-                    has_mfa_input = self._page.evaluate("""
-                        () => {
-                            const inputs = document.querySelectorAll(
-                                'input[name="verificationCode"], input[name="securityCode"], input[type="tel"], '
-                                + 'input[placeholder*="code"], input[placeholder*="Code"], '
-                                + 'input[name="mfaCode"], input[autocomplete="one-time-code"]'
-                            );
-                            return inputs.length > 0;
-                        }
+                    has_mfa_input = self._driver.execute_script("""
+                        var inputs = document.querySelectorAll(
+                            'input[name="verificationCode"], input[name="securityCode"], input[type="tel"], '
+                            + 'input[placeholder*="code"], input[placeholder*="Code"], '
+                            + 'input[name="mfaCode"], input[autocomplete="one-time-code"]'
+                        );
+                        return inputs.length > 0;
                     """)
                     if has_mfa_input:
                         is_mfa_page = True
@@ -607,13 +493,12 @@ class GarminClient:
                 mfa_prompted = True
                 log.info("MFA page detected: %s", url)
 
-                # Auto-check "Remember this browser" if available
                 try:
-                    self._page.evaluate("""
-                        () => {
-                            const cb = document.querySelector('input[name="remember"], input[id="remember"], input[type="checkbox"]');
-                            if (cb && !cb.checked) cb.click();
-                        }
+                    self._driver.execute_script("""
+                        var cb = document.querySelector(
+                            'input[name="remember"], input[id="remember"], input[type="checkbox"]'
+                        );
+                        if (cb && !cb.checked) cb.click();
                     """)
                 except Exception:
                     pass
@@ -636,50 +521,42 @@ class GarminClient:
                     print()
                     print("  MFA required — enter code in the browser window...")
 
-            # Show waiting status for MFA
             if mfa_prompted and poll % 15 == 0 and poll > 0:
                 print("  Still waiting for MFA code...")
 
-            # If we've been stuck on SSO for 30+ seconds after MFA was prompted,
-            # try navigating to the app directly — the session might be valid
             if mfa_prompted and poll > 0 and poll % 30 == 0:
                 log.debug("Stuck on SSO after MFA — trying to navigate to app...")
                 try:
-                    self._page.goto(
-                        "https://connect.garmin.com/modern/",
-                        wait_until="domcontentloaded",
-                        timeout=10000,
-                    )
+                    self._driver.get("https://connect.garmin.com/modern/")
                     time.sleep(2)
-                    url = self._page.url
+                    url = self._driver.current_url
                     if "connect.garmin.com" in url and "sso.garmin.com" not in url:
                         log.info("Navigated to app after MFA: %s", url)
                         break
                 except Exception as e:
                     log.debug("Nav attempt error: %s", e)
 
-            # If console MFA code was entered, type it into the browser
             if mfa_code_result[0] is not None:
                 code = mfa_code_result[0]
-                mfa_code_result[0] = None  # consume it
+                mfa_code_result[0] = None
                 log.info("MFA code from console (%d chars), submitting...", len(code))
                 self._submit_mfa_code(code)
 
         # Wait for app to load
         time.sleep(3)
-        log.debug("Final URL: %s", self._page.url)
+        log.debug("Final URL: %s", self._driver.current_url)
 
         if self._is_on_login_page():
-            print(f"Login failed — still on login page: {self._page.url}")
+            print(f"Login failed — still on login page: {self._driver.current_url}")
             return False
 
         print("Login successful!")
         print("Setting up session...")
-        log.info("Login successful, URL: %s", self._page.url)
-        self._engine.save_session(self._page, self.session_file)
+        log.info("Login successful, URL: %s", self._driver.current_url)
+        self._save_session()
         return self._post_login_setup()
 
-    def _submit_mfa_code(self, code: str):
+    def _submit_mfa_code(self, code: str) -> None:
         """Type an MFA code into the browser and submit."""
         mfa_selectors = [
             'input[name="securityCode"]',
@@ -694,21 +571,22 @@ class GarminClient:
         time.sleep(1)
         for sel in mfa_selectors:
             try:
-                mfa_input = self._page.locator(sel).first
-                mfa_input.wait_for(timeout=3000)
+                mfa_input = WebDriverWait(self._driver, 3).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, sel))
+                )
                 mfa_input.click()
-                mfa_input.fill(code)
+                mfa_input.clear()
+                mfa_input.send_keys(code)
                 log.info("MFA code filled via selector: %s", sel)
 
-                submit_btn = self._page.locator(
-                    'button[type="submit"], button:has-text("Verify"), '
-                    'button:has-text("Submit"), button:has-text("Continue"), '
-                    'button:has-text("Next")'
-                ).first
                 try:
+                    submit_btn = self._driver.find_element(
+                        By.CSS_SELECTOR,
+                        'button[type="submit"]',
+                    )
                     submit_btn.click()
                 except Exception:
-                    self._page.keyboard.press("Enter")
+                    mfa_input.send_keys(Keys.ENTER)
 
                 log.info("MFA code submitted via browser")
                 return
@@ -718,76 +596,158 @@ class GarminClient:
         log.warning("Could not find MFA input field to fill")
 
     def _is_on_login_page(self) -> bool:
-        url = self._page.url.lower()
+        try:
+            url = self._driver.current_url.lower()
+        except Exception:
+            return True
         if "connect.garmin.com" in url and "sso.garmin.com" not in url:
             return False
         return "sso.garmin.com" in url or "signin" in url or "sign-in" in url
 
+    # ── Post-login setup ─────────────────────────────────────────
+
     def _post_login_setup(self) -> bool:
-        # Make sure we're on the /modern/ page which has the CSRF meta tag
-        current = self._page.url
+        current = self._driver.current_url
         if "/modern/" not in current:
             log.debug("Navigating to /modern/ for CSRF (was on %s)", current)
             try:
-                self._page.goto(
-                    "https://connect.garmin.com/modern/",
-                    wait_until="domcontentloaded",
-                )
+                self._driver.get("https://connect.garmin.com/modern/")
             except Exception:
                 pass
             time.sleep(3)
 
-        setup = self._page.evaluate("""
-            async () => {
-                const csrf = document.querySelector(
-                    'meta[name="csrf-token"], meta[name="_csrf"]'
-                )?.content;
-                const h = {'connect-csrf-token': csrf};
-                const resp = await fetch(
-                    '/gc-api/userprofile-service/socialProfile',
-                    {credentials: 'include', headers: h}
-                );
-                const profile = resp.status === 200 ? await resp.json() : null;
-                return {csrf, displayName: profile?.displayName};
-            }
+        setup = self._driver.execute_async_script("""
+            var callback = arguments[arguments.length - 1];
+            (async function() {
+                try {
+                    var csrf = document.querySelector(
+                        'meta[name="csrf-token"], meta[name="_csrf"]'
+                    )?.content;
+                    var h = {'connect-csrf-token': csrf};
+                    var resp = await fetch(
+                        '/gc-api/userprofile-service/socialProfile',
+                        {credentials: 'include', headers: h}
+                    );
+                    var profile = resp.status === 200 ? await resp.json() : null;
+                    return {csrf: csrf, displayName: profile ? profile.displayName : null};
+                } catch(e) {
+                    return {error: String(e)};
+                }
+            })().then(callback).catch(function(e) { callback({error: String(e)}); });
         """)
-        self._csrf = setup.get("csrf")
-        self._display_name = setup.get("displayName")
+
+        self._csrf = setup.get("csrf") if setup else None
+        self._csrf_time = time.time() if self._csrf else 0
+        self._display_name = setup.get("displayName") if setup else None
         if not self._csrf:
             log.debug("Could not extract CSRF token")
             return False
         log.info("Display name: %s", self._display_name)
         return True
 
+    def _ensure_csrf(self) -> Optional[str]:
+        """Re-read CSRF from page meta tag if stale."""
+        if self._csrf and time.time() - self._csrf_time < CSRF_TTL:
+            return self._csrf
+        self._ensure_on_garmin()
+        csrf = self._driver.execute_script(
+            'return document.querySelector(\'meta[name="csrf-token"], meta[name="_csrf"]\')?.content'
+        )
+        if csrf:
+            self._csrf = csrf
+            self._csrf_time = time.time()
+        return self._csrf
+
+    def _ensure_on_garmin(self) -> None:
+        """Make sure the browser is on connect.garmin.com for fetch context."""
+        try:
+            current = self._driver.current_url
+        except Exception:
+            return
+        if "connect.garmin.com" not in current or "sso.garmin.com" in current:
+            self._driver.get("https://connect.garmin.com/modern/")
+            time.sleep(2)
+
+    # ── Public API ───────────────────────────────────────────────
+
+    def navigate(self, url: str) -> None:
+        """Navigate the browser to a URL (same-origin, no CF challenge expected)."""
+        self._driver.get(url)
+        time.sleep(2)
+
+    def api_fetch(self, api_path: str):
+        """Fetch JSON from a /gc-api endpoint via the browser context.
+
+        Returns the parsed JSON or None on failure.
+        """
+        self._ensure_on_garmin()
+        csrf = self._ensure_csrf()
+        return self._driver.execute_async_script("""
+            var callback = arguments[arguments.length - 1];
+            var url = arguments[0];
+            var csrf = arguments[1];
+            (async function() {
+                try {
+                    var resp = await fetch(url, {
+                        credentials: 'include',
+                        headers: {'connect-csrf-token': csrf || '', 'Accept': 'application/json'}
+                    });
+                    if (resp.status !== 200) return null;
+                    return await resp.json();
+                } catch(e) { return null; }
+            })().then(callback).catch(function() { callback(null); });
+        """, api_path, csrf)
+
+    def download_file(self, api_path: str) -> Optional[bytes]:
+        """Download a binary file from a /gc-api endpoint. Returns bytes or None."""
+        self._ensure_on_garmin()
+        csrf = self._ensure_csrf()
+        result = self._driver.execute_async_script("""
+            var callback = arguments[arguments.length - 1];
+            var url = arguments[0];
+            var csrf = arguments[1];
+            (async function() {
+                try {
+                    var resp = await fetch(url, {
+                        credentials: 'include',
+                        headers: {'connect-csrf-token': csrf || ''}
+                    });
+                    if (resp.status !== 200) return {status: resp.status};
+                    var buffer = await resp.arrayBuffer();
+                    return {status: 200, data: Array.from(new Uint8Array(buffer))};
+                } catch(e) { return {status: 'error'}; }
+            })().then(callback).catch(function() { callback({status: 'error'}); });
+        """, api_path, csrf)
+        if result and result.get("status") == 200 and result.get("data"):
+            return bytes(result["data"])
+        return None
+
+    # ── Batch fetching ───────────────────────────────────────────
+
     def _fetch_batch(self, rest: dict, gql: dict) -> dict:
         """Fetch a batch of REST + GraphQL endpoints in parallel via browser."""
-        # Ensure we're on the right page (navigation can destroy context)
-        current = self._page.url
-        if "connect.garmin.com" not in current or "sso.garmin.com" in current:
-            try:
-                self._page.goto(
-                    "https://connect.garmin.com/modern/",
-                    wait_until="domcontentloaded",
-                )
-                time.sleep(2)
-            except Exception:
-                pass
+        self._ensure_on_garmin()
+        csrf = self._ensure_csrf()
 
         rest_entries = list(rest.items())
         gql_entries = list(gql.items())
 
-        return self._page.evaluate(
-            """
-            async ([csrf, restEntries, gqlEntries]) => {
-                const h = {'connect-csrf-token': csrf, 'Accept': 'application/json'};
+        result = self._driver.execute_async_script("""
+            var callback = arguments[arguments.length - 1];
+            var csrf = arguments[0];
+            var restEntries = arguments[1];
+            var gqlEntries = arguments[2];
+
+            (async function() {
+                var h = {'connect-csrf-token': csrf, 'Accept': 'application/json'};
 
                 async function get(url) {
                     try {
-                        const resp = await fetch(url, {credentials:'include', headers: h});
+                        var resp = await fetch(url, {credentials:'include', headers: h});
                         if (resp.status === 200) {
-                            const text = await resp.text();
+                            var text = await resp.text();
                             try { return {status: 200, data: JSON.parse(text)}; }
-                            catch { return {status: 200, data: text}; }
+                            catch(e) { return {status: 200, data: text}; }
                         }
                         return {status: resp.status, data: null};
                     } catch(e) { return {status: 'error', data: e.message}; }
@@ -795,32 +755,36 @@ class GarminClient:
 
                 async function gql(query) {
                     try {
-                        const resp = await fetch('/gc-api/graphql-gateway/graphql', {
+                        var resp = await fetch('/gc-api/graphql-gateway/graphql', {
                             method: 'POST',
                             credentials: 'include',
-                            headers: {...h, 'Content-Type': 'application/json'},
-                            body: JSON.stringify({query})
+                            headers: Object.assign({}, h, {'Content-Type': 'application/json'}),
+                            body: JSON.stringify({query: query})
                         });
                         if (resp.status === 200) return {status: 200, data: await resp.json()};
                         return {status: resp.status, data: null};
                     } catch(e) { return {status: 'error', data: e.message}; }
                 }
 
-                const promises = [
-                    ...restEntries.map(([name, url]) => get(url).then(r => [name, r])),
-                    ...gqlEntries.map(([name, query]) => gql(query).then(r => ['gql_' + name, r])),
-                ];
+                var promises = restEntries.map(function(entry) {
+                    return get(entry[1]).then(function(r) { return [entry[0], r]; });
+                }).concat(gqlEntries.map(function(entry) {
+                    return gql(entry[1]).then(function(r) { return ['gql_' + entry[0], r]; });
+                }));
 
-                const results = await Promise.all(promises);
-                const output = {};
-                for (const [name, result] of results) {
-                    output[name] = result;
+                var results = await Promise.all(promises);
+                var output = {};
+                for (var i = 0; i < results.length; i++) {
+                    output[results[i][0]] = results[i][1];
                 }
                 return output;
-            }
-        """,
-            [self._csrf, rest_entries, gql_entries],
-        )
+            })().then(callback).catch(function(e) { callback({error: String(e)}); });
+        """, csrf, rest_entries, gql_entries)
+
+        if result and "error" in result:
+            log.warning("_fetch_batch JS error: %s", result["error"])
+            return {}
+        return result or {}
 
     def _date_chunks(self, start: str, end: str, max_days: int = 28) -> list:
         """Split a date range into chunks of max_days."""
@@ -847,11 +811,9 @@ class GarminClient:
         ----------
         on_batch : callable, optional
             ``on_batch(endpoint_name, data, cal_date=None)`` called after each
-            successful fetch.  When provided, data is saved immediately (direct-
-            to-DB).  When *None*, results accumulate in memory (legacy mode).
+            successful fetch.
         known_activity_ids : set, optional
-            Activity IDs that already have detail data (splits, HR zones, weather).
-            These will be skipped during per-activity detail fetching.
+            Activity IDs that already have detail data — these will be skipped.
         """
         today = target_date or date.today().isoformat()
         e_date = end_date or today
@@ -860,7 +822,6 @@ class GarminClient:
         all_results = {}
 
         def _process_batch(batch_result, cal_date=None):
-            """Send each endpoint result to on_batch or accumulate in memory."""
             for name, result in batch_result.items():
                 if result.get("status") != 200 or not result.get("data"):
                     continue
@@ -874,7 +835,7 @@ class GarminClient:
                         new = result["data"]
                         all_results[name]["data"] = _merge_data(existing, new)
 
-        # 1. Profile endpoints (no date) + profile GraphQL
+        # 1. Profile endpoints (no date)
         print("  Fetching profile data...")
         profile = self._fetch_batch(
             profile_endpoints(),
@@ -882,15 +843,15 @@ class GarminClient:
         )
         _process_batch(profile)
 
-        # 2. Full-range queries (supports 365+ days)
+        # 2. Full-range queries
         print("  Fetching full-range data (activities, HRV, training, VO2max, weight)...")
         full_rest = full_range_rest(self._display_name, s_date, e_date)
         full_gql = full_range_graphql(self._display_name, s_date, e_date)
         full = self._fetch_batch(full_rest, full_gql)
         _process_batch(full)
 
-        # 2b. Paginate through ALL activities (the search endpoint returns max ~100 per page)
-        page_start = 100  # first page (0-99) already fetched above
+        # 2b. Paginate through ALL activities
+        page_start = 100
         while True:
             act_result = self._fetch_batch(
                 {
@@ -915,9 +876,9 @@ class GarminClient:
                     all_results["activities"]["data"].append(a)
             page_start += 100
             if len(activities_page) < 100:
-                break  # last page
+                break
 
-        # 3. Monthly-chunked queries (max 28-day ranges) — REST + GraphQL
+        # 3. Monthly-chunked queries
         print("  Fetching monthly-chunked data (sleep stats, HRV, calories, etc.)...")
         chunks = self._date_chunks(s_date, e_date, max_days=28)
         for i, (cs, ce) in enumerate(chunks):
@@ -927,7 +888,7 @@ class GarminClient:
             chunk_result = self._fetch_batch(m_rest, m_gql)
             _process_batch(chunk_result)
 
-        # 4. Daily-chunked REST + GraphQL (stress, HR, sleep, SpO2, body battery)
+        # 4. Daily-chunked REST + GraphQL
         print("  Fetching daily data (stress, HR, sleep, SpO2, body battery)...")
         all_days = []
         d = date.fromisoformat(s_date)
@@ -951,12 +912,9 @@ class GarminClient:
 
             batch_result = self._fetch_batch(rest_batch, gql_batch)
 
-            # Daily results: split "endpoint_YYYY-MM-DD" into endpoint + date
             for full_name, result in batch_result.items():
                 if result.get("status") != 200 or not result.get("data"):
                     continue
-                # Extract base name and date from "stress_2026-03-29" or "gql_heart_rate_detail_2026-03-29"
-                # Date is always the last 10 chars after the last underscore
                 parts = full_name.rsplit("_", 1)
                 if len(parts) == 2 and len(parts[1]) == 10 and parts[1][4] == "-":
                     base_name = parts[0]
@@ -982,9 +940,7 @@ class GarminClient:
                     else:
                         all_results[base_name] = {"status": 200, "data": [entry]}
 
-        # 5. Per-activity detail data (splits, HR zones, weather, exercise sets)
-        # Only fetch details for activities we don't already have.
-        # First, collect activity IDs from what was already fetched in this run.
+        # 5. Per-activity detail data
         activity_ids = []
 
         for name_key, result in all_results.items():
@@ -996,19 +952,13 @@ class GarminClient:
                         if aid:
                             activity_ids.append(aid)
 
-        # In on_batch mode, we need to check the API — but only if
-        # known_activity_ids suggests there might be new ones.
         if not activity_ids and on_batch:
-            # Quick check: compare activity count in DB vs API
             try:
-                act_result = self._fetch_batch(
-                    {"_activity_ids": "/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0"},
-                    {},
+                act_data = self.api_fetch(
+                    "/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0"
                 )
-                act_data = act_result.get("_activity_ids", {})
-                if act_data.get("status") == 200 and isinstance(act_data.get("data"), list):
-                    all_api_ids = [a.get("activityId") for a in act_data["data"] if a.get("activityId")]
-                    # Only keep IDs that don't have details yet
+                if isinstance(act_data, list):
+                    all_api_ids = [a.get("activityId") for a in act_data if a.get("activityId")]
                     activity_ids = [aid for aid in all_api_ids if aid not in (known_activity_ids or set())]
             except Exception as e:
                 log.debug("Could not fetch activity IDs: %s", e)
@@ -1073,12 +1023,20 @@ class GarminClient:
         print(f"Exported {len(export['data'])} datasets to {path} ({size_mb:.1f} MB)")
         return path
 
+    # ── Shutdown ─────────────────────────────────────────────────
+
     def close(self):
-        self._engine.close(self._context, self._playwright, self._browser_ref)
-        self._page = None
-        self._context = None
-        self._playwright = None
-        self._browser_ref = None
+        if self._driver is not None:
+            try:
+                self._driver.quit()
+            except Exception as e:
+                log.debug("driver.quit() error: %s", e)
+            self._driver = None
+        self._write_sentinel()
+        self._stop_xvfb()
+
+
+# ─── Utility functions ───────────────────────────────────────────
 
 
 def _merge_data(existing, new):
@@ -1096,7 +1054,6 @@ def _merge_data(existing, new):
         return merged
     if isinstance(existing, list) and isinstance(new, list):
         return existing + new
-    # For scalars, keep the newer value
     return new
 
 

--- a/garmin_givemydata.py
+++ b/garmin_givemydata.py
@@ -282,11 +282,6 @@ examples:
         action="store_true",
         help="Show the browser window (default: headless). Useful for debugging login issues.",
     )
-    parser.add_argument(
-        "--chrome",
-        action="store_true",
-        help="Use Chrome instead of Camoufox (default: auto-detect best engine).",
-    )
 
     args = parser.parse_args()
 
@@ -432,7 +427,6 @@ examples:
             password=password,
             profile_dir=PROFILE_DIR,
             headless=not args.visible,
-            engine="chrome" if args.chrome else "auto",
             session_file=SESSION_FILE,
         )
         try:
@@ -442,20 +436,11 @@ examples:
 
             # Get activity list from API
             print("Fetching activity list...")
-            client._page.goto("https://connect.garmin.com/modern/", wait_until="domcontentloaded")
-            time.sleep(2)
-
-            act_result = client._page.evaluate("""
-                async () => {
-                    const csrf = document.querySelector('meta[name="csrf-token"], meta[name="_csrf"]')?.content;
-                    const resp = await fetch('/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0', {
-                        credentials: 'include',
-                        headers: {'connect-csrf-token': csrf || '', 'Accept': 'application/json'}
-                    });
-                    if (resp.status !== 200) return [];
-                    return await resp.json();
-                }
-            """)
+            act_result = client.api_fetch(
+                "/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0"
+            )
+            if not act_result:
+                act_result = []
 
             if not act_result:
                 print("No activities found.")
@@ -497,31 +482,12 @@ examples:
                     print(f"  {filename} (already exists)")
                     continue
 
-                url = f"/gc-api/download-service/files/activity/{aid}"
-                result = client._page.evaluate(
-                    f"""
-                    async () => {{
-                        try {{
-                            const csrf = document.querySelector(
-                                'meta[name="csrf-token"], meta[name="_csrf"]'
-                            )?.content;
-                            const resp = await fetch('{url}', {{
-                                credentials: 'include',
-                                headers: {{'connect-csrf-token': csrf || ''}}
-                            }});
-                            if (resp.status !== 200) return {{status: resp.status}};
-                            const buffer = await resp.arrayBuffer();
-                            return {{status: 200, data: Array.from(new Uint8Array(buffer))}};
-                        }} catch(e) {{
-                            return {{status: 'error'}};
-                        }}
-                    }}
-                """
-                )
+                api_path = f"/gc-api/download-service/files/activity/{aid}"
+                data = client.download_file(api_path)
 
-                if result.get("status") == 200 and result.get("data"):
+                if data:
                     with open(filepath, "wb") as f:
-                        f.write(bytes(result["data"]))
+                        f.write(data)
                     downloaded += 1
                     print(f"  {filename}")
 
@@ -545,7 +511,6 @@ examples:
         password=password,
         profile_dir=PROFILE_DIR,
         headless=not args.visible,
-        engine="chrome" if args.chrome else "auto",
         session_file=SESSION_FILE,
     )
 
@@ -596,12 +561,6 @@ examples:
                     f"\nDownloading FIT files ({len(new_activities)} new, {len(existing_fits)} already downloaded)..."
                 )
 
-                client._page.goto(
-                    "https://connect.garmin.com/modern/",
-                    wait_until="domcontentloaded",
-                )
-                time.sleep(2)
-
                 downloaded = 0
                 for i, (aid, name, date_str) in enumerate(new_activities):
                     safe_name = ""
@@ -613,31 +572,12 @@ examples:
                     filename = f"{safe_date}_{aid}{safe_name}.zip"
                     filepath = fit_dir / filename
 
-                    url = f"/gc-api/download-service/files/activity/{aid}"
-                    result = client._page.evaluate(
-                        f"""
-                        async () => {{
-                            try {{
-                                const csrf = document.querySelector(
-                                    'meta[name="csrf-token"], meta[name="_csrf"]'
-                                )?.content;
-                                const resp = await fetch('{url}', {{
-                                    credentials: 'include',
-                                    headers: {{'connect-csrf-token': csrf || ''}}
-                                }});
-                                if (resp.status !== 200) return {{status: resp.status}};
-                                const buffer = await resp.arrayBuffer();
-                                return {{status: 200, data: Array.from(new Uint8Array(buffer))}};
-                            }} catch(e) {{
-                                return {{status: 'error'}};
-                            }}
-                        }}
-                    """
-                    )
+                    api_path = f"/gc-api/download-service/files/activity/{aid}"
+                    data = client.download_file(api_path)
 
-                    if result.get("status") == 200 and result.get("data"):
+                    if data:
                         with open(filepath, "wb") as f:
-                            f.write(bytes(result["data"]))
+                            f.write(data)
                         downloaded += 1
 
                     if downloaded > 0 and downloaded % 10 == 0:

--- a/garmin_mcp/export.py
+++ b/garmin_mcp/export.py
@@ -406,10 +406,6 @@ def download_activity_files(
             print("  Login failed!")
             return
 
-        # First navigate to the Garmin app so we have the right context
-        client._page.goto("https://connect.garmin.com/modern/", wait_until="domcontentloaded")
-        time.sleep(2)
-
         downloaded = 0
         skipped = 0
         failed = 0
@@ -436,31 +432,12 @@ def download_activity_files(
                 skipped += 1
                 continue
 
-            url = url_pattern.format(id=aid)
-            result = client._page.evaluate(
-                f"""
-                async () => {{
-                    try {{
-                        const csrf = document.querySelector(
-                            'meta[name="csrf-token"], meta[name="_csrf"]'
-                        )?.content;
-                        const resp = await fetch('{url}', {{
-                            credentials: 'include',
-                            headers: {{'connect-csrf-token': csrf || ''}}
-                        }});
-                        if (resp.status !== 200) return {{status: resp.status}};
-                        const buffer = await resp.arrayBuffer();
-                        return {{status: 200, data: Array.from(new Uint8Array(buffer))}};
-                    }} catch(e) {{
-                        return {{status: 'error', msg: e.message}};
-                    }}
-                }}
-            """
-            )
+            api_path = url_pattern.format(id=aid)
+            file_data = client.download_file(api_path)
 
-            if result.get("status") == 200 and result.get("data"):
+            if file_data:
                 with open(filepath, "wb") as f:
-                    f.write(bytes(result["data"]))
+                    f.write(file_data)
                 downloaded += 1
             else:
                 failed += 1

--- a/garmin_mcp/sync.py
+++ b/garmin_mcp/sync.py
@@ -73,7 +73,6 @@ def incremental_sync(target_date: str = None) -> dict:
         password=password,
         profile_dir=PROFILE_DIR,
         headless=True,
-        engine="auto",
         session_file=SESSION_FILE,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-camoufox = ["camoufox>=0.4"]
+camoufox = ["camoufox>=0.4.11"]
 
 [project.urls]
 Homepage = "https://github.com/nrvim/garmin-givemydata"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "garmin-givemydata"
-version = "0.1.8"
+version = "0.1.9"
 description = "Get your Garmin Connect data back. Browser-based extraction + 47-table SQLite database + MCP server for AI analysis."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,11 @@ classifiers = [
     "Topic :: Database",
 ]
 dependencies = [
-    "playwright>=1.40",
+    "seleniumbase>=4.30",
     "httpx>=0.25",
     "mcp[cli]>=1.0",
     "python-dotenv>=1.0",
 ]
-
-[project.optional-dependencies]
-camoufox = ["camoufox>=0.4.11"]
 
 [project.urls]
 Homepage = "https://github.com/nrvim/garmin-givemydata"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 playwright>=1.40
 httpx>=0.25
 mcp[cli]>=1.0
-camoufox>=0.4
+camoufox>=0.4.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-playwright>=1.40
+seleniumbase>=4.30
 httpx>=0.25
 mcp[cli]>=1.0
-camoufox>=0.4.11

--- a/setup.bat
+++ b/setup.bat
@@ -43,10 +43,9 @@ pip install --upgrade pip -q 2>nul
 pip install -r requirements.txt -q 2>nul
 echo        Dependencies installed
 
-REM ── Step 3: Install browser driver ──
-echo [3/4] Installing browser driver...
-python -m playwright install chromium
-echo        Browser driver ready
+REM ── Step 3: Verify Chrome ──
+echo [3/4] Verifying Chrome...
+echo        Chrome found — SeleniumBase will auto-download the matching chromedriver
 
 REM ── Step 4: Garmin credentials ──
 echo [4/4] Garmin Connect credentials

--- a/setup.sh
+++ b/setup.sh
@@ -75,14 +75,9 @@ pip install --upgrade pip -q 2>&1 | tail -1
 pip install -r requirements.txt -q 2>&1 | tail -1
 echo "       Dependencies installed"
 
-# ── Step 4: Install browser driver ────────────────────────────
-echo "[4/5] Installing browser driver..."
-python -m playwright install chromium 2>&1 | grep -E "downloaded|Downloading" || echo "       Browser driver ready"
-
-# Linux may need system deps
-if [ "$(uname)" = "Linux" ]; then
-    echo "       (Linux detected — if browser fails, run: sudo python -m playwright install-deps chromium)"
-fi
+# ── Step 4: Verify Chrome is ready ────────────────────────────
+echo "[4/5] Verifying Chrome..."
+echo "       Chrome found — SeleniumBase will auto-download the matching chromedriver"
 
 # ── Step 5: Garmin credentials ────────────────────────────────
 echo "[5/5] Garmin Connect credentials"


### PR DESCRIPTION
## Summary

Replaces the Camoufox (Firefox) and Playwright Chrome engines with a single SeleniumBase UC (undetected Chrome) engine. Adds process lifecycle signal handlers to prevent profile corruption on SSH disconnect. Fixes FIT file download failures.

**Related issues: #11, #18, #15. Supersedes #19.**

## The problem

Three stacked root causes behind #11 (session rot within ~1-2 hours over SSH):

1. **Unclean shutdown corrupts browser profile.** SSH disconnect → SIGHUP → Python dies mid-IndexedDB-write → profile state torn → forced reauth. No engine swap alone fixes this.

2. **Camoufox Firefox fingerprint is exotic to Garmin's device tracker.** Garmin's React app fingerprints `Sec-CH-UA-*` client hints via `/gc-api`. Firefox doesn't emit these headers — a Camoufox session is a permanent outlier in Garmin's Chrome-tuned device-tracker population, causing faster refresh-token rotation.

3. **Camoufox seed drift** (daijro/camoufox#442). BrowserForge seed changes on restart → looks like a new device → JWT `did` rotates → refresh token invalidated. Still open upstream, stalled since Feb 2026.

Separately, **FIT file downloads fail with Camoufox** (#18, #15) — users on both macOS and Windows report 0 files downloaded unless they switch to `--chrome`. PR #19 (Copilot) diagnosed this as CORS on S3 redirects, but both #18 and #15 users confirmed `--chrome` fixed it using the same `page.evaluate(fetch(...))` code — the failure was Camoufox-specific, not CORS. This PR eliminates Camoufox entirely. If CORS issues surface on Chrome in some edge cases, we'll escalate to CDP `Network.getResponseBody`.

## What changed

**`garmin_client/client.py`** — full rewrite:
- Deleted `_ChromeEngine` and `_CamoufoxEngine` classes (all Playwright/Camoufox code)
- New `GarminClient` backed by `seleniumbase.Driver(uc=True, user_data_dir=...)` — single engine, Chrome-based, Cloudflare bypass via UC mode
- Added `_ProcessLifecycle` class — installs `atexit` + signal handlers for SIGHUP/SIGTERM/SIGINT so SSH disconnect triggers clean `driver.quit()` instead of killing Chrome mid-write
- Added clean-exit sentinel file (`.garmin_clean_exit`) — detects unclean shutdown on next launch, triggers extra lock cleanup + warm-up
- Chrome `SingletonLock`/`SingletonCookie`/`SingletonSocket` stale lock cleanup (was Firefox `parent.lock`)
- CSRF token cache with 30-minute TTL (was cached forever — stale CSRF caused silent 403s)
- Xvfb management ported from Camoufox engine, upgraded to `1920x1080x24` (was `1280x1024x24`)
- Script timeout set to 120s (was Selenium default 30s — blew up on large exports)
- New public API: `navigate()`, `api_fetch()`, `download_file()` — eliminates `client._page` leakage

**`garmin_givemydata.py`**:
- Removed `--chrome` flag (Chrome is now the only engine)
- FIT downloads: `client._page.evaluate(f"...{url}...")` → `client.download_file(api_path)` — fixes f-string JS injection vulnerability and the FIT download failures in #18
- Activity list fetch: `client._page.evaluate(async_js)` → `client.api_fetch(path)`

**`garmin_mcp/export.py`**: Same `_page` → public API migration for GPX/TCX export downloads

**`garmin_mcp/sync.py`**: Removed `engine="auto"` parameter

**Packaging**:
- `pyproject.toml`: `playwright>=1.40` + `camoufox>=0.4.11` → `seleniumbase>=4.30`
- `requirements.txt`: same
- `setup.sh` / `setup.bat`: removed `playwright install chromium` step
- `.github/workflows/update-homebrew.yml`: updated caveats (Chrome instead of playwright)

**README.md**: Updated browser engine table, manual setup instructions, troubleshooting (session-rot guidance, IP-binding note)

## Why SeleniumBase UC

| | Camoufox | Playwright Chrome | SeleniumBase UC |
|---|---|---|---|
| CF bypass | Yes (Firefox) | No (detected) | Yes (Chrome) |
| `Sec-CH-UA-*` client hints | No (Firefox) | Yes | Yes |
| Profile persistence | Seed drift (#442) | Manual | `user_data_dir` native |
| Bus factor | 2 maintainers | Maintained | 10k+ stars, weekly releases |
| FIT downloads | Broken (#18) | Works | Works |
| Windows | Broken (#15) | Works | Works |

## Migration

Google Chrome must be installed. No `playwright install chromium` step needed — SeleniumBase auto-downloads the matching chromedriver.

**Git clone:**
```bash
cd garmin-givemydata
git pull
source venv/bin/activate
pip install -e .
rm -rf browser_profile/ garmin_session.json
garmin-givemydata
```

**pip:**
```bash
pip install --upgrade garmin-givemydata
rm -rf ~/.garmin-givemydata/browser_profile ~/.garmin-givemydata/garmin_session.json
garmin-givemydata
```

**Homebrew:**
```bash
brew upgrade garmin-givemydata
rm -rf ~/.garmin-givemydata/browser_profile ~/.garmin-givemydata/garmin_session.json
garmin-givemydata
```

The `--chrome` flag is removed (silently ignored for backwards compat). `--visible` still works.

## Testing requested

This is a major engine change. If you were affected by any of these issues, please test this branch and report back:

- **#11** (@dylix) — Session rot over SSH. The root cause was twofold: Camoufox (Firefox) doesn't emit `Sec-CH-UA-*` client hints that Garmin's device tracker expects, causing faster token rotation; and SSH disconnects sent SIGHUP which killed the browser mid-write, corrupting the profile. This PR replaces Camoufox with Chrome (which emits the right client hints) and adds signal handlers so SIGHUP triggers a clean browser shutdown instead of a crash. After upgrading, delete `browser_profile/` and run `garmin-givemydata` on your Ubuntu server over SSH. Does the session survive 2+ hours? Can you disconnect SSH, reconnect, and run again without being forced to re-login?

- **#18** (@sgowtham) — FIT downloads returning 0 files. The downloads were failing because Camoufox's browser-side `fetch()` couldn't complete the binary arrayBuffer roundtrip reliably — you confirmed that switching to `--chrome` fixed it, which proves the issue was Camoufox-specific. This PR removes Camoufox entirely and makes Chrome the only engine. It also fixes an f-string injection issue where download URLs were interpolated directly into JavaScript strings instead of being passed as parameters. After upgrading, do FIT files and GPX/TCX exports download successfully?

- **#15** (@WRPSoft) — Windows requiring `--chrome` flag. Camoufox didn't work on Windows, forcing you to use `--chrome`. Since Chrome is now the default and only engine, the `--chrome` flag no longer exists. After upgrading, does `garmin-givemydata --fit-only --latest` work without it?

## Not addressed in this PR

- #17 (trackpoint extraction) — separate feature
- #13 (body battery/calories parsing) — partially fixed on `dev`, orthogonal to engine swap