### PR TITLE
Add .gitignore entries for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,6 @@ garmin_data_for_ai.json
 .env
 .env.*
 
-# Secrets / credentials
-*.pem
-*.key
-credentials.json
-
 # OS
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,17 @@ __pycache__/
 browser_profile*/
 garmin_data_for_ai.json
 .env
+.env.*
+
+# Secrets / credentials
+*.pem
+*.key
+credentials.json
+
+# OS
+.DS_Store
+Thumbs.db
+
 debug.log
 test_results.log
 full_run.log


### PR DESCRIPTION
The .gitignore covers `.env` but not `.env.*` variants (like `.env.local`, `.env.production`), private keys, or credential files. Since this project handles Garmin credentials, added patterns for those plus OS artifacts to be safe.