### PR TITLE
fix: populate avg_hr and overnight HR from sample arrays

### DIFF
--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -1056,9 +1056,7 @@ def upsert_sleep(conn: sqlite3.Connection, record: dict) -> None:
         return
     calendar_date = dto.get("calendarDate") or record.get("date")
     avg_hr_sleep = (
-        dto.get("averageHrSleep")
-        or dto.get("avgSleepHR")
-        or _mean_sample_values(record.get("sleepHeartRate"), "value")
+        dto.get("averageHrSleep") or dto.get("avgSleepHR") or _mean_sample_values(record.get("sleepHeartRate"), "value")
     )
     conn.execute(
         """
@@ -1287,9 +1285,7 @@ def upsert_heart_rate(conn: sqlite3.Connection, record: dict, cal_date: str = No
     if not d:
         return
     avg_hr = (
-        record.get("averageHeartRate")
-        or record.get("avgHR")
-        or _mean_sample_values(record.get("heartRateValues"), 1)
+        record.get("averageHeartRate") or record.get("avgHR") or _mean_sample_values(record.get("heartRateValues"), 1)
     )
     conn.execute(
         "INSERT OR REPLACE INTO heart_rate (calendar_date, resting_hr, min_hr, max_hr, avg_hr, raw_json) "

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -1026,12 +1026,40 @@ def backfill_hrv_timeline_counts(conn: sqlite3.Connection) -> None:
     )
 
 
+def _mean_sample_values(samples: Any, value_key) -> Optional[float]:
+    """Mean of positive numeric values in a Garmin time-series array.
+
+    Garmin returns HR/SpO2 timelines as either ``[{startGMT, value}, ...]`` or
+    ``[[ts, value], ...]``. Missing samples appear as ``None`` or ``0``;
+    ignore both.
+    """
+    if not isinstance(samples, list):
+        return None
+    vals: list[float] = []
+    for s in samples:
+        v = None
+        if isinstance(s, dict):
+            v = s.get(value_key)
+        elif isinstance(s, (list, tuple)) and len(s) > value_key:
+            v = s[value_key]
+        if isinstance(v, (int, float)) and v > 0:
+            vals.append(float(v))
+    if not vals:
+        return None
+    return round(sum(vals) / len(vals), 1)
+
+
 def upsert_sleep(conn: sqlite3.Connection, record: dict) -> None:
     dto: dict[str, Any] = record.get("dailySleepDTO") or record
     sleep_seconds = dto.get("sleepTimeSeconds")
     if sleep_seconds is None:
         return
     calendar_date = dto.get("calendarDate") or record.get("date")
+    avg_hr_sleep = (
+        dto.get("averageHrSleep")
+        or dto.get("avgSleepHR")
+        or _mean_sample_values(record.get("sleepHeartRate"), "value")
+    )
     conn.execute(
         """
         INSERT OR REPLACE INTO sleep (
@@ -1062,7 +1090,7 @@ def upsert_sleep(conn: sqlite3.Connection, record: dict) -> None:
             "awake_count": dto.get("awakeSleepCount") or dto.get("awakeCount"),
             "average_spo2": dto.get("averageSpO2Value"),
             "lowest_spo2": dto.get("lowestSpO2Value"),
-            "average_hr_sleep": dto.get("averageHrSleep") or dto.get("avgSleepHR"),
+            "average_hr_sleep": avg_hr_sleep,
             "average_respiration": dto.get("averageRespirationValue"),
             "lowest_respiration": dto.get("lowestRespirationValue"),
             "highest_respiration": dto.get("highestRespirationValue"),
@@ -1258,6 +1286,11 @@ def upsert_heart_rate(conn: sqlite3.Connection, record: dict, cal_date: str = No
     d = cal_date or record.get("calendarDate") or record.get("date")
     if not d:
         return
+    avg_hr = (
+        record.get("averageHeartRate")
+        or record.get("avgHR")
+        or _mean_sample_values(record.get("heartRateValues"), 1)
+    )
     conn.execute(
         "INSERT OR REPLACE INTO heart_rate (calendar_date, resting_hr, min_hr, max_hr, avg_hr, raw_json) "
         "VALUES (?, ?, ?, ?, ?, ?)",
@@ -1266,7 +1299,7 @@ def upsert_heart_rate(conn: sqlite3.Connection, record: dict, cal_date: str = No
             record.get("restingHeartRate") or record.get("restingHR"),
             record.get("minHeartRate") or record.get("minHR"),
             record.get("maxHeartRate") or record.get("maxHR"),
-            record.get("averageHeartRate") or record.get("avgHR"),
+            avg_hr,
             json.dumps(record),
         ),
     )


### PR DESCRIPTION
## Summary

`heart_rate.avg_hr` and `sleep.average_hr_sleep` were always `NULL` because the upsert helpers looked up fields the Garmin API does not return — `averageHeartRate`/`avgHR` on the dailyHeartRate response and `averageHrSleep`/`avgSleepHR` on the sleep DTO.

The API ships the underlying samples instead:

- `dailyHeartRate` returns minute-resolution samples in `heartRateValues` (`[[ts, bpm], ...]`).
- `dailySleepData` returns the overnight HR timeline in top-level `sleepHeartRate` (`[{startGMT, value}, ...]`).

This PR adds a small `_mean_sample_values` helper and uses it as a fallback in `upsert_heart_rate` and `upsert_sleep`. The legacy field names are kept so any future API change that adds a precomputed average still wins.

Verified locally:
- 149/149 sleep nights now have `average_hr_sleep`.
- 150 of the most recent days got `avg_hr`. Older days (~1100) returned `heartRateValues: null` from Garmin (their API only retains minute samples for a few months), so `avg_hr` is genuinely unrecoverable for those — `resting_hr`/`min_hr`/`max_hr` were unaffected and remain populated.

## Test plan

- [x] In-memory upsert covers four cases: sleep computed from `sleepHeartRate`, HR computed from `heartRateValues`, explicit `averageHeartRate` still wins when present, missing samples → `NULL`.
- [x] Backfill ran against a real DB (1239 HR rows, 149 sleep rows); spot-checked values match Garmin Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)