### PR TITLE
chore: pretty CSV headers for badges, challenges, personal records

### DIFF
--- a/garmin_mcp/export.py
+++ b/garmin_mcp/export.py
@@ -261,6 +261,27 @@ _CSV_COLUMN_MAP = {
         "chronological_age": "Chronological Age",
         "fitness_age": "Fitness Age",
     },
+    "earned_badges": {
+        "badge_id": "Badge ID",
+        "badge_key": "Badge Key",
+        "badge_name": "Badge Name",
+        "badge_category": "Category",
+        "earned_date": "Earned Date",
+        "earned_number": "Earned Count",
+    },
+    "challenges": {
+        "id": "Challenge ID",
+        "challenge_type": "Type",
+    },
+    "personal_record": {
+        "id": "Record ID",
+        "display_name": "Name",
+        "activity_type": "Activity Type",
+        "pr_type": "PR Type",
+        "value": "Value",
+        "pr_date": "Date",
+        "activity_id": "Activity ID",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Refs #33. The end-to-end pipeline for badges/challenges/PRs already works in v0.1.11 — tables exist, sync populates them, MCP tools expose them, JSON export handles them generically. The only gap @flocsy's request didn't fully cover was the CSV exporter: without a \`_CSV_COLUMN_MAP\` entry it falls back to raw snake_case column names. This adds pretty headers for the three.

## Before / after

\`earned_badges.csv\`:

\`\`\`diff
- badge_id,badge_key,badge_name,badge_category,earned_date,earned_number
+ Badge ID,Badge Key,Badge Name,Category,Earned Date,Earned Count
\`\`\`

\`personal_record.csv\`:

\`\`\`diff
- id,display_name,activity_type,pr_type,value,pr_date,activity_id
+ Record ID,Name,Activity Type,PR Type,Value,Date,Activity ID
\`\`\`

\`challenges.csv\`:

\`\`\`diff
- id,challenge_type
+ Challenge ID,Type
\`\`\`

## Test plan

- [x] Verified locally on a populated DB (45 badges, 19 PRs, 0 challenges) that the headers render as expected
- [x] Empty \`challenges\` table correctly skipped (export_csv's existing behavior)
- [x] All 35 tests pass; ruff clean