### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "garmin-givemydata"
-version = "0.1.9"
+version = "0.1.10"
 description = "Get your Garmin Connect data back. Browser-based extraction + 47-table SQLite database + MCP server for AI analysis."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump package version to 0.1.10 for the next release

## Verification

- python3 -m compileall garmin_client garmin_mcp garmin_givemydata.py run_mcp.py
- python3 -m ruff check .
- python3 -m ruff format --check .