### PR TITLE
fix: filter activity pagination by date range

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,6 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     labels:
-      - ci
+      - dependencies
     commit-message:
       prefix: "ci"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist/
 *.db-wal
 garmin_session.json
 .mcp.json
+.codex
+.codex/
+downloaded_files/

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -901,11 +901,24 @@ class GarminClient:
         s_date = start_date or (date.fromisoformat(today) - timedelta(days=30)).isoformat()
 
         all_results = {}
+        fetched_activity_ids = []
+
+        def _remember_activity_ids(data):
+            if not isinstance(data, list):
+                return
+            for activity in data:
+                if not isinstance(activity, dict):
+                    continue
+                aid = activity.get("activityId")
+                if aid:
+                    fetched_activity_ids.append(aid)
 
         def _process_batch(batch_result, cal_date=None):
             for name, result in batch_result.items():
                 if result.get("status") != 200 or not result.get("data"):
                     continue
+                if name in ("activities", "activities_range"):
+                    _remember_activity_ids(result["data"])
                 if on_batch:
                     on_batch(name, result["data"], cal_date=cal_date)
                 else:
@@ -945,6 +958,7 @@ class GarminClient:
             if not isinstance(activities_page, list) or len(activities_page) == 0:
                 break
             print(f"    Activities page: fetched {len(activities_page)} more (offset {page_start})")
+            _remember_activity_ids(activities_page)
             if on_batch:
                 for a in activities_page:
                     on_batch("activities", a)
@@ -1020,16 +1034,17 @@ class GarminClient:
                         all_results[base_name] = {"status": 200, "data": [entry]}
 
         # 5. Per-activity detail data
-        activity_ids = []
+        activity_ids = list(dict.fromkeys(fetched_activity_ids))
 
-        for name_key, result in all_results.items():
-            if name_key in ("activities", "activities_range"):
-                data = result.get("data", [])
-                if isinstance(data, list):
-                    for a in data:
-                        aid = a.get("activityId")
-                        if aid:
-                            activity_ids.append(aid)
+        if not activity_ids:
+            for name_key, result in all_results.items():
+                if name_key in ("activities", "activities_range"):
+                    data = result.get("data", [])
+                    if isinstance(data, list):
+                        for a in data:
+                            aid = a.get("activityId")
+                            if aid:
+                                activity_ids.append(aid)
 
         if not activity_ids and on_batch:
             try:

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -28,6 +28,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from seleniumbase import Driver
 
 from .endpoints import (
+    activities_search_url,
     activity_detail_endpoints,
     daily_graphql,
     daily_rest,
@@ -934,9 +935,7 @@ class GarminClient:
         page_start = 100
         while True:
             act_result = self._fetch_batch(
-                {
-                    f"activities_page_{page_start}": f"/gc-api/activitylist-service/activities/search/activities?limit=100&start={page_start}&startDate={s_date}&endDate={e_date}"
-                },
+                {f"activities_page_{page_start}": activities_search_url(s_date, e_date, offset=page_start)},
                 {},
             )
             page_data = act_result.get(f"activities_page_{page_start}", {})
@@ -1034,9 +1033,7 @@ class GarminClient:
 
         if not activity_ids and on_batch:
             try:
-                act_data = self.api_fetch(
-                    f"/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0&startDate={s_date}&endDate={e_date}"
-                )
+                act_data = self.api_fetch(activities_search_url(s_date, e_date, limit=1000))
                 if isinstance(act_data, list):
                     all_api_ids = [a.get("activityId") for a in act_data if a.get("activityId")]
                     activity_ids = [aid for aid in all_api_ids if aid not in (known_activity_ids or set())]

--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -930,12 +930,12 @@ class GarminClient:
         full = self._fetch_batch(full_rest, full_gql)
         _process_batch(full)
 
-        # 2b. Paginate through ALL activities
+        # 2b. Paginate remaining activities within the date range
         page_start = 100
         while True:
             act_result = self._fetch_batch(
                 {
-                    f"activities_page_{page_start}": f"/gc-api/activitylist-service/activities/search/activities?limit=100&start={page_start}"
+                    f"activities_page_{page_start}": f"/gc-api/activitylist-service/activities/search/activities?limit=100&start={page_start}&startDate={s_date}&endDate={e_date}"
                 },
                 {},
             )
@@ -1035,7 +1035,7 @@ class GarminClient:
         if not activity_ids and on_batch:
             try:
                 act_data = self.api_fetch(
-                    "/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0"
+                    f"/gc-api/activitylist-service/activities/search/activities?limit=1000&start=0&startDate={s_date}&endDate={e_date}"
                 )
                 if isinstance(act_data, list):
                     all_api_ids = [a.get("activityId") for a in act_data if a.get("activityId")]

--- a/garmin_client/endpoints.py
+++ b/garmin_client/endpoints.py
@@ -44,9 +44,8 @@ def full_range_rest(display_name: str, start_date: str, end_date: str) -> dict:
     """REST endpoints that support full date ranges."""
     dn = display_name
     return {
-        # Note: this returns max ~20-100 activities per page. Pagination
-        # is handled in client.py fetch_all() to get ALL activities.
-        "activities": "/gc-api/activitylist-service/activities/search/activities?limit=100&start=0",
+        # Pagination is handled in client.py fetch_all().
+        "activities": f"/gc-api/activitylist-service/activities/search/activities?limit=100&start=0&startDate={start_date}&endDate={end_date}",
         "weight_range": f"/gc-api/weight-service/weight/dateRange?startDate={start_date}&endDate={end_date}",
         "weight_latest": f"/gc-api/weight-service/weight/latest?date={end_date}",
         "vo2max_trend": f"/gc-api/metrics-service/metrics/maxmet/daily/{start_date}/{end_date}",

--- a/garmin_client/endpoints.py
+++ b/garmin_client/endpoints.py
@@ -40,12 +40,17 @@ def profile_graphql(display_name: str) -> dict:
     }
 
 
+def activities_search_url(start_date: str, end_date: str, limit: int = 100, offset: int = 0) -> str:
+    """Build the activities search URL with date filtering."""
+    return f"/gc-api/activitylist-service/activities/search/activities?limit={limit}&start={offset}&startDate={start_date}&endDate={end_date}"
+
+
 def full_range_rest(display_name: str, start_date: str, end_date: str) -> dict:
     """REST endpoints that support full date ranges."""
     dn = display_name
     return {
         # Pagination is handled in client.py fetch_all().
-        "activities": f"/gc-api/activitylist-service/activities/search/activities?limit=100&start=0&startDate={start_date}&endDate={end_date}",
+        "activities": activities_search_url(start_date, end_date),
         "weight_range": f"/gc-api/weight-service/weight/dateRange?startDate={start_date}&endDate={end_date}",
         "weight_latest": f"/gc-api/weight-service/weight/latest?date={end_date}",
         "vo2max_trend": f"/gc-api/metrics-service/metrics/maxmet/daily/{start_date}/{end_date}",

--- a/garmin_givemydata.py
+++ b/garmin_givemydata.py
@@ -274,7 +274,9 @@ examples:
         help="Download FIT files only, skip health data sync",
     )
     fit_group.add_argument(
-        "--latest", action="store_true", help="Download only the latest FIT file (use with --fit-only)"
+        "--latest",
+        action="store_true",
+        help="Fetch only today's data (or download only the latest FIT file with --fit-only)",
     )
     fit_group.add_argument(
         "--date", type=str, help="Download FIT file for a specific date YYYY-MM-DD (use with --fit-only)"
@@ -403,6 +405,11 @@ examples:
         mode = "full"
         start = (today - timedelta(days=365 * 10)).isoformat()
         end = today.isoformat()
+    elif args.latest and not args.fit_only:
+        mode = "incremental"
+        start = today.isoformat()
+        end = today.isoformat()
+        print(f"Fetching latest data for {today.isoformat()}")
     elif args.days:
         mode = "range"
         start = (today - timedelta(days=args.days)).isoformat()


### PR DESCRIPTION
## Summary

- Add `startDate` and `endDate` params to the activity search endpoint so only activities within the requested range are fetched
- Make `--latest` work for regular syncs — fetches only today's data

## Problem

1. Every sync — even a 1-day incremental — paginated through **all** activities the user has ever recorded. For a user with 3,500+ activities (#23), this meant 35+ API calls just for the activity list.

2. `--latest` only worked with `--fit-only`. Running `garmin-givemydata --latest` ignored the flag and did a full sync, which is not what users expect.

## What changed

- `endpoints.py`: `full_range_rest()` now passes `startDate`/`endDate` to the activities search URL
- `client.py`: pagination loop and activity ID fallback both include the date filter
- `garmin_givemydata.py`: `--latest` without `--fit-only` now sets the date range to today only

## How to test

```bash
git clone https://github.com/nrvim/garmin-givemydata.git
cd garmin-givemydata
git checkout fix/incremental-activity-pagination
bash setup.sh
```

If you already have a database with data:

```bash
# Quick sync — today only
garmin-givemydata --latest

# Normal incremental sync — should no longer paginate through all activities
garmin-givemydata
```

Before this fix you'd see dozens of `Activities page: fetched 100 more (offset ...)` lines. After the fix, you should see zero (or just a few if you had many activities that day).

Fixes #23