### PR TITLE
fix: backfill body_battery aggregates from daily_summary

### DIFF
--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -715,11 +715,21 @@ def init_db(conn: sqlite3.Connection) -> None:
     needs_bb_backfill = conn.execute(
         """SELECT 1 FROM daily_summary ds
            LEFT JOIN body_battery bb ON bb.calendar_date = ds.calendar_date
-           WHERE (ds.body_battery_highest IS NOT NULL
-                  OR ds.body_battery_lowest IS NOT NULL
-                  OR ds.body_battery_charged IS NOT NULL
-                  OR ds.body_battery_drained IS NOT NULL)
-             AND (bb.calendar_date IS NULL OR bb.highest IS NULL)
+           WHERE (ds.body_battery_highest      IS NOT NULL
+                  OR ds.body_battery_lowest        IS NOT NULL
+                  OR ds.body_battery_charged       IS NOT NULL
+                  OR ds.body_battery_drained       IS NOT NULL
+                  OR ds.body_battery_most_recent   IS NOT NULL
+                  OR ds.body_battery_at_wake       IS NOT NULL
+                  OR ds.body_battery_during_sleep  IS NOT NULL)
+             AND (bb.calendar_date IS NULL
+                  OR (bb.highest      IS NULL AND ds.body_battery_highest      IS NOT NULL)
+                  OR (bb.lowest       IS NULL AND ds.body_battery_lowest       IS NOT NULL)
+                  OR (bb.charged      IS NULL AND ds.body_battery_charged      IS NOT NULL)
+                  OR (bb.drained      IS NULL AND ds.body_battery_drained      IS NOT NULL)
+                  OR (bb.most_recent  IS NULL AND ds.body_battery_most_recent  IS NOT NULL)
+                  OR (bb.at_wake      IS NULL AND ds.body_battery_at_wake      IS NOT NULL)
+                  OR (bb.during_sleep IS NULL AND ds.body_battery_during_sleep IS NOT NULL))
            LIMIT 1"""
     ).fetchone()
     if needs_bb_backfill:
@@ -988,13 +998,13 @@ def upsert_body_battery_from_daily_summary(conn: sqlite3.Connection, record: dic
         INSERT INTO body_battery (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(calendar_date) DO UPDATE SET
-            charged      = excluded.charged,
-            drained      = excluded.drained,
-            highest      = excluded.highest,
-            lowest       = excluded.lowest,
-            most_recent  = excluded.most_recent,
-            at_wake      = excluded.at_wake,
-            during_sleep = excluded.during_sleep
+            charged      = COALESCE(excluded.charged,      body_battery.charged),
+            drained      = COALESCE(excluded.drained,      body_battery.drained),
+            highest      = COALESCE(excluded.highest,      body_battery.highest),
+            lowest       = COALESCE(excluded.lowest,       body_battery.lowest),
+            most_recent  = COALESCE(excluded.most_recent,  body_battery.most_recent),
+            at_wake      = COALESCE(excluded.at_wake,      body_battery.at_wake),
+            during_sleep = COALESCE(excluded.during_sleep, body_battery.during_sleep)
         """,
         (d, charged, drained, highest, lowest, most_recent, at_wake, during_sleep),
     )
@@ -1085,10 +1095,13 @@ def backfill_body_battery_from_daily_summaries(conn: sqlite3.Connection) -> None
             ds.body_battery_at_wake,
             ds.body_battery_during_sleep
         FROM daily_summary ds
-        WHERE ds.body_battery_highest IS NOT NULL
-           OR ds.body_battery_lowest IS NOT NULL
-           OR ds.body_battery_charged IS NOT NULL
-           OR ds.body_battery_drained IS NOT NULL
+        WHERE ds.body_battery_highest      IS NOT NULL
+           OR ds.body_battery_lowest       IS NOT NULL
+           OR ds.body_battery_charged      IS NOT NULL
+           OR ds.body_battery_drained      IS NOT NULL
+           OR ds.body_battery_most_recent  IS NOT NULL
+           OR ds.body_battery_at_wake      IS NOT NULL
+           OR ds.body_battery_during_sleep IS NOT NULL
         ON CONFLICT(calendar_date) DO UPDATE SET
             charged      = COALESCE(body_battery.charged, excluded.charged),
             drained      = COALESCE(body_battery.drained, excluded.drained),
@@ -1417,13 +1430,32 @@ def upsert_respiration(conn: sqlite3.Connection, record: dict, cal_date: str = N
 
 
 def upsert_body_battery(conn: sqlite3.Connection, record: dict, cal_date: str = None) -> None:
+    """Upsert a body_battery row from the events endpoint.
+
+    The events payload only carries time-series data, not the per-day
+    aggregate values (which live in daily_summary and are written via
+    upsert_body_battery_from_daily_summary). Use COALESCE on every
+    aggregate column so that calling this *after* the daily_summary path
+    does not erase the aggregates with NULLs from the events payload.
+    raw_json is always replaced with the latest events payload.
+    """
     d = cal_date or record.get("calendarDate") or record.get("date")
     if not d:
         return
     conn.execute(
-        """INSERT OR REPLACE INTO body_battery
+        """INSERT INTO body_battery
            (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(calendar_date) DO UPDATE SET
+               charged      = COALESCE(excluded.charged,      body_battery.charged),
+               drained      = COALESCE(excluded.drained,      body_battery.drained),
+               highest      = COALESCE(excluded.highest,      body_battery.highest),
+               lowest       = COALESCE(excluded.lowest,       body_battery.lowest),
+               most_recent  = COALESCE(excluded.most_recent,  body_battery.most_recent),
+               at_wake      = COALESCE(excluded.at_wake,      body_battery.at_wake),
+               during_sleep = COALESCE(excluded.during_sleep, body_battery.during_sleep),
+               raw_json     = excluded.raw_json
+        """,
         (
             d,
             record.get("bodyBatteryChargedValue") or record.get("charged"),

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -712,6 +712,19 @@ def init_db(conn: sqlite3.Connection) -> None:
     if needs_cal_backfill:
         backfill_calories_from_daily_summaries(conn)
 
+    needs_bb_backfill = conn.execute(
+        """SELECT 1 FROM daily_summary ds
+           LEFT JOIN body_battery bb ON bb.calendar_date = ds.calendar_date
+           WHERE (ds.body_battery_highest IS NOT NULL
+                  OR ds.body_battery_lowest IS NOT NULL
+                  OR ds.body_battery_charged IS NOT NULL
+                  OR ds.body_battery_drained IS NOT NULL)
+             AND (bb.calendar_date IS NULL OR bb.highest IS NULL)
+           LIMIT 1"""
+    ).fetchone()
+    if needs_bb_backfill:
+        backfill_body_battery_from_daily_summaries(conn)
+
     conn.commit()
 
 
@@ -945,6 +958,46 @@ def upsert_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
         },
     )
     upsert_calories_from_daily_summary(conn, record)
+    upsert_body_battery_from_daily_summary(conn, record)
+
+
+def upsert_body_battery_from_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
+    """Backfill body_battery aggregate columns from a daily_summary record.
+
+    The body_battery_events endpoint only returns time-series data; the
+    aggregates (highest/lowest/charged/drained/etc.) live in daily_summary.
+    Mirrors upsert_calories_from_daily_summary.
+
+    raw_json is intentionally not touched here so the events-endpoint
+    time-series payload (when present) is preserved.
+    """
+    d = record.get("calendarDate")
+    if not d:
+        return
+    charged = record.get("bodyBatteryChargedValue")
+    drained = record.get("bodyBatteryDrainedValue")
+    highest = record.get("bodyBatteryHighestValue")
+    lowest = record.get("bodyBatteryLowestValue")
+    most_recent = record.get("bodyBatteryMostRecentValue")
+    at_wake = record.get("bodyBatteryAtWakeTime")
+    during_sleep = record.get("bodyBatteryDuringSleep")
+    if all(v is None for v in (charged, drained, highest, lowest, most_recent, at_wake, during_sleep)):
+        return
+    conn.execute(
+        """
+        INSERT INTO body_battery (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(calendar_date) DO UPDATE SET
+            charged      = excluded.charged,
+            drained      = excluded.drained,
+            highest      = excluded.highest,
+            lowest       = excluded.lowest,
+            most_recent  = excluded.most_recent,
+            at_wake      = excluded.at_wake,
+            during_sleep = excluded.during_sleep
+        """,
+        (d, charged, drained, highest, lowest, most_recent, at_wake, during_sleep),
+    )
 
 
 def upsert_calories_from_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
@@ -1003,6 +1056,47 @@ def backfill_calories_from_daily_summaries(conn: sqlite3.Connection) -> None:
               ds.bmr_kilocalories IS NOT NULL OR
               ds.remaining_kilocalories IS NOT NULL
           )
+        """
+    )
+
+
+def backfill_body_battery_from_daily_summaries(conn: sqlite3.Connection) -> None:
+    """Backfill body_battery aggregate columns from daily_summary.
+
+    Historically body_battery rows were created from the body_battery_events
+    endpoint which only contains time-series data — the aggregate columns
+    (highest/lowest/charged/drained/etc.) were left NULL even though the
+    same values lived in daily_summary the whole time. See issue #13.
+
+    Inserts a body_battery row for any daily_summary date that doesn't have
+    one, and fills NULL aggregate columns on existing rows. raw_json is left
+    untouched so events-endpoint time-series data is preserved.
+    """
+    conn.execute(
+        """
+        INSERT INTO body_battery (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep)
+        SELECT
+            ds.calendar_date,
+            ds.body_battery_charged,
+            ds.body_battery_drained,
+            ds.body_battery_highest,
+            ds.body_battery_lowest,
+            ds.body_battery_most_recent,
+            ds.body_battery_at_wake,
+            ds.body_battery_during_sleep
+        FROM daily_summary ds
+        WHERE ds.body_battery_highest IS NOT NULL
+           OR ds.body_battery_lowest IS NOT NULL
+           OR ds.body_battery_charged IS NOT NULL
+           OR ds.body_battery_drained IS NOT NULL
+        ON CONFLICT(calendar_date) DO UPDATE SET
+            charged      = COALESCE(body_battery.charged, excluded.charged),
+            drained      = COALESCE(body_battery.drained, excluded.drained),
+            highest      = COALESCE(body_battery.highest, excluded.highest),
+            lowest       = COALESCE(body_battery.lowest, excluded.lowest),
+            most_recent  = COALESCE(body_battery.most_recent, excluded.most_recent),
+            at_wake      = COALESCE(body_battery.at_wake, excluded.at_wake),
+            during_sleep = COALESCE(body_battery.during_sleep, excluded.during_sleep)
         """
     )
 

--- a/tests/test_db_body_battery.py
+++ b/tests/test_db_body_battery.py
@@ -1,0 +1,132 @@
+"""Regression tests for body_battery aggregate backfill from daily_summary.
+
+Issue #13: the body_battery_events endpoint only returns time-series data,
+so the body_battery table's aggregate columns (highest/lowest/charged/etc.)
+were always NULL even though the same values lived in daily_summary.
+"""
+
+import json
+
+from garmin_mcp.db import (
+    backfill_body_battery_from_daily_summaries,
+    upsert_body_battery,
+    upsert_body_battery_from_daily_summary,
+    upsert_daily_summary,
+)
+
+
+def _ds(date: str, **bb) -> dict:
+    """Build a daily_summary record with body_battery aggregate fields."""
+    rec = {"calendarDate": date}
+    rec.update(
+        {
+            "bodyBatteryChargedValue": bb.get("charged"),
+            "bodyBatteryDrainedValue": bb.get("drained"),
+            "bodyBatteryHighestValue": bb.get("highest"),
+            "bodyBatteryLowestValue": bb.get("lowest"),
+            "bodyBatteryMostRecentValue": bb.get("most_recent"),
+            "bodyBatteryAtWakeTime": bb.get("at_wake"),
+            "bodyBatteryDuringSleep": bb.get("during_sleep"),
+        }
+    )
+    return rec
+
+
+def _bb_row(conn, date: str) -> dict:
+    return dict(conn.execute("SELECT * FROM body_battery WHERE calendar_date = ?", (date,)).fetchone() or {})
+
+
+class TestUpsertBodyBatteryFromDailySummary:
+    def test_inserts_new_row_with_aggregates(self, temp_db):
+        upsert_body_battery_from_daily_summary(
+            temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, drained=54, at_wake=99)
+        )
+        row = _bb_row(temp_db, "2026-05-01")
+        assert row["highest"] == 99
+        assert row["lowest"] == 47
+        assert row["charged"] == 53
+        assert row["drained"] == 54
+        assert row["at_wake"] == 99
+
+    def test_updates_existing_row_without_clobbering_raw_json(self, temp_db):
+        # Simulate the events endpoint having populated raw_json + a row
+        # but NOT the aggregate columns
+        events_record = {"bodyBattery": {"data": [["2026-05-01T22:00", 50, 1, 3]]}}
+        upsert_body_battery(temp_db, events_record, cal_date="2026-05-01")
+        before = _bb_row(temp_db, "2026-05-01")
+        assert before["highest"] is None
+        assert before["raw_json"] is not None
+
+        # Now run the daily_summary path
+        upsert_body_battery_from_daily_summary(temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53))
+
+        after = _bb_row(temp_db, "2026-05-01")
+        assert after["highest"] == 99
+        assert after["lowest"] == 47
+        assert after["charged"] == 53
+        # raw_json from events endpoint must survive
+        assert after["raw_json"] == before["raw_json"]
+        assert "bodyBattery" in json.loads(after["raw_json"])
+
+    def test_skips_when_all_values_are_none(self, temp_db):
+        # No body_battery fields in the daily_summary — should not insert
+        upsert_body_battery_from_daily_summary(temp_db, {"calendarDate": "2026-05-01"})
+        assert _bb_row(temp_db, "2026-05-01") == {}
+
+    def test_skips_when_no_calendar_date(self, temp_db):
+        upsert_body_battery_from_daily_summary(temp_db, {"bodyBatteryHighestValue": 99})
+        assert temp_db.execute("SELECT COUNT(*) FROM body_battery").fetchone()[0] == 0
+
+
+class TestBackfillBodyBatteryFromDailySummaries:
+    def test_inserts_missing_rows_and_fills_existing_nulls(self, temp_db):
+        # Three daily_summary rows with body_battery data
+        upsert_daily_summary(temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, drained=54))
+        upsert_daily_summary(temp_db, _ds("2026-05-02", highest=80, lowest=38, charged=56, drained=32))
+        upsert_daily_summary(temp_db, _ds("2026-05-03", highest=84, lowest=38, charged=37, drained=51))
+        # Wipe the body_battery rows that upsert_daily_summary just created
+        # to simulate the pre-fix state where they never existed
+        temp_db.execute("DELETE FROM body_battery")
+        # Plus a body_battery row from the events endpoint with NULL aggregates
+        upsert_body_battery(
+            temp_db,
+            {"bodyBattery": {"data": [["2026-05-02T22:00", 50, 1, 3]]}},
+            cal_date="2026-05-02",
+        )
+        before = _bb_row(temp_db, "2026-05-02")
+        assert before["highest"] is None
+
+        backfill_body_battery_from_daily_summaries(temp_db)
+
+        # All three dates should now have aggregates populated
+        for date, expected_highest in (("2026-05-01", 99), ("2026-05-02", 80), ("2026-05-03", 84)):
+            row = _bb_row(temp_db, date)
+            assert row["highest"] == expected_highest, f"date {date}: highest={row.get('highest')}"
+
+        # Events-endpoint raw_json on 2026-05-02 must have survived
+        row_2 = _bb_row(temp_db, "2026-05-02")
+        assert row_2["raw_json"] is not None
+        assert "bodyBattery" in json.loads(row_2["raw_json"])
+
+    def test_does_not_overwrite_existing_aggregate(self, temp_db):
+        # daily_summary has highest=99, but body_battery already has highest=42
+        # (e.g. set by a different code path). The backfill must keep 42.
+        upsert_daily_summary(temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53))
+        temp_db.execute("UPDATE body_battery SET highest = 42 WHERE calendar_date = '2026-05-01'")
+        backfill_body_battery_from_daily_summaries(temp_db)
+        assert _bb_row(temp_db, "2026-05-01")["highest"] == 42
+
+    def test_skips_dates_without_body_battery_in_daily_summary(self, temp_db):
+        # daily_summary row with NO body battery data — backfill should not
+        # touch body_battery for that date
+        upsert_daily_summary(temp_db, {"calendarDate": "2026-05-01", "totalSteps": 10000})
+        backfill_body_battery_from_daily_summaries(temp_db)
+        assert temp_db.execute("SELECT COUNT(*) FROM body_battery").fetchone()[0] == 0
+
+    def test_idempotent(self, temp_db):
+        upsert_daily_summary(temp_db, _ds("2026-05-01", highest=99, charged=53))
+        backfill_body_battery_from_daily_summaries(temp_db)
+        first = _bb_row(temp_db, "2026-05-01")
+        backfill_body_battery_from_daily_summaries(temp_db)
+        second = _bb_row(temp_db, "2026-05-01")
+        assert first == second

--- a/tests/test_db_body_battery.py
+++ b/tests/test_db_body_battery.py
@@ -77,6 +77,47 @@ class TestUpsertBodyBatteryFromDailySummary:
         upsert_body_battery_from_daily_summary(temp_db, {"bodyBatteryHighestValue": 99})
         assert temp_db.execute("SELECT COUNT(*) FROM body_battery").fetchone()[0] == 0
 
+    def test_partial_daily_summary_does_not_clobber_existing_aggregates(self, temp_db):
+        # Realistic: a sync sets {highest, lowest, charged}. A later sync of
+        # the same date returns a partial daily_summary that only has highest.
+        # The other fields must not be wiped to NULL.
+        upsert_body_battery_from_daily_summary(
+            temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, at_wake=99)
+        )
+        upsert_body_battery_from_daily_summary(temp_db, _ds("2026-05-01", highest=80))
+        row = _bb_row(temp_db, "2026-05-01")
+        assert row["highest"] == 80  # latest value wins
+        assert row["lowest"] == 47  # preserved
+        assert row["charged"] == 53  # preserved
+        assert row["at_wake"] == 99  # preserved
+
+
+class TestUpsertBodyBatteryEventsOrdering:
+    """Real sync order is daily_summary FIRST, body_battery_events AFTER.
+    The events upsert must not wipe the aggregates that daily_summary just
+    populated (issue #13 + Copilot review on PR #40).
+    """
+
+    def test_events_payload_after_daily_summary_preserves_aggregates(self, temp_db):
+        # Step 1: daily_summary populates aggregates
+        upsert_body_battery_from_daily_summary(
+            temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, drained=54, at_wake=99)
+        )
+        # Step 2: events endpoint fires with time-series data, no aggregates
+        events_payload = {"bodyBattery": {"data": [["2026-05-01T22:00", 50, 1, 3]]}}
+        upsert_body_battery(temp_db, events_payload, cal_date="2026-05-01")
+
+        row = _bb_row(temp_db, "2026-05-01")
+        # Aggregates from daily_summary must survive the events upsert
+        assert row["highest"] == 99
+        assert row["lowest"] == 47
+        assert row["charged"] == 53
+        assert row["drained"] == 54
+        assert row["at_wake"] == 99
+        # raw_json now reflects the events payload (the time-series is what
+        # the body_battery row's raw_json is meant to hold)
+        assert "bodyBattery" in json.loads(row["raw_json"])
+
 
 class TestBackfillBodyBatteryFromDailySummaries:
     def test_inserts_missing_rows_and_fills_existing_nulls(self, temp_db):


### PR DESCRIPTION
## Summary

Refs #13. The body_battery_events endpoint only returns time-series data — it never populates the aggregate columns (`highest`, `lowest`, `charged`, `drained`, `most_recent`, `at_wake`, `during_sleep`). Those values exist in `daily_summary` all along but were never copied across, so the body_battery table held thousands of rows of NULLs and `garmin_body_battery` MCP tool was useless even though the data existed in another table.

## Live evidence (before this PR)

```
daily_summary  2026-05-02: highest=99, lowest=47, charged=53, drained=54
body_battery   2026-05-02: highest=None, lowest=None, charged=None, drained=None
```

## Fix

Two pieces, mirroring the existing `calories_from_daily_summary` pattern:

1. **`upsert_body_battery_from_daily_summary()`** — called from `upsert_daily_summary` on every sync. `INSERT … ON CONFLICT DO UPDATE` so the aggregate columns are always refreshed without clobbering `raw_json` (which holds the events endpoint's time-series data when present).

2. **`backfill_body_battery_from_daily_summaries()`** — bulk migration for existing rows. Wired into `init_db()` with a guard that only runs when there's actually work to do. Uses `COALESCE` to fill NULL aggregates without overwriting any pre-existing values.

## Live verification

Ran the backfill against a real, populated database (3,663 daily_summary rows, 3,645 body_battery rows):

```
BEFORE init_db:
  body_battery: 3645 rows, with_highest=0, with_charged=0

AFTER init_db:
  body_battery: 3645 rows, with_highest=525, with_charged=525, with_drained=525, with_at_wake=465

Sample rows:
  2026-05-02: highest=99, lowest=47, charged=53, drained=54, at_wake=99
  2026-05-01: highest=100, lowest=51, charged=49, drained=55, at_wake=100
  2026-04-30: highest=80, lowest=38, charged=56, drained=32, at_wake=80
```

525 = the number of dates that have body_battery data in `daily_summary` (since Oct 2024). Pre-Oct 2024 rows correctly stay NULL because the device didn't track it.

`SELECT COUNT(*) FROM daily_summary ds JOIN body_battery bb ON bb.calendar_date = ds.calendar_date WHERE ds.body_battery_highest IS NOT NULL AND bb.highest IS NULL` returns **0** after the migration.

## Tests

8 new unit tests in `tests/test_db_body_battery.py`:

- `test_inserts_new_row_with_aggregates`
- `test_updates_existing_row_without_clobbering_raw_json` (the critical one — verifies the events endpoint's time-series stays intact)
- `test_skips_when_all_values_are_none`
- `test_skips_when_no_calendar_date`
- `test_inserts_missing_rows_and_fills_existing_nulls` (bulk backfill)
- `test_does_not_overwrite_existing_aggregate`
- `test_skips_dates_without_body_battery_in_daily_summary`
- `test_idempotent`

All 43 tests in the suite pass; ruff clean.

## Impact

- **Existing users:** on next `garmin-mcp` (or any) run, `init_db` detects the missing data and runs the bulk backfill once. Subsequent runs no-op (the guard query returns 0 rows).
- **New syncs:** `upsert_daily_summary` now also writes the body_battery aggregates, so they stay current.
- **MCP tool `garmin_body_battery`:** finally returns useful data instead of NULLs.
- **No schema change.** No data is dropped or overwritten.

## Stacked on?

This stacks cleanly on main (off `eae73fc`). Independent of PR #39 (pagination fix) — both can merge in any order.

Diagnosis credit: @SuperRaven, @dylix, @SPooKfpv in the issue thread.