### PR TITLE
feat: surface hidden Garmin fields via migrations and broaden MCP exposure

### DIFF
--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -715,11 +715,21 @@ def init_db(conn: sqlite3.Connection) -> None:
     needs_bb_backfill = conn.execute(
         """SELECT 1 FROM daily_summary ds
            LEFT JOIN body_battery bb ON bb.calendar_date = ds.calendar_date
-           WHERE (ds.body_battery_highest IS NOT NULL
-                  OR ds.body_battery_lowest IS NOT NULL
-                  OR ds.body_battery_charged IS NOT NULL
-                  OR ds.body_battery_drained IS NOT NULL)
-             AND (bb.calendar_date IS NULL OR bb.highest IS NULL)
+           WHERE (ds.body_battery_highest      IS NOT NULL
+                  OR ds.body_battery_lowest        IS NOT NULL
+                  OR ds.body_battery_charged       IS NOT NULL
+                  OR ds.body_battery_drained       IS NOT NULL
+                  OR ds.body_battery_most_recent   IS NOT NULL
+                  OR ds.body_battery_at_wake       IS NOT NULL
+                  OR ds.body_battery_during_sleep  IS NOT NULL)
+             AND (bb.calendar_date IS NULL
+                  OR (bb.highest      IS NULL AND ds.body_battery_highest      IS NOT NULL)
+                  OR (bb.lowest       IS NULL AND ds.body_battery_lowest       IS NOT NULL)
+                  OR (bb.charged      IS NULL AND ds.body_battery_charged      IS NOT NULL)
+                  OR (bb.drained      IS NULL AND ds.body_battery_drained      IS NOT NULL)
+                  OR (bb.most_recent  IS NULL AND ds.body_battery_most_recent  IS NOT NULL)
+                  OR (bb.at_wake      IS NULL AND ds.body_battery_at_wake      IS NOT NULL)
+                  OR (bb.during_sleep IS NULL AND ds.body_battery_during_sleep IS NOT NULL))
            LIMIT 1"""
     ).fetchone()
     if needs_bb_backfill:
@@ -988,13 +998,13 @@ def upsert_body_battery_from_daily_summary(conn: sqlite3.Connection, record: dic
         INSERT INTO body_battery (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(calendar_date) DO UPDATE SET
-            charged      = excluded.charged,
-            drained      = excluded.drained,
-            highest      = excluded.highest,
-            lowest       = excluded.lowest,
-            most_recent  = excluded.most_recent,
-            at_wake      = excluded.at_wake,
-            during_sleep = excluded.during_sleep
+            charged      = COALESCE(excluded.charged,      body_battery.charged),
+            drained      = COALESCE(excluded.drained,      body_battery.drained),
+            highest      = COALESCE(excluded.highest,      body_battery.highest),
+            lowest       = COALESCE(excluded.lowest,       body_battery.lowest),
+            most_recent  = COALESCE(excluded.most_recent,  body_battery.most_recent),
+            at_wake      = COALESCE(excluded.at_wake,      body_battery.at_wake),
+            during_sleep = COALESCE(excluded.during_sleep, body_battery.during_sleep)
         """,
         (d, charged, drained, highest, lowest, most_recent, at_wake, during_sleep),
     )
@@ -1085,10 +1095,13 @@ def backfill_body_battery_from_daily_summaries(conn: sqlite3.Connection) -> None
             ds.body_battery_at_wake,
             ds.body_battery_during_sleep
         FROM daily_summary ds
-        WHERE ds.body_battery_highest IS NOT NULL
-           OR ds.body_battery_lowest IS NOT NULL
-           OR ds.body_battery_charged IS NOT NULL
-           OR ds.body_battery_drained IS NOT NULL
+        WHERE ds.body_battery_highest      IS NOT NULL
+           OR ds.body_battery_lowest       IS NOT NULL
+           OR ds.body_battery_charged      IS NOT NULL
+           OR ds.body_battery_drained      IS NOT NULL
+           OR ds.body_battery_most_recent  IS NOT NULL
+           OR ds.body_battery_at_wake      IS NOT NULL
+           OR ds.body_battery_during_sleep IS NOT NULL
         ON CONFLICT(calendar_date) DO UPDATE SET
             charged      = COALESCE(body_battery.charged, excluded.charged),
             drained      = COALESCE(body_battery.drained, excluded.drained),
@@ -1417,13 +1430,32 @@ def upsert_respiration(conn: sqlite3.Connection, record: dict, cal_date: str = N
 
 
 def upsert_body_battery(conn: sqlite3.Connection, record: dict, cal_date: str = None) -> None:
+    """Upsert a body_battery row from the events endpoint.
+
+    The events payload only carries time-series data, not the per-day
+    aggregate values (which live in daily_summary and are written via
+    upsert_body_battery_from_daily_summary). Use COALESCE on every
+    aggregate column so that calling this *after* the daily_summary path
+    does not erase the aggregates with NULLs from the events payload.
+    raw_json is always replaced with the latest events payload.
+    """
     d = cal_date or record.get("calendarDate") or record.get("date")
     if not d:
         return
     conn.execute(
-        """INSERT OR REPLACE INTO body_battery
+        """INSERT INTO body_battery
            (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(calendar_date) DO UPDATE SET
+               charged      = COALESCE(excluded.charged,      body_battery.charged),
+               drained      = COALESCE(excluded.drained,      body_battery.drained),
+               highest      = COALESCE(excluded.highest,      body_battery.highest),
+               lowest       = COALESCE(excluded.lowest,       body_battery.lowest),
+               most_recent  = COALESCE(excluded.most_recent,  body_battery.most_recent),
+               at_wake      = COALESCE(excluded.at_wake,      body_battery.at_wake),
+               during_sleep = COALESCE(excluded.during_sleep, body_battery.during_sleep),
+               raw_json     = excluded.raw_json
+        """,
         (
             d,
             record.get("bodyBatteryChargedValue") or record.get("charged"),

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -712,6 +712,19 @@ def init_db(conn: sqlite3.Connection) -> None:
     if needs_cal_backfill:
         backfill_calories_from_daily_summaries(conn)
 
+    needs_bb_backfill = conn.execute(
+        """SELECT 1 FROM daily_summary ds
+           LEFT JOIN body_battery bb ON bb.calendar_date = ds.calendar_date
+           WHERE (ds.body_battery_highest IS NOT NULL
+                  OR ds.body_battery_lowest IS NOT NULL
+                  OR ds.body_battery_charged IS NOT NULL
+                  OR ds.body_battery_drained IS NOT NULL)
+             AND (bb.calendar_date IS NULL OR bb.highest IS NULL)
+           LIMIT 1"""
+    ).fetchone()
+    if needs_bb_backfill:
+        backfill_body_battery_from_daily_summaries(conn)
+
     conn.commit()
 
 
@@ -945,6 +958,46 @@ def upsert_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
         },
     )
     upsert_calories_from_daily_summary(conn, record)
+    upsert_body_battery_from_daily_summary(conn, record)
+
+
+def upsert_body_battery_from_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
+    """Backfill body_battery aggregate columns from a daily_summary record.
+
+    The body_battery_events endpoint only returns time-series data; the
+    aggregates (highest/lowest/charged/drained/etc.) live in daily_summary.
+    Mirrors upsert_calories_from_daily_summary.
+
+    raw_json is intentionally not touched here so the events-endpoint
+    time-series payload (when present) is preserved.
+    """
+    d = record.get("calendarDate")
+    if not d:
+        return
+    charged = record.get("bodyBatteryChargedValue")
+    drained = record.get("bodyBatteryDrainedValue")
+    highest = record.get("bodyBatteryHighestValue")
+    lowest = record.get("bodyBatteryLowestValue")
+    most_recent = record.get("bodyBatteryMostRecentValue")
+    at_wake = record.get("bodyBatteryAtWakeTime")
+    during_sleep = record.get("bodyBatteryDuringSleep")
+    if all(v is None for v in (charged, drained, highest, lowest, most_recent, at_wake, during_sleep)):
+        return
+    conn.execute(
+        """
+        INSERT INTO body_battery (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(calendar_date) DO UPDATE SET
+            charged      = excluded.charged,
+            drained      = excluded.drained,
+            highest      = excluded.highest,
+            lowest       = excluded.lowest,
+            most_recent  = excluded.most_recent,
+            at_wake      = excluded.at_wake,
+            during_sleep = excluded.during_sleep
+        """,
+        (d, charged, drained, highest, lowest, most_recent, at_wake, during_sleep),
+    )
 
 
 def upsert_calories_from_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
@@ -1003,6 +1056,47 @@ def backfill_calories_from_daily_summaries(conn: sqlite3.Connection) -> None:
               ds.bmr_kilocalories IS NOT NULL OR
               ds.remaining_kilocalories IS NOT NULL
           )
+        """
+    )
+
+
+def backfill_body_battery_from_daily_summaries(conn: sqlite3.Connection) -> None:
+    """Backfill body_battery aggregate columns from daily_summary.
+
+    Historically body_battery rows were created from the body_battery_events
+    endpoint which only contains time-series data — the aggregate columns
+    (highest/lowest/charged/drained/etc.) were left NULL even though the
+    same values lived in daily_summary the whole time. See issue #13.
+
+    Inserts a body_battery row for any daily_summary date that doesn't have
+    one, and fills NULL aggregate columns on existing rows. raw_json is left
+    untouched so events-endpoint time-series data is preserved.
+    """
+    conn.execute(
+        """
+        INSERT INTO body_battery (calendar_date, charged, drained, highest, lowest, most_recent, at_wake, during_sleep)
+        SELECT
+            ds.calendar_date,
+            ds.body_battery_charged,
+            ds.body_battery_drained,
+            ds.body_battery_highest,
+            ds.body_battery_lowest,
+            ds.body_battery_most_recent,
+            ds.body_battery_at_wake,
+            ds.body_battery_during_sleep
+        FROM daily_summary ds
+        WHERE ds.body_battery_highest IS NOT NULL
+           OR ds.body_battery_lowest IS NOT NULL
+           OR ds.body_battery_charged IS NOT NULL
+           OR ds.body_battery_drained IS NOT NULL
+        ON CONFLICT(calendar_date) DO UPDATE SET
+            charged      = COALESCE(body_battery.charged, excluded.charged),
+            drained      = COALESCE(body_battery.drained, excluded.drained),
+            highest      = COALESCE(body_battery.highest, excluded.highest),
+            lowest       = COALESCE(body_battery.lowest, excluded.lowest),
+            most_recent  = COALESCE(body_battery.most_recent, excluded.most_recent),
+            at_wake      = COALESCE(body_battery.at_wake, excluded.at_wake),
+            during_sleep = COALESCE(body_battery.during_sleep, excluded.during_sleep)
         """
     )
 

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -750,7 +750,9 @@ def migrate_activity_splits_table(conn: sqlite3.Connection) -> None:
         return
 
     log.info("Migrating activity_splits table, added columns: %s — backfilling from raw_json", ", ".join(added))
-    rows = conn.execute("SELECT activity_id, split_number, raw_json FROM activity_splits WHERE raw_json IS NOT NULL").fetchall()
+    rows = conn.execute(
+        "SELECT activity_id, split_number, raw_json FROM activity_splits WHERE raw_json IS NOT NULL"
+    ).fetchall()
     for activity_id, split_number, raw in rows:
         try:
             split = json.loads(raw)
@@ -796,8 +798,9 @@ def _add_columns(conn: sqlite3.Connection, table: str, columns: list[tuple[str, 
     return added
 
 
-def _backfill_from_raw(conn: sqlite3.Connection, table: str, pk_cols: list[str],
-                       added: list[str], mapping: dict[str, str]) -> None:
+def _backfill_from_raw(
+    conn: sqlite3.Connection, table: str, pk_cols: list[str], added: list[str], mapping: dict[str, str]
+) -> None:
     """Backfill *added* columns from raw_json using *mapping* {col: json_key}."""
     if not added:
         return
@@ -807,7 +810,7 @@ def _backfill_from_raw(conn: sqlite3.Connection, table: str, pk_cols: list[str],
     pks = ", ".join(pk_cols)
     rows = conn.execute(f"SELECT {pks}, raw_json FROM {table} WHERE raw_json IS NOT NULL").fetchall()
     for row in rows:
-        pk_vals = row[:len(pk_cols)]
+        pk_vals = row[: len(pk_cols)]
         try:
             data = json.loads(row[len(pk_cols)])
         except (json.JSONDecodeError, TypeError):
@@ -822,76 +825,119 @@ def _backfill_from_raw(conn: sqlite3.Connection, table: str, pk_cols: list[str],
 
 
 def migrate_sleep_table(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "sleep", [
-        ("body_battery_change", "INTEGER"),
-        ("resting_heart_rate", "INTEGER"),
-        ("avg_skin_temp_deviation_c", "REAL"),
-        ("avg_skin_temp_deviation_f", "REAL"),
-    ])
-    _backfill_from_raw(conn, "sleep", ["calendar_date"], added, {
-        "body_battery_change": "bodyBatteryChange",
-        "resting_heart_rate": "restingHeartRate",
-        "avg_skin_temp_deviation_c": "avgSkinTempDeviationC",
-        "avg_skin_temp_deviation_f": "avgSkinTempDeviationF",
-    })
+    added = _add_columns(
+        conn,
+        "sleep",
+        [
+            ("body_battery_change", "INTEGER"),
+            ("resting_heart_rate", "INTEGER"),
+            ("avg_skin_temp_deviation_c", "REAL"),
+            ("avg_skin_temp_deviation_f", "REAL"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "sleep",
+        ["calendar_date"],
+        added,
+        {
+            "body_battery_change": "bodyBatteryChange",
+            "resting_heart_rate": "restingHeartRate",
+            "avg_skin_temp_deviation_c": "avgSkinTempDeviationC",
+            "avg_skin_temp_deviation_f": "avgSkinTempDeviationF",
+        },
+    )
 
 
 def migrate_hrv_table(conn: sqlite3.Connection) -> None:
     added = _add_columns(conn, "hrv", [("feedback_phrase", "TEXT")])
-    _backfill_from_raw(conn, "hrv", ["calendar_date"], added,
-                       {"feedback_phrase": "feedbackPhrase"})
+    _backfill_from_raw(conn, "hrv", ["calendar_date"], added, {"feedback_phrase": "feedbackPhrase"})
 
 
 def migrate_heart_rate_table(conn: sqlite3.Connection) -> None:
     added = _add_columns(conn, "heart_rate", [("last_7day_avg_resting", "REAL")])
-    _backfill_from_raw(conn, "heart_rate", ["calendar_date"], added,
-                       {"last_7day_avg_resting": "lastSevenDaysAvgRestingHeartRate"})
+    _backfill_from_raw(
+        conn, "heart_rate", ["calendar_date"], added, {"last_7day_avg_resting": "lastSevenDaysAvgRestingHeartRate"}
+    )
 
 
 def migrate_spo2_table(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "spo2", [
-        ("events_below_threshold", "INTEGER"),
-        ("duration_below_threshold_secs", "REAL"),
-    ])
-    _backfill_from_raw(conn, "spo2", ["calendar_date"], added, {
-        "events_below_threshold": "numberOfEventsBelowThreshold",
-        "duration_below_threshold_secs": "durationOfEventsBelowThreshold",
-    })
+    added = _add_columns(
+        conn,
+        "spo2",
+        [
+            ("events_below_threshold", "INTEGER"),
+            ("duration_below_threshold_secs", "REAL"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "spo2",
+        ["calendar_date"],
+        added,
+        {
+            "events_below_threshold": "numberOfEventsBelowThreshold",
+            "duration_below_threshold_secs": "durationOfEventsBelowThreshold",
+        },
+    )
 
 
 def migrate_respiration_table(conn: sqlite3.Connection) -> None:
     added = _add_columns(conn, "respiration", [("avg_sleep", "REAL")])
-    _backfill_from_raw(conn, "respiration", ["calendar_date"], added,
-                       {"avg_sleep": "avgSleepRespirationValue"})
+    _backfill_from_raw(conn, "respiration", ["calendar_date"], added, {"avg_sleep": "avgSleepRespirationValue"})
 
 
 def migrate_hydration_table(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "hydration", [
-        ("sweat_loss_ml", "REAL"),
-        ("activity_intake_ml", "REAL"),
-    ])
-    _backfill_from_raw(conn, "hydration", ["calendar_date"], added, {
-        "sweat_loss_ml": "sweatLossInML",
-        "activity_intake_ml": "activityIntakeInML",
-    })
+    added = _add_columns(
+        conn,
+        "hydration",
+        [
+            ("sweat_loss_ml", "REAL"),
+            ("activity_intake_ml", "REAL"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "hydration",
+        ["calendar_date"],
+        added,
+        {
+            "sweat_loss_ml": "sweatLossInML",
+            "activity_intake_ml": "activityIntakeInML",
+        },
+    )
 
 
 def migrate_weight_table_v2(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "weight", [
-        ("metabolic_age", "REAL"),
-        ("physique_rating", "INTEGER"),
-    ])
-    _backfill_from_raw(conn, "weight", ["timestamp"], added, {
-        "metabolic_age": "metabolicAge",
-        "physique_rating": "physiqueRating",
-    })
+    added = _add_columns(
+        conn,
+        "weight",
+        [
+            ("metabolic_age", "REAL"),
+            ("physique_rating", "INTEGER"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "weight",
+        ["timestamp"],
+        added,
+        {
+            "metabolic_age": "metabolicAge",
+            "physique_rating": "physiqueRating",
+        },
+    )
 
 
 def migrate_endurance_score_table(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "endurance_score", [
-        ("feedback_phrase", "TEXT"),
-        ("contributors", "TEXT"),
-    ])
+    added = _add_columns(
+        conn,
+        "endurance_score",
+        [
+            ("feedback_phrase", "TEXT"),
+            ("contributors", "TEXT"),
+        ],
+    )
     if not added:
         return
     rows = conn.execute("SELECT calendar_date, raw_json FROM endurance_score WHERE raw_json IS NOT NULL").fetchall()
@@ -915,29 +961,49 @@ def migrate_endurance_score_table(conn: sqlite3.Connection) -> None:
 
 
 def migrate_hill_score_table(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "hill_score", [
-        ("vo2_max", "REAL"),
-        ("vo2_max_precise", "REAL"),
-        ("feedback_phrase_id", "TEXT"),
-    ])
-    _backfill_from_raw(conn, "hill_score", ["calendar_date"], added, {
-        "vo2_max": "vo2Max",
-        "vo2_max_precise": "vo2MaxPreciseValue",
-        "feedback_phrase_id": "hillScoreFeedbackPhraseId",
-    })
+    added = _add_columns(
+        conn,
+        "hill_score",
+        [
+            ("vo2_max", "REAL"),
+            ("vo2_max_precise", "REAL"),
+            ("feedback_phrase_id", "TEXT"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "hill_score",
+        ["calendar_date"],
+        added,
+        {
+            "vo2_max": "vo2Max",
+            "vo2_max_precise": "vo2MaxPreciseValue",
+            "feedback_phrase_id": "hillScoreFeedbackPhraseId",
+        },
+    )
 
 
 def migrate_gear_table(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "gear", [
-        ("distance_used_meters", "REAL"),
-        ("duration_used_seconds", "INTEGER"),
-        ("days_used", "INTEGER"),
-    ])
-    _backfill_from_raw(conn, "gear", ["gear_id"], added, {
-        "distance_used_meters": "distanceUsedMeters",
-        "duration_used_seconds": "durationUsedSeconds",
-        "days_used": "daysUsed",
-    })
+    added = _add_columns(
+        conn,
+        "gear",
+        [
+            ("distance_used_meters", "REAL"),
+            ("duration_used_seconds", "INTEGER"),
+            ("days_used", "INTEGER"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "gear",
+        ["gear_id"],
+        added,
+        {
+            "distance_used_meters": "distanceUsedMeters",
+            "duration_used_seconds": "durationUsedSeconds",
+            "days_used": "daysUsed",
+        },
+    )
 
 
 def migrate_sleep_table_v2(conn: sqlite3.Connection) -> None:
@@ -959,24 +1025,28 @@ def migrate_sleep_table_v2(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE sleep RENAME COLUMN sleep_score_composition TO sleep_light_pct")
     conn.commit()
 
-    _add_columns(conn, "sleep", [
-        ("sleep_need_minutes", "INTEGER"),
-        ("highest_spo2", "REAL"),
-        ("sleep_score_overall", "INTEGER"),
-        ("sleep_light_pct", "INTEGER"),
-        ("sleep_score_rem", "INTEGER"),
-        ("sleep_score_deep", "INTEGER"),
-    ])
+    _add_columns(
+        conn,
+        "sleep",
+        [
+            ("sleep_need_minutes", "INTEGER"),
+            ("highest_spo2", "REAL"),
+            ("sleep_score_overall", "INTEGER"),
+            ("sleep_light_pct", "INTEGER"),
+            ("sleep_score_rem", "INTEGER"),
+            ("sleep_score_deep", "INTEGER"),
+        ],
+    )
     # All fields are nested under dailySleepDTO — use direct SQL UPDATE with json_extract.
     # WHERE {col} IS NULL makes the backfill idempotent and safe to re-run even
     # if the schema is in a partially-migrated state.
     update_map = {
-        "sleep_need_minutes":  "$.dailySleepDTO.sleepNeed.actual",
-        "highest_spo2":        "$.dailySleepDTO.highestSpO2Value",
+        "sleep_need_minutes": "$.dailySleepDTO.sleepNeed.actual",
+        "highest_spo2": "$.dailySleepDTO.highestSpO2Value",
         "sleep_score_overall": "$.dailySleepDTO.sleepScores.overall.value",
-        "sleep_light_pct":     "$.dailySleepDTO.sleepScores.lightPercentage.value",
-        "sleep_score_rem":     "$.dailySleepDTO.sleepScores.remPercentage.value",
-        "sleep_score_deep":    "$.dailySleepDTO.sleepScores.deepPercentage.value",
+        "sleep_light_pct": "$.dailySleepDTO.sleepScores.lightPercentage.value",
+        "sleep_score_rem": "$.dailySleepDTO.sleepScores.remPercentage.value",
+        "sleep_score_deep": "$.dailySleepDTO.sleepScores.deepPercentage.value",
     }
     for col, path in update_map.items():
         conn.execute(
@@ -987,32 +1057,62 @@ def migrate_sleep_table_v2(conn: sqlite3.Connection) -> None:
 
 
 def migrate_fitness_age_table(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "fitness_age", [
-        ("achievable_fitness_age", "REAL"),
-    ])
-    _backfill_from_raw(conn, "fitness_age", ["calendar_date"], added, {
-        "achievable_fitness_age": "achievableFitnessAge",
-    })
+    added = _add_columns(
+        conn,
+        "fitness_age",
+        [
+            ("achievable_fitness_age", "REAL"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "fitness_age",
+        ["calendar_date"],
+        added,
+        {
+            "achievable_fitness_age": "achievableFitnessAge",
+        },
+    )
 
 
 def migrate_weight_table_v3(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "weight", [
-        ("visceral_fat", "REAL"),
-    ])
-    _backfill_from_raw(conn, "weight", ["timestamp"], added, {
-        "visceral_fat": "visceralFat",
-    })
+    added = _add_columns(
+        conn,
+        "weight",
+        [
+            ("visceral_fat", "REAL"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "weight",
+        ["timestamp"],
+        added,
+        {
+            "visceral_fat": "visceralFat",
+        },
+    )
 
 
 def migrate_gear_table_v2(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "gear", [
-        ("status", "TEXT"),
-        ("max_usage_distance_meters", "REAL"),
-    ])
-    _backfill_from_raw(conn, "gear", ["gear_id"], added, {
-        "status": "status",
-        "max_usage_distance_meters": "maxUsageDistanceMeters",
-    })
+    added = _add_columns(
+        conn,
+        "gear",
+        [
+            ("status", "TEXT"),
+            ("max_usage_distance_meters", "REAL"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "gear",
+        ["gear_id"],
+        added,
+        {
+            "status": "status",
+            "max_usage_distance_meters": "maxUsageDistanceMeters",
+        },
+    )
 
 
 def migrate_activity_table(conn: sqlite3.Connection) -> None:
@@ -1029,19 +1129,23 @@ def migrate_activity_table(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE activity RENAME COLUMN total_work_kj TO total_work_kcal")
         conn.commit()
 
-    _add_columns(conn, "activity", [
-        ("body_battery_change", "INTEGER"),
-        ("total_work_kcal", "REAL"),
-        ("avg_grade_adjusted_speed", "REAL"),
-        ("activity_steps", "INTEGER"),
-        ("activity_min_hr", "INTEGER"),
-    ])
+    _add_columns(
+        conn,
+        "activity",
+        [
+            ("body_battery_change", "INTEGER"),
+            ("total_work_kcal", "REAL"),
+            ("avg_grade_adjusted_speed", "REAL"),
+            ("activity_steps", "INTEGER"),
+            ("activity_min_hr", "INTEGER"),
+        ],
+    )
     update_map = {
-        "body_battery_change":      "$.summaryDTO.differenceBodyBattery",
-        "total_work_kcal":          "$.summaryDTO.totalWork",
+        "body_battery_change": "$.summaryDTO.differenceBodyBattery",
+        "total_work_kcal": "$.summaryDTO.totalWork",
         "avg_grade_adjusted_speed": "$.summaryDTO.avgGradeAdjustedSpeed",
-        "activity_steps":           "$.summaryDTO.steps",
-        "activity_min_hr":          "$.summaryDTO.minHR",
+        "activity_steps": "$.summaryDTO.steps",
+        "activity_min_hr": "$.summaryDTO.minHR",
     }
     for col, path in update_map.items():
         conn.execute(
@@ -1052,66 +1156,87 @@ def migrate_activity_table(conn: sqlite3.Connection) -> None:
 
 
 def migrate_activity_splits_v2(conn: sqlite3.Connection) -> None:
-    added = _add_columns(conn, "activity_splits", [
-        ("normalized_power", "REAL"),
-        ("avg_respiration_rate", "REAL"),
-        ("max_respiration_rate", "REAL"),
-        ("start_latitude", "REAL"),
-        ("start_longitude", "REAL"),
-        ("end_latitude", "REAL"),
-        ("end_longitude", "REAL"),
-        ("start_time_gmt", "TEXT"),
-        ("calories", "REAL"),
-        ("left_pedal_smoothness", "REAL"),
-        ("right_pedal_smoothness", "REAL"),
-        ("left_torque_effectiveness", "REAL"),
-        ("right_torque_effectiveness", "REAL"),
-        ("surface_unpaved_pct", "REAL"),
-    ])
-    _backfill_from_raw(conn, "activity_splits", ["activity_id", "split_number"], added, {
-        "normalized_power": "normalizedPower",
-        "avg_respiration_rate": "avgRespirationRate",
-        "max_respiration_rate": "maxRespirationRate",
-        "start_latitude": "startLatitude",
-        "start_longitude": "startLongitude",
-        "end_latitude": "endLatitude",
-        "end_longitude": "endLongitude",
-        "start_time_gmt": "startTimeGMT",
-        "calories": "calories",
-        "left_pedal_smoothness": "leftPedalSmoothness",
-        "right_pedal_smoothness": "rightPedalSmoothness",
-        "left_torque_effectiveness": "leftTorqueEffectiveness",
-        "right_torque_effectiveness": "rightTorqueEffectiveness",
-        "surface_unpaved_pct": "surfaceTypeUnpavedPercentage",
-    })
+    added = _add_columns(
+        conn,
+        "activity_splits",
+        [
+            ("normalized_power", "REAL"),
+            ("avg_respiration_rate", "REAL"),
+            ("max_respiration_rate", "REAL"),
+            ("start_latitude", "REAL"),
+            ("start_longitude", "REAL"),
+            ("end_latitude", "REAL"),
+            ("end_longitude", "REAL"),
+            ("start_time_gmt", "TEXT"),
+            ("calories", "REAL"),
+            ("left_pedal_smoothness", "REAL"),
+            ("right_pedal_smoothness", "REAL"),
+            ("left_torque_effectiveness", "REAL"),
+            ("right_torque_effectiveness", "REAL"),
+            ("surface_unpaved_pct", "REAL"),
+        ],
+    )
+    _backfill_from_raw(
+        conn,
+        "activity_splits",
+        ["activity_id", "split_number"],
+        added,
+        {
+            "normalized_power": "normalizedPower",
+            "avg_respiration_rate": "avgRespirationRate",
+            "max_respiration_rate": "maxRespirationRate",
+            "start_latitude": "startLatitude",
+            "start_longitude": "startLongitude",
+            "end_latitude": "endLatitude",
+            "end_longitude": "endLongitude",
+            "start_time_gmt": "startTimeGMT",
+            "calories": "calories",
+            "left_pedal_smoothness": "leftPedalSmoothness",
+            "right_pedal_smoothness": "rightPedalSmoothness",
+            "left_torque_effectiveness": "leftTorqueEffectiveness",
+            "right_torque_effectiveness": "rightTorqueEffectiveness",
+            "surface_unpaved_pct": "surfaceTypeUnpavedPercentage",
+        },
+    )
 
 
 def migrate_hollow_tables(conn: sqlite3.Connection) -> None:
     """Add scalar columns to previously raw_json-only tables and backfill."""
-    _add_columns(conn, "daily_events", [
-        ("activity_type", "TEXT"),
-        ("activity_sub_type", "TEXT"),
-        ("start_timestamp_local", "TEXT"),
-        ("end_timestamp_local", "TEXT"),
-        ("duration_seconds", "REAL"),
-        ("device_id", "TEXT"),
-    ])
-    _add_columns(conn, "wellness_activity", [
-        ("activity_name", "TEXT"),
-        ("wellness_activity_type", "TEXT"),
-        ("start_timestamp_local", "TEXT"),
-        ("end_timestamp_local", "TEXT"),
-    ])
-    _add_columns(conn, "health_snapshot", [
-        ("activity_name", "TEXT"),
-        ("wellness_activity_type", "TEXT"),
-        ("start_timestamp_local", "TEXT"),
-        ("end_timestamp_local", "TEXT"),
-    ])
+    _add_columns(
+        conn,
+        "daily_events",
+        [
+            ("activity_type", "TEXT"),
+            ("activity_sub_type", "TEXT"),
+            ("start_timestamp_local", "TEXT"),
+            ("end_timestamp_local", "TEXT"),
+            ("duration_seconds", "REAL"),
+            ("device_id", "TEXT"),
+        ],
+    )
+    _add_columns(
+        conn,
+        "wellness_activity",
+        [
+            ("activity_name", "TEXT"),
+            ("wellness_activity_type", "TEXT"),
+            ("start_timestamp_local", "TEXT"),
+            ("end_timestamp_local", "TEXT"),
+        ],
+    )
+    _add_columns(
+        conn,
+        "health_snapshot",
+        [
+            ("activity_name", "TEXT"),
+            ("wellness_activity_type", "TEXT"),
+            ("start_timestamp_local", "TEXT"),
+            ("end_timestamp_local", "TEXT"),
+        ],
+    )
     # Backfill daily_events via upsert (handles both dict and list raw_json)
     de_rows = conn.execute(
-        "SELECT calendar_date, raw_json FROM daily_events "
-        "WHERE activity_type IS NULL AND raw_json IS NOT NULL"
+        "SELECT calendar_date, raw_json FROM daily_events WHERE activity_type IS NULL AND raw_json IS NOT NULL"
     ).fetchall()
     for cal_date, raw in de_rows:
         try:
@@ -1122,18 +1247,24 @@ def migrate_hollow_tables(conn: sqlite3.Connection) -> None:
 
     # Backfill scalar columns for each hollow table from their raw_json
     for table, mapping in [
-        ("wellness_activity", {
-            "activity_name": "activityName",
-            "wellness_activity_type": "wellnessActivityType",
-            "start_timestamp_local": "startTimestampLocal",
-            "end_timestamp_local": "endTimestampLocal",
-        }),
-        ("health_snapshot", {
-            "activity_name": "activityName",
-            "wellness_activity_type": "wellnessActivityType",
-            "start_timestamp_local": "startTimestampLocal",
-            "end_timestamp_local": "endTimestampLocal",
-        }),
+        (
+            "wellness_activity",
+            {
+                "activity_name": "activityName",
+                "wellness_activity_type": "wellnessActivityType",
+                "start_timestamp_local": "startTimestampLocal",
+                "end_timestamp_local": "endTimestampLocal",
+            },
+        ),
+        (
+            "health_snapshot",
+            {
+                "activity_name": "activityName",
+                "wellness_activity_type": "wellnessActivityType",
+                "start_timestamp_local": "startTimestampLocal",
+                "end_timestamp_local": "endTimestampLocal",
+            },
+        ),
     ]:
         rows = conn.execute(f"SELECT calendar_date, raw_json FROM {table} WHERE raw_json IS NOT NULL").fetchall()
         for cal_date, raw in rows:
@@ -1733,7 +1864,9 @@ def upsert_sleep(conn: sqlite3.Connection, record: dict) -> None:
             record.get("restingHeartRate"),
             record.get("avgSkinTempDeviationC"),
             record.get("avgSkinTempDeviationF"),
-            (dto.get("sleepNeed") or {}).get("actual") if isinstance(dto.get("sleepNeed"), dict) else dto.get("sleepNeed"),
+            (dto.get("sleepNeed") or {}).get("actual")
+            if isinstance(dto.get("sleepNeed"), dict)
+            else dto.get("sleepNeed"),
             dto.get("highestSpO2Value"),
             # Guard against Garmin returning null for a specific score sub-dict
             # (e.g. {"sleepScores": {"overall": null}}) — happens on nights where

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -124,16 +124,27 @@ CREATE TABLE IF NOT EXISTS sleep (
     avg_sleep_stress            REAL,
     sleep_score_feedback        TEXT,
     sleep_score_insight         TEXT,
+    body_battery_change         INTEGER,
+    resting_heart_rate          INTEGER,
+    avg_skin_temp_deviation_c   REAL,
+    avg_skin_temp_deviation_f   REAL,
+    sleep_need_minutes          INTEGER,
+    highest_spo2                REAL,
+    sleep_score_overall         INTEGER,
+    sleep_light_pct             INTEGER,
+    sleep_score_rem             INTEGER,
+    sleep_score_deep            INTEGER,
     raw_json                    TEXT
 );
 
 CREATE TABLE IF NOT EXISTS heart_rate (
-    calendar_date   TEXT PRIMARY KEY,
-    resting_hr      INTEGER,
-    min_hr          INTEGER,
-    max_hr          INTEGER,
-    avg_hr          REAL,
-    raw_json        TEXT
+    calendar_date           TEXT PRIMARY KEY,
+    resting_hr              INTEGER,
+    min_hr                  INTEGER,
+    max_hr                  INTEGER,
+    avg_hr                  REAL,
+    last_7day_avg_resting   REAL,
+    raw_json                TEXT
 );
 
 CREATE TABLE IF NOT EXISTS stress (
@@ -145,19 +156,22 @@ CREATE TABLE IF NOT EXISTS stress (
 );
 
 CREATE TABLE IF NOT EXISTS spo2 (
-    calendar_date   TEXT PRIMARY KEY,
-    avg_spo2        REAL,
-    min_spo2        REAL,
-    max_spo2        REAL,
-    raw_json        TEXT
+    calendar_date                   TEXT PRIMARY KEY,
+    avg_spo2                        REAL,
+    min_spo2                        REAL,
+    max_spo2                        REAL,
+    events_below_threshold          INTEGER,
+    duration_below_threshold_secs   REAL,
+    raw_json                        TEXT
 );
 
 CREATE TABLE IF NOT EXISTS respiration (
-    calendar_date   TEXT PRIMARY KEY,
-    avg_waking      REAL,
-    min_value       REAL,
-    max_value       REAL,
-    raw_json        TEXT
+    calendar_date       TEXT PRIMARY KEY,
+    avg_waking          REAL,
+    avg_sleep           REAL,
+    min_value           REAL,
+    max_value           REAL,
+    raw_json            TEXT
 );
 
 CREATE TABLE IF NOT EXISTS body_battery (
@@ -197,17 +211,20 @@ CREATE TABLE IF NOT EXISTS intensity_minutes (
 );
 
 CREATE TABLE IF NOT EXISTS hydration (
-    calendar_date   TEXT PRIMARY KEY,
-    goal_ml         REAL,
-    intake_ml       REAL,
-    raw_json        TEXT
+    calendar_date       TEXT PRIMARY KEY,
+    goal_ml             REAL,
+    intake_ml           REAL,
+    sweat_loss_ml       REAL,
+    activity_intake_ml  REAL,
+    raw_json            TEXT
 );
 
 CREATE TABLE IF NOT EXISTS fitness_age (
-    calendar_date       TEXT PRIMARY KEY,
-    chronological_age   INTEGER,
-    fitness_age         REAL,
-    raw_json            TEXT
+    calendar_date           TEXT PRIMARY KEY,
+    chronological_age       INTEGER,
+    fitness_age             REAL,
+    achievable_fitness_age  REAL,
+    raw_json                TEXT
 );
 
 CREATE TABLE IF NOT EXISTS daily_movement (
@@ -216,8 +233,12 @@ CREATE TABLE IF NOT EXISTS daily_movement (
 );
 
 CREATE TABLE IF NOT EXISTS wellness_activity (
-    calendar_date   TEXT PRIMARY KEY,
-    raw_json        TEXT
+    calendar_date           TEXT PRIMARY KEY,
+    activity_name           TEXT,
+    wellness_activity_type  TEXT,
+    start_timestamp_local   TEXT,
+    end_timestamp_local     TEXT,
+    raw_json                TEXT
 );
 
 CREATE TABLE IF NOT EXISTS training_status (
@@ -235,8 +256,14 @@ CREATE TABLE IF NOT EXISTS health_status (
 );
 
 CREATE TABLE IF NOT EXISTS daily_events (
-    calendar_date   TEXT PRIMARY KEY,
-    raw_json        TEXT
+    calendar_date           TEXT PRIMARY KEY,
+    activity_type           TEXT,
+    activity_sub_type       TEXT,
+    start_timestamp_local   TEXT,
+    end_timestamp_local     TEXT,
+    duration_seconds        REAL,
+    device_id               TEXT,
+    raw_json                TEXT
 );
 
 CREATE TABLE IF NOT EXISTS activity_trends (
@@ -297,6 +324,11 @@ CREATE TABLE IF NOT EXISTS activity (
     max_temperature                     REAL,
     manufacturer                        TEXT,
     device_id                           INTEGER,
+    body_battery_change                 INTEGER,
+    total_work_kcal                     REAL,
+    avg_grade_adjusted_speed            REAL,
+    activity_steps                      INTEGER,
+    activity_min_hr                     INTEGER,
     raw_json                            TEXT
 );
 
@@ -355,6 +387,7 @@ CREATE TABLE IF NOT EXISTS hrv (
     last_night_avg      REAL,
     last_night_5min_high REAL,
     status              TEXT,
+    feedback_phrase     TEXT,
     baseline_low        REAL,
     baseline_upper      REAL,
     start_timestamp     TEXT,
@@ -393,6 +426,9 @@ CREATE TABLE IF NOT EXISTS weight (
     body_water      REAL,
     bone_mass       REAL,
     muscle_mass     REAL,
+    metabolic_age   REAL,
+    physique_rating INTEGER,
+    visceral_fat    REAL,
     source          TEXT,
     raw_json        TEXT
 );
@@ -421,8 +457,12 @@ CREATE TABLE IF NOT EXISTS sleep_stats (
 );
 
 CREATE TABLE IF NOT EXISTS health_snapshot (
-    calendar_date   TEXT PRIMARY KEY,
-    raw_json        TEXT
+    calendar_date           TEXT PRIMARY KEY,
+    activity_name           TEXT,
+    wellness_activity_type  TEXT,
+    start_timestamp_local   TEXT,
+    end_timestamp_local     TEXT,
+    raw_json                TEXT
 );
 
 CREATE TABLE IF NOT EXISTS workout_schedule (
@@ -467,13 +507,18 @@ CREATE TABLE IF NOT EXISTS device (
 );
 
 CREATE TABLE IF NOT EXISTS gear (
-    gear_id         TEXT PRIMARY KEY,
-    gear_type       TEXT,
-    display_name    TEXT,
-    brand           TEXT,
-    model           TEXT,
-    date_begin      TEXT,
-    raw_json        TEXT
+    gear_id                     TEXT PRIMARY KEY,
+    gear_type                   TEXT,
+    display_name                TEXT,
+    brand                       TEXT,
+    model                       TEXT,
+    date_begin                  TEXT,
+    distance_used_meters        REAL,
+    duration_used_seconds       INTEGER,
+    days_used                   INTEGER,
+    status                      TEXT,
+    max_usage_distance_meters   REAL,
+    raw_json                    TEXT
 );
 
 CREATE TABLE IF NOT EXISTS goals (
@@ -514,6 +559,8 @@ CREATE TABLE IF NOT EXISTS endurance_score (
     classification                  TEXT,
     vo2_max                         REAL,
     vo2_max_precise                 REAL,
+    feedback_phrase                 TEXT,
+    contributors                    TEXT,
     raw_json                        TEXT
 );
 
@@ -522,6 +569,9 @@ CREATE TABLE IF NOT EXISTS hill_score (
     overall_score                   INTEGER,
     endurance_score                 INTEGER,
     strength_score                  INTEGER,
+    vo2_max                         REAL,
+    vo2_max_precise                 REAL,
+    feedback_phrase_id              TEXT,
     raw_json                        TEXT
 );
 
@@ -545,6 +595,25 @@ CREATE TABLE IF NOT EXISTS activity_splits (
     elevation_gain                  REAL,
     elevation_loss                  REAL,
     avg_cadence                     REAL,
+    avg_swim_cadence                REAL,
+    avg_swolf                       REAL,
+    total_strokes                   INTEGER,
+    swim_stroke                     TEXT,
+    num_active_lengths              INTEGER,
+    normalized_power                REAL,
+    avg_respiration_rate            REAL,
+    max_respiration_rate            REAL,
+    start_latitude                  REAL,
+    start_longitude                 REAL,
+    end_latitude                    REAL,
+    end_longitude                   REAL,
+    start_time_gmt                  TEXT,
+    calories                        REAL,
+    left_pedal_smoothness           REAL,
+    right_pedal_smoothness          REAL,
+    left_torque_effectiveness       REAL,
+    right_torque_effectiveness      REAL,
+    surface_unpaved_pct             REAL,
     raw_json                        TEXT,
     PRIMARY KEY (activity_id, split_number)
 );
@@ -657,6 +726,426 @@ CREATE INDEX IF NOT EXISTS idx_trackpoints_activity ON activity_trackpoints (act
 """
 
 
+def migrate_activity_splits_table(conn: sqlite3.Connection) -> None:
+    """Add swim-specific columns to activity_splits and backfill from raw_json."""
+    cursor = conn.execute("PRAGMA table_info(activity_splits)")
+    cols = {row[1] for row in cursor.fetchall()}
+    new_cols = [
+        ("avg_swim_cadence", "REAL"),
+        ("avg_swolf", "REAL"),
+        ("total_strokes", "INTEGER"),
+        ("swim_stroke", "TEXT"),
+        ("num_active_lengths", "INTEGER"),
+    ]
+    added = []
+    for name, col_type in new_cols:
+        if name not in cols:
+            try:
+                conn.execute(f"ALTER TABLE activity_splits ADD COLUMN {name} {col_type}")
+                added.append(name)
+            except sqlite3.OperationalError as e:
+                log.debug("Migration note (activity_splits.%s): %s", name, e)
+
+    if not added:
+        return
+
+    log.info("Migrating activity_splits table, added columns: %s — backfilling from raw_json", ", ".join(added))
+    rows = conn.execute("SELECT activity_id, split_number, raw_json FROM activity_splits WHERE raw_json IS NOT NULL").fetchall()
+    for activity_id, split_number, raw in rows:
+        try:
+            split = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        conn.execute(
+            """UPDATE activity_splits
+               SET avg_swim_cadence   = COALESCE(avg_swim_cadence,   ?),
+                   avg_swolf          = COALESCE(avg_swolf,          ?),
+                   total_strokes      = COALESCE(total_strokes,      ?),
+                   swim_stroke        = COALESCE(swim_stroke,        ?),
+                   num_active_lengths = COALESCE(num_active_lengths, ?)
+               WHERE activity_id = ? AND split_number = ?""",
+            (
+                split.get("averageSwimCadence") or None,
+                split.get("averageSWOLF") or None,
+                split.get("totalNumberOfStrokes") or None,
+                split.get("swimStroke"),
+                split.get("numberOfActiveLengths") or None,
+                activity_id,
+                split_number,
+            ),
+        )
+    log.info("Backfilled swim columns for %d splits", len(rows))
+
+
+def _add_columns(conn: sqlite3.Connection, table: str, columns: list[tuple[str, str]]) -> list[str]:
+    """Add missing columns to *table*. Returns list of added column names."""
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    added = []
+    for name, col_type in columns:
+        if name not in existing:
+            try:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {col_type}")
+                added.append(name)
+            except sqlite3.OperationalError as e:
+                # The PRAGMA check above prevents "duplicate column" — anything
+                # reaching here is a real problem (missing table, disk error,
+                # etc.) and should be visible at default log level.
+                log.warning("Could not add %s.%s: %s", table, name, e)
+    if added:
+        log.info("Migrated %s: added %s", table, ", ".join(added))
+    return added
+
+
+def _backfill_from_raw(conn: sqlite3.Connection, table: str, pk_cols: list[str],
+                       added: list[str], mapping: dict[str, str]) -> None:
+    """Backfill *added* columns from raw_json using *mapping* {col: json_key}."""
+    if not added:
+        return
+    active = {c: mapping[c] for c in added if c in mapping}
+    if not active:
+        return
+    pks = ", ".join(pk_cols)
+    rows = conn.execute(f"SELECT {pks}, raw_json FROM {table} WHERE raw_json IS NOT NULL").fetchall()
+    for row in rows:
+        pk_vals = row[:len(pk_cols)]
+        try:
+            data = json.loads(row[len(pk_cols)])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(data, list):
+            continue
+        set_clause = ", ".join(f"{c} = COALESCE({c}, ?)" for c in active)
+        # dict.get returns None for missing keys; do NOT coerce 0/False/'' to None.
+        vals = [data.get(jk) for jk in active.values()]
+        where = " AND ".join(f"{c} = ?" for c in pk_cols)
+        conn.execute(f"UPDATE {table} SET {set_clause} WHERE {where}", vals + list(pk_vals))
+
+
+def migrate_sleep_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "sleep", [
+        ("body_battery_change", "INTEGER"),
+        ("resting_heart_rate", "INTEGER"),
+        ("avg_skin_temp_deviation_c", "REAL"),
+        ("avg_skin_temp_deviation_f", "REAL"),
+    ])
+    _backfill_from_raw(conn, "sleep", ["calendar_date"], added, {
+        "body_battery_change": "bodyBatteryChange",
+        "resting_heart_rate": "restingHeartRate",
+        "avg_skin_temp_deviation_c": "avgSkinTempDeviationC",
+        "avg_skin_temp_deviation_f": "avgSkinTempDeviationF",
+    })
+
+
+def migrate_hrv_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "hrv", [("feedback_phrase", "TEXT")])
+    _backfill_from_raw(conn, "hrv", ["calendar_date"], added,
+                       {"feedback_phrase": "feedbackPhrase"})
+
+
+def migrate_heart_rate_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "heart_rate", [("last_7day_avg_resting", "REAL")])
+    _backfill_from_raw(conn, "heart_rate", ["calendar_date"], added,
+                       {"last_7day_avg_resting": "lastSevenDaysAvgRestingHeartRate"})
+
+
+def migrate_spo2_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "spo2", [
+        ("events_below_threshold", "INTEGER"),
+        ("duration_below_threshold_secs", "REAL"),
+    ])
+    _backfill_from_raw(conn, "spo2", ["calendar_date"], added, {
+        "events_below_threshold": "numberOfEventsBelowThreshold",
+        "duration_below_threshold_secs": "durationOfEventsBelowThreshold",
+    })
+
+
+def migrate_respiration_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "respiration", [("avg_sleep", "REAL")])
+    _backfill_from_raw(conn, "respiration", ["calendar_date"], added,
+                       {"avg_sleep": "avgSleepRespirationValue"})
+
+
+def migrate_hydration_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "hydration", [
+        ("sweat_loss_ml", "REAL"),
+        ("activity_intake_ml", "REAL"),
+    ])
+    _backfill_from_raw(conn, "hydration", ["calendar_date"], added, {
+        "sweat_loss_ml": "sweatLossInML",
+        "activity_intake_ml": "activityIntakeInML",
+    })
+
+
+def migrate_weight_table_v2(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "weight", [
+        ("metabolic_age", "REAL"),
+        ("physique_rating", "INTEGER"),
+    ])
+    _backfill_from_raw(conn, "weight", ["timestamp"], added, {
+        "metabolic_age": "metabolicAge",
+        "physique_rating": "physiqueRating",
+    })
+
+
+def migrate_endurance_score_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "endurance_score", [
+        ("feedback_phrase", "TEXT"),
+        ("contributors", "TEXT"),
+    ])
+    if not added:
+        return
+    rows = conn.execute("SELECT calendar_date, raw_json FROM endurance_score WHERE raw_json IS NOT NULL").fetchall()
+    for cal_date, raw in rows:
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        contributors = data.get("contributors")
+        conn.execute(
+            """UPDATE endurance_score
+               SET feedback_phrase = COALESCE(feedback_phrase, ?),
+                   contributors    = COALESCE(contributors, ?)
+               WHERE calendar_date = ?""",
+            (
+                data.get("feedbackPhrase"),
+                json.dumps(contributors) if contributors is not None else None,
+                cal_date,
+            ),
+        )
+
+
+def migrate_hill_score_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "hill_score", [
+        ("vo2_max", "REAL"),
+        ("vo2_max_precise", "REAL"),
+        ("feedback_phrase_id", "TEXT"),
+    ])
+    _backfill_from_raw(conn, "hill_score", ["calendar_date"], added, {
+        "vo2_max": "vo2Max",
+        "vo2_max_precise": "vo2MaxPreciseValue",
+        "feedback_phrase_id": "hillScoreFeedbackPhraseId",
+    })
+
+
+def migrate_gear_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "gear", [
+        ("distance_used_meters", "REAL"),
+        ("duration_used_seconds", "INTEGER"),
+        ("days_used", "INTEGER"),
+    ])
+    _backfill_from_raw(conn, "gear", ["gear_id"], added, {
+        "distance_used_meters": "distanceUsedMeters",
+        "duration_used_seconds": "durationUsedSeconds",
+        "days_used": "daysUsed",
+    })
+
+
+def migrate_sleep_table_v2(conn: sqlite3.Connection) -> None:
+    """Add sleep score and SpO2/sleep-need columns, backfill from nested raw_json paths.
+
+    Requires SQLite >= 3.25 for ALTER TABLE ... RENAME COLUMN (Sept 2018).
+    Python 3.10+ on any current OS satisfies this.
+
+    The rename block handles an unreleased intermediate schema where columns
+    were named with the wrong unit suffix. RENAME preserves existing values
+    (it doesn't convert them) — if a fork stored seconds in sleep_need_seconds,
+    those seconds-values are now mislabeled as minutes. In practice these
+    columns never shipped, so no upstream user is affected.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(sleep)").fetchall()}
+    if "sleep_need_seconds" in cols and "sleep_need_minutes" not in cols:
+        conn.execute("ALTER TABLE sleep RENAME COLUMN sleep_need_seconds TO sleep_need_minutes")
+    if "sleep_score_composition" in cols and "sleep_light_pct" not in cols:
+        conn.execute("ALTER TABLE sleep RENAME COLUMN sleep_score_composition TO sleep_light_pct")
+    conn.commit()
+
+    _add_columns(conn, "sleep", [
+        ("sleep_need_minutes", "INTEGER"),
+        ("highest_spo2", "REAL"),
+        ("sleep_score_overall", "INTEGER"),
+        ("sleep_light_pct", "INTEGER"),
+        ("sleep_score_rem", "INTEGER"),
+        ("sleep_score_deep", "INTEGER"),
+    ])
+    # All fields are nested under dailySleepDTO — use direct SQL UPDATE with json_extract.
+    # WHERE {col} IS NULL makes the backfill idempotent and safe to re-run even
+    # if the schema is in a partially-migrated state.
+    update_map = {
+        "sleep_need_minutes":  "$.dailySleepDTO.sleepNeed.actual",
+        "highest_spo2":        "$.dailySleepDTO.highestSpO2Value",
+        "sleep_score_overall": "$.dailySleepDTO.sleepScores.overall.value",
+        "sleep_light_pct":     "$.dailySleepDTO.sleepScores.lightPercentage.value",
+        "sleep_score_rem":     "$.dailySleepDTO.sleepScores.remPercentage.value",
+        "sleep_score_deep":    "$.dailySleepDTO.sleepScores.deepPercentage.value",
+    }
+    for col, path in update_map.items():
+        conn.execute(
+            f"UPDATE sleep SET {col} = json_extract(raw_json, ?) WHERE raw_json IS NOT NULL AND {col} IS NULL",
+            (path,),
+        )
+    conn.commit()
+
+
+def migrate_fitness_age_table(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "fitness_age", [
+        ("achievable_fitness_age", "REAL"),
+    ])
+    _backfill_from_raw(conn, "fitness_age", ["calendar_date"], added, {
+        "achievable_fitness_age": "achievableFitnessAge",
+    })
+
+
+def migrate_weight_table_v3(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "weight", [
+        ("visceral_fat", "REAL"),
+    ])
+    _backfill_from_raw(conn, "weight", ["timestamp"], added, {
+        "visceral_fat": "visceralFat",
+    })
+
+
+def migrate_gear_table_v2(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "gear", [
+        ("status", "TEXT"),
+        ("max_usage_distance_meters", "REAL"),
+    ])
+    _backfill_from_raw(conn, "gear", ["gear_id"], added, {
+        "status": "status",
+        "max_usage_distance_meters": "maxUsageDistanceMeters",
+    })
+
+
+def migrate_activity_table(conn: sqlite3.Connection) -> None:
+    """Add new columns to activity table and backfill from summaryDTO in raw_json.
+
+    Note: summaryDTO.totalWork is in kilocalories of mechanical work, not joules
+    (verified against avg_power × duration: 224W × 4648s ≈ 1041 kJ ≈ 248 kcal,
+    matching the stored value of 248.21).
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(activity)").fetchall()}
+    if "total_work_kj" in cols and "total_work_kcal" not in cols:
+        # Pre-release intermediate schema had wrong unit suffix; values were
+        # always kcal — just rename the column.
+        conn.execute("ALTER TABLE activity RENAME COLUMN total_work_kj TO total_work_kcal")
+        conn.commit()
+
+    _add_columns(conn, "activity", [
+        ("body_battery_change", "INTEGER"),
+        ("total_work_kcal", "REAL"),
+        ("avg_grade_adjusted_speed", "REAL"),
+        ("activity_steps", "INTEGER"),
+        ("activity_min_hr", "INTEGER"),
+    ])
+    update_map = {
+        "body_battery_change":      "$.summaryDTO.differenceBodyBattery",
+        "total_work_kcal":          "$.summaryDTO.totalWork",
+        "avg_grade_adjusted_speed": "$.summaryDTO.avgGradeAdjustedSpeed",
+        "activity_steps":           "$.summaryDTO.steps",
+        "activity_min_hr":          "$.summaryDTO.minHR",
+    }
+    for col, path in update_map.items():
+        conn.execute(
+            f"UPDATE activity SET {col} = json_extract(raw_json, ?) WHERE raw_json IS NOT NULL AND {col} IS NULL",
+            (path,),
+        )
+    conn.commit()
+
+
+def migrate_activity_splits_v2(conn: sqlite3.Connection) -> None:
+    added = _add_columns(conn, "activity_splits", [
+        ("normalized_power", "REAL"),
+        ("avg_respiration_rate", "REAL"),
+        ("max_respiration_rate", "REAL"),
+        ("start_latitude", "REAL"),
+        ("start_longitude", "REAL"),
+        ("end_latitude", "REAL"),
+        ("end_longitude", "REAL"),
+        ("start_time_gmt", "TEXT"),
+        ("calories", "REAL"),
+        ("left_pedal_smoothness", "REAL"),
+        ("right_pedal_smoothness", "REAL"),
+        ("left_torque_effectiveness", "REAL"),
+        ("right_torque_effectiveness", "REAL"),
+        ("surface_unpaved_pct", "REAL"),
+    ])
+    _backfill_from_raw(conn, "activity_splits", ["activity_id", "split_number"], added, {
+        "normalized_power": "normalizedPower",
+        "avg_respiration_rate": "avgRespirationRate",
+        "max_respiration_rate": "maxRespirationRate",
+        "start_latitude": "startLatitude",
+        "start_longitude": "startLongitude",
+        "end_latitude": "endLatitude",
+        "end_longitude": "endLongitude",
+        "start_time_gmt": "startTimeGMT",
+        "calories": "calories",
+        "left_pedal_smoothness": "leftPedalSmoothness",
+        "right_pedal_smoothness": "rightPedalSmoothness",
+        "left_torque_effectiveness": "leftTorqueEffectiveness",
+        "right_torque_effectiveness": "rightTorqueEffectiveness",
+        "surface_unpaved_pct": "surfaceTypeUnpavedPercentage",
+    })
+
+
+def migrate_hollow_tables(conn: sqlite3.Connection) -> None:
+    """Add scalar columns to previously raw_json-only tables and backfill."""
+    _add_columns(conn, "daily_events", [
+        ("activity_type", "TEXT"),
+        ("activity_sub_type", "TEXT"),
+        ("start_timestamp_local", "TEXT"),
+        ("end_timestamp_local", "TEXT"),
+        ("duration_seconds", "REAL"),
+        ("device_id", "TEXT"),
+    ])
+    _add_columns(conn, "wellness_activity", [
+        ("activity_name", "TEXT"),
+        ("wellness_activity_type", "TEXT"),
+        ("start_timestamp_local", "TEXT"),
+        ("end_timestamp_local", "TEXT"),
+    ])
+    _add_columns(conn, "health_snapshot", [
+        ("activity_name", "TEXT"),
+        ("wellness_activity_type", "TEXT"),
+        ("start_timestamp_local", "TEXT"),
+        ("end_timestamp_local", "TEXT"),
+    ])
+    # Backfill daily_events via upsert (handles both dict and list raw_json)
+    de_rows = conn.execute(
+        "SELECT calendar_date, raw_json FROM daily_events "
+        "WHERE activity_type IS NULL AND raw_json IS NOT NULL"
+    ).fetchall()
+    for cal_date, raw in de_rows:
+        try:
+            record = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        upsert_daily_events(conn, record, cal_date=cal_date)
+
+    # Backfill scalar columns for each hollow table from their raw_json
+    for table, mapping in [
+        ("wellness_activity", {
+            "activity_name": "activityName",
+            "wellness_activity_type": "wellnessActivityType",
+            "start_timestamp_local": "startTimestampLocal",
+            "end_timestamp_local": "endTimestampLocal",
+        }),
+        ("health_snapshot", {
+            "activity_name": "activityName",
+            "wellness_activity_type": "wellnessActivityType",
+            "start_timestamp_local": "startTimestampLocal",
+            "end_timestamp_local": "endTimestampLocal",
+        }),
+    ]:
+        rows = conn.execute(f"SELECT calendar_date, raw_json FROM {table} WHERE raw_json IS NOT NULL").fetchall()
+        for cal_date, raw in rows:
+            try:
+                data = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            set_parts = ", ".join(f"{col} = COALESCE({col}, ?)" for col in mapping)
+            vals = [data.get(jk) for jk in mapping.values()]
+            conn.execute(f"UPDATE {table} SET {set_parts} WHERE calendar_date = ?", vals + [cal_date])
+
+
 def migrate_training_status_table(conn: sqlite3.Connection) -> None:
     """Migrate the training_status table to include acute and chronic load columns."""
     cursor = conn.execute("PRAGMA table_info(training_status)")
@@ -685,6 +1174,24 @@ def init_db(conn: sqlite3.Connection) -> None:
     migrate_weight_table(conn)
     migrate_device_table(conn)
     migrate_training_status_table(conn)
+    migrate_activity_splits_table(conn)
+    migrate_activity_splits_v2(conn)
+    migrate_hrv_table(conn)
+    migrate_sleep_table(conn)
+    migrate_heart_rate_table(conn)
+    migrate_spo2_table(conn)
+    migrate_respiration_table(conn)
+    migrate_hydration_table(conn)
+    migrate_weight_table_v2(conn)
+    migrate_endurance_score_table(conn)
+    migrate_hill_score_table(conn)
+    migrate_gear_table(conn)
+    migrate_gear_table_v2(conn)
+    migrate_hollow_tables(conn)
+    migrate_sleep_table_v2(conn)
+    migrate_fitness_age_table(conn)
+    migrate_weight_table_v3(conn)
+    migrate_activity_table(conn)
 
     # Only run cleanup/backfill when there are rows that actually need it.
     needs_cleanup = conn.execute(
@@ -1165,45 +1672,79 @@ def upsert_sleep(conn: sqlite3.Connection, record: dict) -> None:
     avg_hr_sleep = (
         dto.get("averageHrSleep") or dto.get("avgSleepHR") or _mean_sample_values(record.get("sleepHeartRate"), "value")
     )
+    # Multiple endpoints write to the same sleep row (REST sleep + GQL sleep_summaries +
+    # GQL sleep_detail). They arrive in arbitrary order and carry different subsets of
+    # fields. INSERT OR REPLACE would silently wipe out values set by a prior endpoint.
+    # INSERT OR IGNORE + UPDATE lets each endpoint contribute what it knows while
+    # COALESCE preserves non-null values already set by earlier writes.
+    conn.execute("INSERT OR IGNORE INTO sleep (calendar_date) VALUES (?)", (calendar_date,))
     conn.execute(
         """
-        INSERT OR REPLACE INTO sleep (
-            calendar_date, sleep_time_seconds, nap_time_seconds,
-            deep_sleep_seconds, light_sleep_seconds, rem_sleep_seconds,
-            awake_sleep_seconds, unmeasurable_sleep_seconds, awake_count,
-            average_spo2, lowest_spo2, average_hr_sleep, average_respiration,
-            lowest_respiration, highest_respiration, avg_sleep_stress,
-            sleep_score_feedback, sleep_score_insight, raw_json
-        ) VALUES (
-            :calendar_date, :sleep_time_seconds, :nap_time_seconds,
-            :deep_sleep_seconds, :light_sleep_seconds, :rem_sleep_seconds,
-            :awake_sleep_seconds, :unmeasurable_sleep_seconds, :awake_count,
-            :average_spo2, :lowest_spo2, :average_hr_sleep, :average_respiration,
-            :lowest_respiration, :highest_respiration, :avg_sleep_stress,
-            :sleep_score_feedback, :sleep_score_insight, :raw_json
-        )
+        UPDATE sleep SET
+            sleep_time_seconds          = ?,
+            nap_time_seconds            = ?,
+            deep_sleep_seconds          = ?,
+            light_sleep_seconds         = ?,
+            rem_sleep_seconds           = ?,
+            awake_sleep_seconds         = ?,
+            unmeasurable_sleep_seconds  = ?,
+            awake_count                 = ?,
+            average_spo2                = ?,
+            lowest_spo2                 = ?,
+            average_hr_sleep            = ?,
+            average_respiration         = ?,
+            lowest_respiration          = ?,
+            highest_respiration         = ?,
+            avg_sleep_stress            = ?,
+            sleep_score_feedback        = ?,
+            sleep_score_insight         = ?,
+            body_battery_change         = COALESCE(?, body_battery_change),
+            resting_heart_rate          = COALESCE(?, resting_heart_rate),
+            avg_skin_temp_deviation_c   = COALESCE(?, avg_skin_temp_deviation_c),
+            avg_skin_temp_deviation_f   = COALESCE(?, avg_skin_temp_deviation_f),
+            sleep_need_minutes          = COALESCE(?, sleep_need_minutes),
+            highest_spo2                = COALESCE(?, highest_spo2),
+            sleep_score_overall         = COALESCE(?, sleep_score_overall),
+            sleep_light_pct             = COALESCE(?, sleep_light_pct),
+            sleep_score_rem             = COALESCE(?, sleep_score_rem),
+            sleep_score_deep            = COALESCE(?, sleep_score_deep),
+            raw_json                    = ?
+        WHERE calendar_date = ?
         """,
-        {
-            "calendar_date": calendar_date,
-            "sleep_time_seconds": sleep_seconds,
-            "nap_time_seconds": dto.get("napTimeSeconds"),
-            "deep_sleep_seconds": dto.get("deepSleepSeconds"),
-            "light_sleep_seconds": dto.get("lightSleepSeconds"),
-            "rem_sleep_seconds": dto.get("remSleepSeconds"),
-            "awake_sleep_seconds": dto.get("awakeSleepSeconds"),
-            "unmeasurable_sleep_seconds": dto.get("unmeasurableSleepSeconds"),
-            "awake_count": dto.get("awakeSleepCount") or dto.get("awakeCount"),
-            "average_spo2": dto.get("averageSpO2Value"),
-            "lowest_spo2": dto.get("lowestSpO2Value"),
-            "average_hr_sleep": avg_hr_sleep,
-            "average_respiration": dto.get("averageRespirationValue"),
-            "lowest_respiration": dto.get("lowestRespirationValue"),
-            "highest_respiration": dto.get("highestRespirationValue"),
-            "avg_sleep_stress": dto.get("avgSleepStress"),
-            "sleep_score_feedback": dto.get("sleepScoreFeedback"),
-            "sleep_score_insight": dto.get("sleepScoreInsight"),
-            "raw_json": json.dumps(record),
-        },
+        (
+            sleep_seconds,
+            dto.get("napTimeSeconds"),
+            dto.get("deepSleepSeconds"),
+            dto.get("lightSleepSeconds"),
+            dto.get("remSleepSeconds"),
+            dto.get("awakeSleepSeconds"),
+            dto.get("unmeasurableSleepSeconds"),
+            dto.get("awakeSleepCount") or dto.get("awakeCount"),
+            dto.get("averageSpO2Value"),
+            dto.get("lowestSpO2Value"),
+            avg_hr_sleep,
+            dto.get("averageRespirationValue"),
+            dto.get("lowestRespirationValue"),
+            dto.get("highestRespirationValue"),
+            dto.get("avgSleepStress"),
+            dto.get("sleepScoreFeedback"),
+            dto.get("sleepScoreInsight"),
+            record.get("bodyBatteryChange"),
+            record.get("restingHeartRate"),
+            record.get("avgSkinTempDeviationC"),
+            record.get("avgSkinTempDeviationF"),
+            (dto.get("sleepNeed") or {}).get("actual") if isinstance(dto.get("sleepNeed"), dict) else dto.get("sleepNeed"),
+            dto.get("highestSpO2Value"),
+            # Guard against Garmin returning null for a specific score sub-dict
+            # (e.g. {"sleepScores": {"overall": null}}) — happens on nights where
+            # scoring failed but the rest of the structure is present.
+            ((dto.get("sleepScores") or {}).get("overall") or {}).get("value"),
+            ((dto.get("sleepScores") or {}).get("lightPercentage") or {}).get("value"),
+            ((dto.get("sleepScores") or {}).get("remPercentage") or {}).get("value"),
+            ((dto.get("sleepScores") or {}).get("deepPercentage") or {}).get("value"),
+            json.dumps(record),
+            calendar_date,
+        ),
     )
 
 
@@ -1225,40 +1766,71 @@ def upsert_activity(conn: sqlite3.Connection, record: dict) -> None:
         or record.get("maxBikingCadenceInRevPerMinute")
         or record.get("maxCadence")
     )
+    # summaryDTO is present in activity_details records; flat list records lack it.
+    # Use INSERT OR IGNORE + UPDATE (not INSERT OR REPLACE) so a flat-list record
+    # arriving after a detailed record doesn't blank out the summaryDTO-only columns.
+    # COALESCE preserves prior non-null values for those fields.
+    summary: dict = record.get("summaryDTO") or {}
+    activity_id = record.get("activityId")
+    conn.execute("INSERT OR IGNORE INTO activity (activity_id) VALUES (?)", (activity_id,))
     conn.execute(
         """
-        INSERT OR REPLACE INTO activity (
-            activity_id, activity_name, activity_type, activity_type_id,
-            parent_type_id, start_time_local, start_time_gmt,
-            duration_seconds, elapsed_duration_seconds, moving_duration_seconds,
-            distance_meters, calories, bmr_calories, average_hr, max_hr,
-            average_speed, max_speed, elevation_gain, elevation_loss,
-            min_elevation, max_elevation, avg_power, max_power, norm_power,
-            training_stress_score, intensity_factor, aerobic_training_effect,
-            anaerobic_training_effect, vo2max_value, avg_cadence, max_cadence,
-            avg_respiration, training_load, moderate_intensity_minutes,
-            vigorous_intensity_minutes, start_latitude, start_longitude,
-            end_latitude, end_longitude, location_name, lap_count,
-            water_estimated, min_temperature, max_temperature,
-            manufacturer, device_id, raw_json
-        ) VALUES (
-            :activity_id, :activity_name, :activity_type, :activity_type_id,
-            :parent_type_id, :start_time_local, :start_time_gmt,
-            :duration_seconds, :elapsed_duration_seconds, :moving_duration_seconds,
-            :distance_meters, :calories, :bmr_calories, :average_hr, :max_hr,
-            :average_speed, :max_speed, :elevation_gain, :elevation_loss,
-            :min_elevation, :max_elevation, :avg_power, :max_power, :norm_power,
-            :training_stress_score, :intensity_factor, :aerobic_training_effect,
-            :anaerobic_training_effect, :vo2max_value, :avg_cadence, :max_cadence,
-            :avg_respiration, :training_load, :moderate_intensity_minutes,
-            :vigorous_intensity_minutes, :start_latitude, :start_longitude,
-            :end_latitude, :end_longitude, :location_name, :lap_count,
-            :water_estimated, :min_temperature, :max_temperature,
-            :manufacturer, :device_id, :raw_json
-        )
+        UPDATE activity SET
+            activity_name = :activity_name,
+            activity_type = :activity_type,
+            activity_type_id = :activity_type_id,
+            parent_type_id = :parent_type_id,
+            start_time_local = :start_time_local,
+            start_time_gmt = :start_time_gmt,
+            duration_seconds = :duration_seconds,
+            elapsed_duration_seconds = :elapsed_duration_seconds,
+            moving_duration_seconds = :moving_duration_seconds,
+            distance_meters = :distance_meters,
+            calories = :calories,
+            bmr_calories = :bmr_calories,
+            average_hr = :average_hr,
+            max_hr = :max_hr,
+            average_speed = :average_speed,
+            max_speed = :max_speed,
+            elevation_gain = :elevation_gain,
+            elevation_loss = :elevation_loss,
+            min_elevation = :min_elevation,
+            max_elevation = :max_elevation,
+            avg_power = :avg_power,
+            max_power = :max_power,
+            norm_power = :norm_power,
+            training_stress_score = :training_stress_score,
+            intensity_factor = :intensity_factor,
+            aerobic_training_effect = :aerobic_training_effect,
+            anaerobic_training_effect = :anaerobic_training_effect,
+            vo2max_value = :vo2max_value,
+            avg_cadence = :avg_cadence,
+            max_cadence = :max_cadence,
+            avg_respiration = :avg_respiration,
+            training_load = :training_load,
+            moderate_intensity_minutes = :moderate_intensity_minutes,
+            vigorous_intensity_minutes = :vigorous_intensity_minutes,
+            start_latitude = :start_latitude,
+            start_longitude = :start_longitude,
+            end_latitude = :end_latitude,
+            end_longitude = :end_longitude,
+            location_name = :location_name,
+            lap_count = :lap_count,
+            water_estimated = :water_estimated,
+            min_temperature = :min_temperature,
+            max_temperature = :max_temperature,
+            manufacturer = :manufacturer,
+            device_id = :device_id,
+            body_battery_change      = COALESCE(:body_battery_change, body_battery_change),
+            total_work_kcal          = COALESCE(:total_work_kcal, total_work_kcal),
+            avg_grade_adjusted_speed = COALESCE(:avg_grade_adjusted_speed, avg_grade_adjusted_speed),
+            activity_steps           = COALESCE(:activity_steps, activity_steps),
+            activity_min_hr          = COALESCE(:activity_min_hr, activity_min_hr),
+            raw_json = :raw_json
+        WHERE activity_id = :activity_id
         """,
         {
-            "activity_id": record.get("activityId"),
+            "activity_id": activity_id,
             "activity_name": record.get("activityName"),
             "activity_type": activity_type_key,
             "activity_type_id": activity_type_id,
@@ -1304,6 +1876,11 @@ def upsert_activity(conn: sqlite3.Connection, record: dict) -> None:
             "max_temperature": record.get("maxTemperature"),
             "manufacturer": record.get("manufacturer"),
             "device_id": record.get("deviceId"),
+            "body_battery_change": summary.get("differenceBodyBattery"),
+            "total_work_kcal": summary.get("totalWork"),
+            "avg_grade_adjusted_speed": summary.get("avgGradeAdjustedSpeed"),
+            "activity_steps": summary.get("steps"),
+            "activity_min_hr": summary.get("minHR"),
             "raw_json": json.dumps(record),
         },
     )
@@ -1363,11 +1940,11 @@ def upsert_hrv(conn: sqlite3.Connection, record: dict) -> None:
         """
         INSERT OR REPLACE INTO hrv (
             calendar_date, weekly_avg, last_night, last_night_avg,
-            last_night_5min_high, status, baseline_low, baseline_upper,
+            last_night_5min_high, status, feedback_phrase, baseline_low, baseline_upper,
             start_timestamp, end_timestamp, raw_json
         ) VALUES (
             :calendar_date, :weekly_avg, :last_night, :last_night_avg,
-            :last_night_5min_high, :status, :baseline_low, :baseline_upper,
+            :last_night_5min_high, :status, :feedback_phrase, :baseline_low, :baseline_upper,
             :start_timestamp, :end_timestamp, :raw_json
         )
         """,
@@ -1378,6 +1955,7 @@ def upsert_hrv(conn: sqlite3.Connection, record: dict) -> None:
             "last_night_avg": record.get("lastNightAvg") or record.get("lastNight5MinHigh"),
             "last_night_5min_high": record.get("lastNight5MinHigh"),
             "status": record.get("status"),
+            "feedback_phrase": record.get("feedbackPhrase"),
             "baseline_low": record.get("baselineLowUpper"),
             "baseline_upper": record.get("baselineBalancedUpper"),
             "start_timestamp": record.get("startTimestampLocal") or record.get("startTimestampGMT"),
@@ -1394,16 +1972,28 @@ def upsert_heart_rate(conn: sqlite3.Connection, record: dict, cal_date: str = No
     avg_hr = (
         record.get("averageHeartRate") or record.get("avgHR") or _mean_sample_values(record.get("heartRateValues"), 1)
     )
+    # gql_heart_rate_detail also routes here but lacks lastSevenDaysAvgRestingHeartRate.
+    # COALESCE preserves the value written by the REST endpoint.
+    conn.execute("INSERT OR IGNORE INTO heart_rate (calendar_date) VALUES (?)", (d,))
     conn.execute(
-        "INSERT OR REPLACE INTO heart_rate (calendar_date, resting_hr, min_hr, max_hr, avg_hr, raw_json) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
+        """
+        UPDATE heart_rate SET
+            resting_hr              = ?,
+            min_hr                  = ?,
+            max_hr                  = ?,
+            avg_hr                  = ?,
+            last_7day_avg_resting   = COALESCE(?, last_7day_avg_resting),
+            raw_json                = ?
+        WHERE calendar_date = ?
+        """,
         (
-            d,
             record.get("restingHeartRate") or record.get("restingHR"),
             record.get("minHeartRate") or record.get("minHR"),
             record.get("maxHeartRate") or record.get("maxHR"),
             avg_hr,
+            record.get("lastSevenDaysAvgRestingHeartRate"),
             json.dumps(record),
+            d,
         ),
     )
 
@@ -1417,7 +2007,7 @@ def upsert_stress(conn: sqlite3.Connection, record: dict, cal_date: str = None) 
         "VALUES (?, ?, ?, ?, ?)",
         (
             d,
-            record.get("averageStressLevel") or record.get("overallStressLevel"),
+            record.get("avgStressLevel") or record.get("averageStressLevel") or record.get("overallStressLevel"),
             record.get("maxStressLevel") or record.get("highStressDuration"),
             record.get("stressQualifier"),
             json.dumps(record),
@@ -1430,12 +2020,16 @@ def upsert_spo2(conn: sqlite3.Connection, record: dict, cal_date: str = None) ->
     if not d:
         return
     conn.execute(
-        "INSERT OR REPLACE INTO spo2 (calendar_date, avg_spo2, min_spo2, max_spo2, raw_json) VALUES (?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO spo2 "
+        "(calendar_date, avg_spo2, min_spo2, max_spo2, events_below_threshold, duration_below_threshold_secs, raw_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
         (
             d,
             record.get("averageSpo2") or record.get("averageSpO2"),
             record.get("lowestSpo2") or record.get("lowestSpO2"),
             record.get("latestSpo2") or record.get("latestSpO2"),
+            record.get("numberOfEventsBelowThreshold"),
+            record.get("durationOfEventsBelowThreshold"),
             json.dumps(record),
         ),
     )
@@ -1445,15 +2039,26 @@ def upsert_respiration(conn: sqlite3.Connection, record: dict, cal_date: str = N
     d = cal_date or record.get("calendarDate") or record.get("date")
     if not d:
         return
+    # avgSleepRespirationValue may be absent on same-day syncs (sleep not yet processed).
+    # COALESCE preserves the value once it arrives without requiring a full re-sync.
+    conn.execute("INSERT OR IGNORE INTO respiration (calendar_date) VALUES (?)", (d,))
     conn.execute(
-        "INSERT OR REPLACE INTO respiration (calendar_date, avg_waking, min_value, max_value, raw_json) "
-        "VALUES (?, ?, ?, ?, ?)",
+        """
+        UPDATE respiration SET
+            avg_waking  = ?,
+            avg_sleep   = COALESCE(?, avg_sleep),
+            min_value   = ?,
+            max_value   = ?,
+            raw_json    = ?
+        WHERE calendar_date = ?
+        """,
         (
-            d,
             record.get("avgWakingRespirationValue"),
+            record.get("avgSleepRespirationValue"),
             record.get("lowestRespirationValue"),
             record.get("highestRespirationValue"),
             json.dumps(record),
+            d,
         ),
     )
 
@@ -1553,13 +2158,26 @@ def upsert_hydration(conn: sqlite3.Connection, record: dict, cal_date: str = Non
     d = cal_date or record.get("calendarDate") or record.get("date")
     if not d:
         return
+    # sweatLossInML / activityIntakeInML may be absent depending on endpoint variant.
+    # COALESCE preserves values once written without requiring a full re-sync.
+    conn.execute("INSERT OR IGNORE INTO hydration (calendar_date) VALUES (?)", (d,))
     conn.execute(
-        "INSERT OR REPLACE INTO hydration (calendar_date, goal_ml, intake_ml, raw_json) VALUES (?, ?, ?, ?)",
+        """
+        UPDATE hydration SET
+            goal_ml             = ?,
+            intake_ml           = ?,
+            sweat_loss_ml       = COALESCE(?, sweat_loss_ml),
+            activity_intake_ml  = COALESCE(?, activity_intake_ml),
+            raw_json            = ?
+        WHERE calendar_date = ?
+        """,
         (
-            d,
             record.get("goalInML") or record.get("baseGoalInML"),
             record.get("intakeInML") or record.get("valueInML"),
+            record.get("sweatLossInML"),
+            record.get("activityIntakeInML"),
             json.dumps(record),
+            d,
         ),
     )
 
@@ -1569,12 +2187,13 @@ def upsert_fitness_age(conn: sqlite3.Connection, record: dict, cal_date: str = N
     if not d:
         return
     conn.execute(
-        "INSERT OR REPLACE INTO fitness_age (calendar_date, chronological_age, fitness_age, raw_json) "
-        "VALUES (?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO fitness_age (calendar_date, chronological_age, fitness_age, achievable_fitness_age, raw_json) "
+        "VALUES (?, ?, ?, ?, ?)",
         (
             d,
             record.get("chronologicalAge"),
             record.get("fitnessAge"),
+            record.get("achievableFitnessAge"),
             json.dumps(record),
         ),
     )
@@ -1624,8 +2243,9 @@ def upsert_weight(conn: sqlite3.Connection, record: dict, cal_date: str = None) 
 
     conn.execute(
         """INSERT OR REPLACE INTO weight
-           (timestamp, calendar_date, weight, bmi, body_fat, body_water, bone_mass, muscle_mass, source, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           (timestamp, calendar_date, weight, bmi, body_fat, body_water, bone_mass, muscle_mass,
+            metabolic_age, physique_rating, visceral_fat, source, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             actual_ts,
             d,
@@ -1635,6 +2255,9 @@ def upsert_weight(conn: sqlite3.Connection, record: dict, cal_date: str = None) 
             record.get("bodyWater"),
             record.get("boneMass"),
             record.get("muscleMass"),
+            record.get("metabolicAge"),
+            record.get("physiqueRating"),
+            record.get("visceralFat"),
             source,
             json.dumps(record),
         ),
@@ -1700,16 +2323,20 @@ def upsert_endurance_score(conn: sqlite3.Connection, record: dict, cal_date: str
     d = cal_date or record.get("calendarDate") or record.get("date")
     if not d:
         return
+    contributors = record.get("contributors")
     conn.execute(
         """INSERT OR REPLACE INTO endurance_score
-           (calendar_date, overall_score, classification, vo2_max, vo2_max_precise, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?)""",
+           (calendar_date, overall_score, classification, vo2_max, vo2_max_precise,
+            feedback_phrase, contributors, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             d,
             record.get("overallScore"),
             record.get("classification"),
             record.get("vo2Max"),
             record.get("vo2MaxPreciseValue"),
+            record.get("feedbackPhrase"),
+            json.dumps(contributors) if contributors is not None else None,
             json.dumps(record),
         ),
     )
@@ -1721,13 +2348,17 @@ def upsert_hill_score(conn: sqlite3.Connection, record: dict, cal_date: str = No
         return
     conn.execute(
         """INSERT OR REPLACE INTO hill_score
-           (calendar_date, overall_score, endurance_score, strength_score, raw_json)
-           VALUES (?, ?, ?, ?, ?)""",
+           (calendar_date, overall_score, endurance_score, strength_score,
+            vo2_max, vo2_max_precise, feedback_phrase_id, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             d,
             record.get("overallScore"),
             record.get("enduranceScore"),
             record.get("strengthScore"),
+            record.get("vo2Max"),
+            record.get("vo2MaxPreciseValue"),
+            record.get("hillScoreFeedbackPhraseId"),
             json.dumps(record),
         ),
     )
@@ -1762,8 +2393,16 @@ def upsert_activity_splits(conn: sqlite3.Connection, activity_id: int, data) -> 
             """INSERT OR REPLACE INTO activity_splits
                (activity_id, split_number, distance_meters, duration_seconds,
                 average_speed, average_hr, max_hr, elevation_gain, elevation_loss,
-                avg_cadence, raw_json)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                avg_cadence, avg_swim_cadence, avg_swolf, total_strokes,
+                swim_stroke, num_active_lengths,
+                normalized_power, avg_respiration_rate, max_respiration_rate,
+                start_latitude, start_longitude, end_latitude, end_longitude,
+                start_time_gmt, calories,
+                left_pedal_smoothness, right_pedal_smoothness,
+                left_torque_effectiveness, right_torque_effectiveness,
+                surface_unpaved_pct, raw_json)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                       ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 activity_id,
                 i + 1,
@@ -1775,6 +2414,25 @@ def upsert_activity_splits(conn: sqlite3.Connection, activity_id: int, data) -> 
                 split.get("elevationGain"),
                 split.get("elevationLoss"),
                 split.get("averageRunCadence") or split.get("averageBikeCadence"),
+                split.get("averageSwimCadence") or None,
+                split.get("averageSWOLF") or None,
+                split.get("totalNumberOfStrokes") or None,
+                split.get("swimStroke"),
+                split.get("numberOfActiveLengths") or None,
+                split.get("normalizedPower"),
+                split.get("avgRespirationRate"),
+                split.get("maxRespirationRate"),
+                split.get("startLatitude"),
+                split.get("startLongitude"),
+                split.get("endLatitude"),
+                split.get("endLongitude"),
+                split.get("startTimeGMT"),
+                split.get("calories"),
+                split.get("leftPedalSmoothness"),
+                split.get("rightPedalSmoothness"),
+                split.get("leftTorqueEffectiveness"),
+                split.get("rightTorqueEffectiveness"),
+                split.get("surfaceTypeUnpavedPercentage"),
                 json.dumps(split),
             ),
         )
@@ -1908,8 +2566,22 @@ def upsert_daily_movement(conn, record, cal_date=None):
 
 def upsert_wellness_activity(conn, record, cal_date=None):
     d = cal_date or record.get("calendarDate") or record.get("date")
-    if d:
-        _upsert_raw_only(conn, "wellness_activity", "calendar_date", record, d)
+    if not d:
+        return
+    conn.execute(
+        """INSERT OR REPLACE INTO wellness_activity
+           (calendar_date, activity_name, wellness_activity_type,
+            start_timestamp_local, end_timestamp_local, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (
+            d,
+            record.get("activityName"),
+            record.get("wellnessActivityType"),
+            record.get("startTimestampLocal"),
+            record.get("endTimestampLocal"),
+            json.dumps(record),
+        ),
+    )
 
 
 def upsert_training_status(conn, record, cal_date=None):
@@ -1967,8 +2639,27 @@ def upsert_health_status(conn, record, cal_date=None):
 
 def upsert_daily_events(conn, record, cal_date=None):
     d = cal_date or record.get("calendarDate") or record.get("date")
-    if d:
-        _upsert_raw_only(conn, "daily_events", "calendar_date", record, d)
+    if not d:
+        return
+    # record may be a list of event objects; use the first non-rest event for scalars
+    events = record if isinstance(record, list) else [record]
+    primary = next((e for e in events if e.get("activityType")), events[0] if events else {})
+    conn.execute(
+        """INSERT OR REPLACE INTO daily_events
+           (calendar_date, activity_type, activity_sub_type,
+            start_timestamp_local, end_timestamp_local, duration_seconds, device_id, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            d,
+            primary.get("activityType"),
+            primary.get("activitySubType"),
+            primary.get("startTimestampLocal"),
+            primary.get("endTimestampLocal"),
+            primary.get("duration"),
+            primary.get("deviceId"),
+            json.dumps(record),
+        ),
+    )
 
 
 def upsert_activity_trends(conn, record, activity_type="all", cal_date=None):
@@ -1988,8 +2679,22 @@ def upsert_sleep_stats(conn, record):
 
 def upsert_health_snapshot(conn, record):
     d = record.get("calendarDate") or record.get("date")
-    if d:
-        _upsert_raw_only(conn, "health_snapshot", "calendar_date", record, d)
+    if not d:
+        return
+    conn.execute(
+        """INSERT OR REPLACE INTO health_snapshot
+           (calendar_date, activity_name, wellness_activity_type,
+            start_timestamp_local, end_timestamp_local, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (
+            d,
+            record.get("activityName"),
+            record.get("wellnessActivityType"),
+            record.get("startTimestampLocal"),
+            record.get("endTimestampLocal"),
+            json.dumps(record),
+        ),
+    )
 
 
 def upsert_workout_schedule(conn, record):
@@ -2066,15 +2771,22 @@ def upsert_gear(conn, record):
         return
     conn.execute(
         """INSERT OR REPLACE INTO gear
-           (gear_id, gear_type, display_name, brand, model, date_begin, raw_json)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+           (gear_id, gear_type, display_name, brand, model, date_begin,
+            distance_used_meters, duration_used_seconds, days_used,
+            status, max_usage_distance_meters, raw_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             str(g_id),
-            record.get("gearTypeName"),
-            record.get("displayName"),
-            record.get("customMakeModel") or record.get("brandName"),
-            record.get("modelName"),
-            record.get("dateBegin"),
+            record.get("gearTypeName") or record.get("gearType"),
+            record.get("displayName") or record.get("name"),
+            record.get("customMakeModel") or record.get("brandName") or record.get("brand"),
+            record.get("modelName") or record.get("model"),
+            record.get("dateBegin") or record.get("firstUseDate"),
+            record.get("distanceUsedMeters"),
+            record.get("durationUsedSeconds"),
+            record.get("daysUsed"),
+            record.get("status"),
+            record.get("maxUsageDistanceMeters"),
             json.dumps(record),
         ),
     )

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -606,12 +606,14 @@ def garmin_today() -> str:
     try:
         daily = query(
             conn,
-            """SELECT total_steps, resting_heart_rate, average_stress_level,
-                      max_stress_level, body_battery_highest, body_battery_lowest,
-                      body_battery_at_wake, average_spo2, lowest_spo2,
-                      avg_waking_respiration, total_kilocalories, active_kilocalories,
+            """SELECT total_steps, resting_heart_rate, min_heart_rate, max_heart_rate,
+                      average_stress_level, max_stress_level,
+                      body_battery_highest, body_battery_lowest, body_battery_at_wake,
+                      average_spo2, lowest_spo2, avg_waking_respiration,
+                      total_kilocalories, active_kilocalories,
                       moderate_intensity_minutes, vigorous_intensity_minutes,
-                      floors_ascended, sedentary_seconds, active_seconds
+                      floors_ascended, sedentary_seconds, active_seconds,
+                      highly_active_seconds, sleeping_seconds
                FROM daily_summary WHERE calendar_date = ?""",
             [today],
         )
@@ -631,7 +633,8 @@ def garmin_today() -> str:
 
         tr = query(
             conn,
-            """SELECT score, level, feedback_short,
+            """SELECT score, level, feedback_short, feedback_long,
+                      recovery_time, recovery_time_factor_percent, recovery_time_factor_feedback,
                       hrv_factor_percent, hrv_factor_feedback, hrv_weekly_average,
                       sleep_history_factor_percent, sleep_history_factor_feedback,
                       stress_history_factor_percent, stress_history_factor_feedback,
@@ -714,15 +717,32 @@ def garmin_activity_detail(activity_id: int = 0, last: bool = False) -> str:
             conn,
             """SELECT activity_id, activity_name, activity_type, start_time_local,
                       ROUND(duration_seconds / 60.0, 1) AS duration_min,
+                      ROUND(elapsed_duration_seconds / 60.0, 1) AS elapsed_duration_min,
+                      ROUND(moving_duration_seconds / 60.0, 1) AS moving_duration_min,
                       ROUND(distance_meters / 1000.0, 2) AS distance_km,
                       calories, ROUND(average_hr, 0) AS avg_hr, ROUND(max_hr, 0) AS max_hr,
+                      ROUND(average_speed, 3) AS avg_speed_mps,
+                      ROUND(max_speed, 3) AS max_speed_mps,
                       ROUND(elevation_gain, 0) AS elevation_gain_m,
+                      ROUND(elevation_loss, 0) AS elevation_loss_m,
+                      ROUND(min_elevation, 0) AS min_elevation_m,
+                      ROUND(max_elevation, 0) AS max_elevation_m,
                       ROUND(avg_power, 0) AS avg_power_w,
+                      ROUND(max_power, 0) AS max_power_w,
+                      ROUND(norm_power, 0) AS norm_power_w,
+                      ROUND(training_stress_score, 1) AS tss,
+                      intensity_factor,
                       ROUND(training_load, 1) AS training_load,
                       aerobic_training_effect, anaerobic_training_effect,
-                      vo2max_value, ROUND(avg_cadence, 0) AS avg_cadence,
+                      vo2max_value,
+                      ROUND(avg_cadence, 0) AS avg_cadence,
+                      ROUND(max_cadence, 0) AS max_cadence,
                       ROUND(avg_respiration, 1) AS avg_respiration,
-                      location_name
+                      lap_count, location_name,
+                      min_temperature, max_temperature,
+                      body_battery_change, total_work_kcal,
+                      ROUND(avg_grade_adjusted_speed, 3) AS avg_grade_adjusted_speed_mps,
+                      activity_steps, activity_min_hr
                FROM activity WHERE activity_id = ?""",
             [activity_id],
         )
@@ -736,7 +756,14 @@ def garmin_activity_detail(activity_id: int = 0, last: bool = False) -> str:
                       ROUND(average_speed, 3) AS avg_speed,
                       ROUND(average_hr, 0) AS avg_hr, ROUND(max_hr, 0) AS max_hr,
                       ROUND(elevation_gain, 1) AS elev_gain,
-                      ROUND(avg_cadence, 0) AS avg_cadence
+                      ROUND(elevation_loss, 1) AS elev_loss,
+                      ROUND(avg_cadence, 0) AS avg_cadence,
+                      avg_swim_cadence, avg_swolf, total_strokes,
+                      swim_stroke, num_active_lengths,
+                      ROUND(normalized_power, 0) AS norm_power_w,
+                      ROUND(avg_respiration_rate, 1) AS avg_resp,
+                      ROUND(max_respiration_rate, 1) AS max_resp,
+                      ROUND(calories, 0) AS calories
                FROM activity_splits WHERE activity_id = ?
                ORDER BY split_number""",
             [activity_id],
@@ -875,10 +902,12 @@ def garmin_sleep(start_date: str = "", days: int = 7) -> str:
             conn,
             """SELECT calendar_date,
                       ROUND(sleep_time_seconds / 3600.0, 2) AS total_hours,
+                      ROUND(nap_time_seconds / 60.0, 0) AS nap_min,
                       ROUND(deep_sleep_seconds / 60.0, 0) AS deep_min,
                       ROUND(light_sleep_seconds / 60.0, 0) AS light_min,
                       ROUND(rem_sleep_seconds / 60.0, 0) AS rem_min,
                       ROUND(awake_sleep_seconds / 60.0, 0) AS awake_min,
+                      ROUND(unmeasurable_sleep_seconds / 60.0, 0) AS unmeasurable_min,
                       awake_count,
                       CASE WHEN sleep_time_seconds > 0
                            THEN ROUND(deep_sleep_seconds * 100.0 / sleep_time_seconds, 1)
@@ -888,10 +917,20 @@ def garmin_sleep(start_date: str = "", days: int = 7) -> str:
                            ELSE 0 END AS rem_pct,
                       average_spo2, lowest_spo2,
                       average_hr_sleep AS avg_hr,
+                      resting_heart_rate,
+                      body_battery_change,
                       average_respiration AS avg_resp,
+                      lowest_respiration, highest_respiration,
                       avg_sleep_stress,
+                      avg_skin_temp_deviation_c, avg_skin_temp_deviation_f,
                       sleep_score_feedback AS feedback,
-                      sleep_score_insight AS insight
+                      sleep_score_insight AS insight,
+                      sleep_need_minutes,
+                      highest_spo2,
+                      sleep_score_overall,
+                      sleep_light_pct,
+                      sleep_score_rem,
+                      sleep_score_deep
                FROM sleep
                WHERE calendar_date BETWEEN ? AND ?
                ORDER BY calendar_date""",
@@ -1201,6 +1240,7 @@ def garmin_fitness_age(period: str = "month") -> str:
             f"""SELECT {group_expr} AS period,
                        ROUND(AVG(chronological_age), 1) AS chrono_age,
                        ROUND(AVG(fitness_age), 1) AS fitness_age,
+                       ROUND(AVG(achievable_fitness_age), 1) AS avg_achievable_fitness_age,
                        ROUND(AVG(chronological_age) - AVG(fitness_age), 1) AS gap_years,
                        ROUND(MIN(fitness_age), 1) AS best_fitness_age
                 FROM fitness_age
@@ -1248,8 +1288,9 @@ def garmin_hrv(days: int = 30) -> str:
     try:
         rows = query(
             conn,
-            """SELECT calendar_date, weekly_avg, last_night_avg,
-                      last_night_5min_high, status, baseline_low, baseline_upper
+            """SELECT calendar_date, weekly_avg, last_night, last_night_avg,
+                      last_night_5min_high, status, feedback_phrase,
+                      baseline_low, baseline_upper, start_timestamp, end_timestamp
                FROM hrv WHERE calendar_date >= ? ORDER BY calendar_date""",
             [start],
         )
@@ -1326,19 +1367,22 @@ def garmin_body_battery(days: int = 14) -> str:
     try:
         rows = query(
             conn,
-            """SELECT d.calendar_date,
-                      d.body_battery_highest AS high,
-                      d.body_battery_lowest AS low,
-                      d.body_battery_at_wake AS at_wake,
-                      d.body_battery_during_sleep AS sleep_charge,
-                      d.body_battery_highest - d.body_battery_lowest AS daily_range,
+            """SELECT bb.calendar_date,
+                      bb.highest AS high,
+                      bb.lowest AS low,
+                      bb.charged,
+                      bb.drained,
+                      bb.most_recent,
+                      bb.at_wake,
+                      bb.during_sleep AS sleep_charge,
+                      bb.highest - bb.lowest AS daily_range,
                       s.deep_sleep_seconds,
                       ROUND(s.sleep_time_seconds / 3600.0, 2) AS sleep_hours,
                       s.avg_sleep_stress
-               FROM daily_summary d
-               LEFT JOIN sleep s ON d.calendar_date = s.calendar_date
-               WHERE d.calendar_date >= ?
-               ORDER BY d.calendar_date""",
+               FROM body_battery bb
+               LEFT JOIN sleep s ON bb.calendar_date = s.calendar_date
+               WHERE bb.calendar_date >= ?
+               ORDER BY bb.calendar_date""",
             [start],
         )
 
@@ -1383,16 +1427,17 @@ def garmin_stress(days: int = 14) -> str:
     try:
         rows = query(
             conn,
-            """SELECT calendar_date,
-                      average_stress_level AS avg_stress,
-                      max_stress_level AS max_stress,
-                      ROUND(low_stress_seconds / 3600.0, 1) AS low_stress_hrs,
-                      ROUND(medium_stress_seconds / 3600.0, 1) AS med_stress_hrs,
-                      ROUND(high_stress_seconds / 3600.0, 1) AS high_stress_hrs,
-                      stress_qualifier
-               FROM daily_summary
-               WHERE calendar_date >= ? AND average_stress_level IS NOT NULL
-               ORDER BY calendar_date""",
+            """SELECT s.calendar_date,
+                      s.avg_stress,
+                      s.max_stress,
+                      s.stress_qualifier,
+                      ROUND(ds.low_stress_seconds / 3600.0, 1) AS low_stress_hrs,
+                      ROUND(ds.medium_stress_seconds / 3600.0, 1) AS med_stress_hrs,
+                      ROUND(ds.high_stress_seconds / 3600.0, 1) AS high_stress_hrs
+               FROM stress s
+               LEFT JOIN daily_summary ds ON s.calendar_date = ds.calendar_date
+               WHERE s.calendar_date >= ? AND s.avg_stress IS NOT NULL
+               ORDER BY s.calendar_date""",
             [start],
         )
 
@@ -1433,11 +1478,18 @@ def garmin_heart_rate(days: int = 30) -> str:
     try:
         rows = query(
             conn,
-            """SELECT calendar_date, resting_heart_rate AS rhr,
-                      min_heart_rate AS min_hr, max_heart_rate AS max_hr
-               FROM daily_summary
-               WHERE calendar_date >= ? AND resting_heart_rate IS NOT NULL
-               ORDER BY calendar_date""",
+            """SELECT hr.calendar_date, hr.resting_hr AS rhr,
+                      hr.min_hr, hr.max_hr, hr.avg_hr,
+                      hr.last_7day_avg_resting,
+                      hr.last_7day_avg_resting AS avg_resting_heart_rate_7day,
+                      ds.min_heart_rate AS ds_min_hr,
+                      ds.max_heart_rate AS ds_max_hr,
+                      ds.highly_active_seconds,
+                      ds.sleeping_seconds
+               FROM heart_rate hr
+               LEFT JOIN daily_summary ds ON hr.calendar_date = ds.calendar_date
+               WHERE hr.calendar_date >= ? AND hr.resting_hr IS NOT NULL
+               ORDER BY hr.calendar_date""",
             [start],
         )
         if not rows:
@@ -1456,8 +1508,13 @@ def garmin_heart_rate(days: int = 30) -> str:
                     "rhr": rhr,
                     "min_hr": r["min_hr"],
                     "max_hr": r["max_hr"],
-                    "avg_7d": avg_7d,
+                    "avg_hr": r["avg_hr"],
+                    "garmin_7d_avg": r["last_7day_avg_resting"],
+                    "avg_resting_heart_rate_7day": r["avg_resting_heart_rate_7day"],
+                    "computed_7d_avg": avg_7d,
                     "elevated": elevated,
+                    "highly_active_seconds": r["highly_active_seconds"],
+                    "sleeping_seconds": r["sleeping_seconds"],
                 }
             )
 
@@ -1502,20 +1559,19 @@ def garmin_spo2(days: int = 14) -> str:
         rows = query(
             conn,
             """SELECT calendar_date,
-                      average_spo2 AS avg_spo2,
-                      lowest_spo2 AS min_spo2,
-                      latest_spo2 AS latest,
-                      CASE WHEN average_spo2 < 95 THEN 1 ELSE 0 END AS below_normal,
-                      CASE WHEN lowest_spo2 < 80 THEN 1 ELSE 0 END AS critical_low
-               FROM daily_summary
-               WHERE calendar_date >= ? AND average_spo2 IS NOT NULL
+                      avg_spo2, min_spo2, max_spo2,
+                      events_below_threshold, duration_below_threshold_secs,
+                      CASE WHEN avg_spo2 < 95 THEN 1 ELSE 0 END AS below_normal,
+                      CASE WHEN min_spo2 < 80 THEN 1 ELSE 0 END AS critical_low
+               FROM spo2
+               WHERE calendar_date >= ? AND avg_spo2 IS NOT NULL
                ORDER BY calendar_date""",
             [start],
         )
 
         avgs = [r["avg_spo2"] for r in rows if r["avg_spo2"]]
-        below_count = sum(1 for r in rows if r["below_normal"])
-        critical_count = sum(1 for r in rows if r["critical_low"])
+        below_count = sum(1 for r in rows if r.get("below_normal"))
+        critical_count = sum(1 for r in rows if r.get("critical_low"))
 
         result = {
             "summary": {
@@ -1557,6 +1613,7 @@ def garmin_body_composition() -> str:
                       ROUND(body_water, 1) AS body_water_pct,
                       ROUND(bone_mass / 1000.0, 2) AS bone_mass_kg,
                       ROUND(muscle_mass / 1000.0, 1) AS muscle_mass_kg,
+                      metabolic_age, physique_rating, visceral_fat,
                       source
                FROM weight
                WHERE weight IS NOT NULL
@@ -1588,7 +1645,8 @@ def garmin_devices() -> str:
     try:
         rows = query(
             conn,
-            """SELECT display_name, device_type, last_sync
+            """SELECT device_id, display_name, device_type, application_key,
+                      last_sync, software_version, battery_status, battery_voltage
                FROM device ORDER BY last_sync DESC""",
         )
         return json.dumps(rows, indent=2, default=str)
@@ -1934,6 +1992,7 @@ def garmin_hydration(days: int = 30) -> str:
             conn,
             """SELECT calendar_date,
                       goal_ml, intake_ml,
+                      sweat_loss_ml, activity_intake_ml,
                       CASE WHEN goal_ml > 0
                            THEN ROUND(intake_ml * 100.0 / goal_ml, 0)
                            ELSE NULL END AS pct_of_goal
@@ -1977,11 +2036,11 @@ def garmin_respiration(days: int = 14) -> str:
         rows = query(
             conn,
             """SELECT calendar_date,
-                      avg_waking_respiration AS avg_waking,
-                      highest_respiration AS max_resp,
-                      lowest_respiration AS min_resp
-               FROM daily_summary
-               WHERE calendar_date >= ? AND avg_waking_respiration IS NOT NULL
+                      avg_waking, avg_sleep,
+                      max_value AS max_resp,
+                      min_value AS min_resp
+               FROM respiration
+               WHERE calendar_date >= ? AND avg_waking IS NOT NULL
                ORDER BY calendar_date""",
             [start],
         )
@@ -2412,7 +2471,7 @@ def garmin_endurance_score(days: int = 30) -> str:
         rows = query(
             conn,
             """SELECT calendar_date, overall_score, classification,
-                      vo2_max_precise
+                      vo2_max, vo2_max_precise, feedback_phrase, contributors
                FROM endurance_score
                WHERE calendar_date >= ? AND overall_score IS NOT NULL
                ORDER BY calendar_date""",
@@ -2454,7 +2513,8 @@ def garmin_hill_score(days: int = 30) -> str:
         rows = query(
             conn,
             """SELECT calendar_date, overall_score,
-                      endurance_score, strength_score
+                      endurance_score, strength_score,
+                      vo2_max, vo2_max_precise, feedback_phrase_id
                FROM hill_score
                WHERE calendar_date >= ? AND overall_score IS NOT NULL
                ORDER BY calendar_date""",
@@ -2534,14 +2594,21 @@ def garmin_health_snapshot() -> str:
     try:
         rows = query(
             conn,
-            """SELECT calendar_date, raw_json
+            """SELECT calendar_date, activity_name, wellness_activity_type,
+                      start_timestamp_local, end_timestamp_local, raw_json
                FROM health_snapshot
                ORDER BY calendar_date DESC""",
         )
 
         parsed = []
         for r in rows:
-            entry = {"date": r["calendar_date"]}
+            entry = {
+                "date": r["calendar_date"],
+                "activity_name": r["activity_name"],
+                "wellness_activity_type": r["wellness_activity_type"],
+                "start": r["start_timestamp_local"],
+                "end": r["end_timestamp_local"],
+            }
             if r["raw_json"]:
                 try:
                     entry["data"] = json.loads(r["raw_json"])
@@ -2575,7 +2642,9 @@ def garmin_gear() -> str:
         rows = query(
             conn,
             """SELECT gear_id, gear_type, display_name,
-                      brand, model, date_begin
+                      brand, model, date_begin,
+                      distance_used_meters, duration_used_seconds, days_used,
+                      status, max_usage_distance_meters
                FROM gear""",
         )
         return json.dumps(
@@ -2604,7 +2673,9 @@ def garmin_daily_events(days: int = 7) -> str:
     try:
         rows = query(
             conn,
-            """SELECT calendar_date, raw_json
+            """SELECT calendar_date, activity_type, activity_sub_type,
+                      start_timestamp_local, end_timestamp_local,
+                      duration_seconds, device_id, raw_json
                FROM daily_events
                WHERE calendar_date >= ?
                ORDER BY calendar_date DESC""",
@@ -2613,7 +2684,15 @@ def garmin_daily_events(days: int = 7) -> str:
 
         parsed = []
         for r in rows:
-            entry = {"date": r["calendar_date"]}
+            entry = {
+                "date": r["calendar_date"],
+                "activity_type": r["activity_type"],
+                "activity_sub_type": r["activity_sub_type"],
+                "start": r["start_timestamp_local"],
+                "end": r["end_timestamp_local"],
+                "duration_seconds": r["duration_seconds"],
+                "device_id": r["device_id"],
+            }
             if r["raw_json"]:
                 try:
                     entry["events"] = json.loads(r["raw_json"])
@@ -2668,6 +2747,114 @@ def garmin_hr_zones() -> str:
                     entry["zones"] = r["raw_json"]
             parsed.append(entry)
         return json.dumps(parsed, indent=2, default=str)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_load_focus — aerobic/anaerobic training distribution
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_load_focus(days: int = 28) -> str:
+    """Training load distribution across aerobic and anaerobic zones.
+
+    Shows how your training load is split between low aerobic, high aerobic,
+    and anaerobic zones, plus a focus_status indicating whether your training
+    distribution is optimal.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, anaerobic, high_aerobic, low_aerobic, focus_status
+               FROM load_focus
+               WHERE calendar_date >= ?
+               ORDER BY calendar_date""",
+            [start],
+        )
+        return json.dumps(
+            {
+                "latest": rows[-1] if rows else {},
+                "daily": rows,
+                "note": "No load focus data" if not rows else None,
+            },
+            indent=2,
+            default=str,
+        )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_lactate_threshold — lactate threshold pace and HR
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_lactate_threshold() -> str:
+    """Lactate threshold pace and heart rate by sport.
+
+    The lactate threshold is the highest intensity you can sustain aerobically.
+    Used to set training zones and pace targets for races.
+    """
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, speed, heart_rate,
+                      heart_rate_cycling, rowing_speed, heart_rate_rowing
+               FROM lactate_threshold
+               ORDER BY calendar_date DESC""",
+        )
+        return json.dumps(
+            {
+                "latest": rows[0] if rows else {},
+                "history": rows,
+                "note": "No lactate threshold data" if not rows else None,
+            },
+            indent=2,
+            default=str,
+        )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# garmin_wellness_activity — wellness activity sessions
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def garmin_wellness_activity(days: int = 30) -> str:
+    """Wellness activity sessions detected by Garmin (yoga, breathwork, etc).
+
+    These are non-sport wellness sessions tracked separately from regular
+    activities, including start/end times and activity type.
+    """
+    start = str(date.today() - timedelta(days=days - 1))
+    conn = get_connection()
+    try:
+        rows = query(
+            conn,
+            """SELECT calendar_date, activity_name, wellness_activity_type,
+                      start_timestamp_local, end_timestamp_local
+               FROM wellness_activity
+               WHERE calendar_date >= ?
+               ORDER BY calendar_date DESC""",
+            [start],
+        )
+        return json.dumps(
+            {
+                "total": len(rows),
+                "sessions": rows,
+                "note": "No wellness activity data" if not rows else None,
+            },
+            indent=2,
+            default=str,
+        )
     finally:
         conn.close()
 

--- a/garmin_mcp/sync.py
+++ b/garmin_mcp/sync.py
@@ -46,7 +46,7 @@ def _parse_trackpoints_for_activities(conn, activity_ids):
     return total_trackpoints
 
 
-def incremental_sync(target_date: str = None, save_raw: bool = False, parse_trackpoints: bool = True) -> dict:
+def incremental_sync(target_date: str = None, start_date: str = None, save_raw: bool = False, parse_trackpoints: bool = True) -> dict:
     """Fetch today's data from Garmin and save directly to the database.
 
     Parameters
@@ -54,6 +54,9 @@ def incremental_sync(target_date: str = None, save_raw: bool = False, parse_trac
     target_date:
         ISO date string (``YYYY-MM-DD``) to treat as "today".  Defaults to
         the actual current date.
+    start_date:
+        ISO date string (``YYYY-MM-DD``) for the beginning of the fetch range.
+        Defaults to yesterday (incremental). Set to an early date for full-history sync.
     save_raw:
         Whether to save raw JSON responses under the ``debug/raw`` directory
         (next to ``browser_profile``).
@@ -64,13 +67,29 @@ def incremental_sync(target_date: str = None, save_raw: bool = False, parse_trac
     Returns
     -------
     dict
-        Summary with keys: ``status``, ``target_date``, ``yesterday``,
+        Summary with keys: ``status``, ``target_date``, ``start_date``,
         ``records`` (per-endpoint counts), ``total_upserted``.
     """
     from garmin_client import GarminClient
 
     today = target_date or date.today().isoformat()
     yesterday = (date.fromisoformat(today) - timedelta(days=1)).isoformat()
+
+    if start_date is not None:
+        try:
+            parsed_start = date.fromisoformat(start_date)
+        except ValueError:
+            return {
+                "status": "error",
+                "message": f"start_date must be YYYY-MM-DD, got: {start_date!r}",
+            }
+        if parsed_start > date.fromisoformat(today):
+            return {
+                "status": "error",
+                "message": f"start_date ({start_date}) must be on or before target_date ({today})",
+            }
+    effective_start = start_date or yesterday
+    is_backfill = start_date is not None and start_date != yesterday
 
     PROJECT_DIR = Path(__file__).parent.parent
     PROFILE_DIR = PROJECT_DIR / "browser_profile"
@@ -129,7 +148,8 @@ def incremental_sync(target_date: str = None, save_raw: bool = False, parse_trac
         session_file=SESSION_FILE,
     )
 
-    logger.info("Starting incremental sync for %s (+ %s)", today, yesterday)
+    sync_label = "backfill" if is_backfill else "incremental sync"
+    logger.info("Starting %s for %s (from %s)", sync_label, today, effective_start)
 
     try:
         if not client.login():
@@ -137,7 +157,7 @@ def incremental_sync(target_date: str = None, save_raw: bool = False, parse_trac
 
         client.fetch_all(
             target_date=today,
-            start_date=yesterday,
+            start_date=effective_start,
             end_date=today,
             on_batch=on_batch,
             known_activity_ids=known_activity_ids,
@@ -158,17 +178,17 @@ def incremental_sync(target_date: str = None, save_raw: bool = False, parse_trac
     total = sum(counts.values())
     conn.execute(
         "INSERT INTO sync_log (sync_date, sync_type, records_upserted, status) VALUES (?, ?, ?, ?)",
-        (sync_ts, "incremental_sync", total, "ok"),
+        (sync_ts, "backfill" if is_backfill else "incremental_sync", total, "ok"),
     )
     conn.commit()
     conn.close()
 
-    logger.info("Incremental sync complete. Total records upserted: %d", total)
+    logger.info("%s complete. Total records upserted: %d", sync_label.capitalize(), total)
 
     return {
         "status": "ok",
         "target_date": today,
-        "yesterday": yesterday,
+        "start_date": effective_start,
         "records": counts,
         "total_upserted": total,
     }
@@ -179,12 +199,18 @@ def incremental_sync(target_date: str = None, save_raw: bool = False, parse_trac
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
-    arg_date = sys.argv[1] if len(sys.argv) > 1 else None
-    result = incremental_sync(target_date=arg_date)
+    parser = argparse.ArgumentParser(
+        description="Sync data from Garmin Connect into the local SQLite database.",
+        epilog="Example: python -m garmin_mcp.sync --start-date 2018-01-01 (full history backfill)",
+    )
+    parser.add_argument("target_date", nargs="?", help="YYYY-MM-DD (default: today)")
+    parser.add_argument("--start-date", help="YYYY-MM-DD start of range (default: yesterday)")
+    args = parser.parse_args()
+    result = incremental_sync(target_date=args.target_date, start_date=args.start_date)
     print(result)

--- a/garmin_mcp/sync.py
+++ b/garmin_mcp/sync.py
@@ -46,7 +46,9 @@ def _parse_trackpoints_for_activities(conn, activity_ids):
     return total_trackpoints
 
 
-def incremental_sync(target_date: str = None, start_date: str = None, save_raw: bool = False, parse_trackpoints: bool = True) -> dict:
+def incremental_sync(
+    target_date: str = None, start_date: str = None, save_raw: bool = False, parse_trackpoints: bool = True
+) -> dict:
     """Fetch today's data from Garmin and save directly to the database.
 
     Parameters

--- a/tests/test_db_body_battery.py
+++ b/tests/test_db_body_battery.py
@@ -1,0 +1,132 @@
+"""Regression tests for body_battery aggregate backfill from daily_summary.
+
+Issue #13: the body_battery_events endpoint only returns time-series data,
+so the body_battery table's aggregate columns (highest/lowest/charged/etc.)
+were always NULL even though the same values lived in daily_summary.
+"""
+
+import json
+
+from garmin_mcp.db import (
+    backfill_body_battery_from_daily_summaries,
+    upsert_body_battery,
+    upsert_body_battery_from_daily_summary,
+    upsert_daily_summary,
+)
+
+
+def _ds(date: str, **bb) -> dict:
+    """Build a daily_summary record with body_battery aggregate fields."""
+    rec = {"calendarDate": date}
+    rec.update(
+        {
+            "bodyBatteryChargedValue": bb.get("charged"),
+            "bodyBatteryDrainedValue": bb.get("drained"),
+            "bodyBatteryHighestValue": bb.get("highest"),
+            "bodyBatteryLowestValue": bb.get("lowest"),
+            "bodyBatteryMostRecentValue": bb.get("most_recent"),
+            "bodyBatteryAtWakeTime": bb.get("at_wake"),
+            "bodyBatteryDuringSleep": bb.get("during_sleep"),
+        }
+    )
+    return rec
+
+
+def _bb_row(conn, date: str) -> dict:
+    return dict(conn.execute("SELECT * FROM body_battery WHERE calendar_date = ?", (date,)).fetchone() or {})
+
+
+class TestUpsertBodyBatteryFromDailySummary:
+    def test_inserts_new_row_with_aggregates(self, temp_db):
+        upsert_body_battery_from_daily_summary(
+            temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, drained=54, at_wake=99)
+        )
+        row = _bb_row(temp_db, "2026-05-01")
+        assert row["highest"] == 99
+        assert row["lowest"] == 47
+        assert row["charged"] == 53
+        assert row["drained"] == 54
+        assert row["at_wake"] == 99
+
+    def test_updates_existing_row_without_clobbering_raw_json(self, temp_db):
+        # Simulate the events endpoint having populated raw_json + a row
+        # but NOT the aggregate columns
+        events_record = {"bodyBattery": {"data": [["2026-05-01T22:00", 50, 1, 3]]}}
+        upsert_body_battery(temp_db, events_record, cal_date="2026-05-01")
+        before = _bb_row(temp_db, "2026-05-01")
+        assert before["highest"] is None
+        assert before["raw_json"] is not None
+
+        # Now run the daily_summary path
+        upsert_body_battery_from_daily_summary(temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53))
+
+        after = _bb_row(temp_db, "2026-05-01")
+        assert after["highest"] == 99
+        assert after["lowest"] == 47
+        assert after["charged"] == 53
+        # raw_json from events endpoint must survive
+        assert after["raw_json"] == before["raw_json"]
+        assert "bodyBattery" in json.loads(after["raw_json"])
+
+    def test_skips_when_all_values_are_none(self, temp_db):
+        # No body_battery fields in the daily_summary — should not insert
+        upsert_body_battery_from_daily_summary(temp_db, {"calendarDate": "2026-05-01"})
+        assert _bb_row(temp_db, "2026-05-01") == {}
+
+    def test_skips_when_no_calendar_date(self, temp_db):
+        upsert_body_battery_from_daily_summary(temp_db, {"bodyBatteryHighestValue": 99})
+        assert temp_db.execute("SELECT COUNT(*) FROM body_battery").fetchone()[0] == 0
+
+
+class TestBackfillBodyBatteryFromDailySummaries:
+    def test_inserts_missing_rows_and_fills_existing_nulls(self, temp_db):
+        # Three daily_summary rows with body_battery data
+        upsert_daily_summary(temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, drained=54))
+        upsert_daily_summary(temp_db, _ds("2026-05-02", highest=80, lowest=38, charged=56, drained=32))
+        upsert_daily_summary(temp_db, _ds("2026-05-03", highest=84, lowest=38, charged=37, drained=51))
+        # Wipe the body_battery rows that upsert_daily_summary just created
+        # to simulate the pre-fix state where they never existed
+        temp_db.execute("DELETE FROM body_battery")
+        # Plus a body_battery row from the events endpoint with NULL aggregates
+        upsert_body_battery(
+            temp_db,
+            {"bodyBattery": {"data": [["2026-05-02T22:00", 50, 1, 3]]}},
+            cal_date="2026-05-02",
+        )
+        before = _bb_row(temp_db, "2026-05-02")
+        assert before["highest"] is None
+
+        backfill_body_battery_from_daily_summaries(temp_db)
+
+        # All three dates should now have aggregates populated
+        for date, expected_highest in (("2026-05-01", 99), ("2026-05-02", 80), ("2026-05-03", 84)):
+            row = _bb_row(temp_db, date)
+            assert row["highest"] == expected_highest, f"date {date}: highest={row.get('highest')}"
+
+        # Events-endpoint raw_json on 2026-05-02 must have survived
+        row_2 = _bb_row(temp_db, "2026-05-02")
+        assert row_2["raw_json"] is not None
+        assert "bodyBattery" in json.loads(row_2["raw_json"])
+
+    def test_does_not_overwrite_existing_aggregate(self, temp_db):
+        # daily_summary has highest=99, but body_battery already has highest=42
+        # (e.g. set by a different code path). The backfill must keep 42.
+        upsert_daily_summary(temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53))
+        temp_db.execute("UPDATE body_battery SET highest = 42 WHERE calendar_date = '2026-05-01'")
+        backfill_body_battery_from_daily_summaries(temp_db)
+        assert _bb_row(temp_db, "2026-05-01")["highest"] == 42
+
+    def test_skips_dates_without_body_battery_in_daily_summary(self, temp_db):
+        # daily_summary row with NO body battery data — backfill should not
+        # touch body_battery for that date
+        upsert_daily_summary(temp_db, {"calendarDate": "2026-05-01", "totalSteps": 10000})
+        backfill_body_battery_from_daily_summaries(temp_db)
+        assert temp_db.execute("SELECT COUNT(*) FROM body_battery").fetchone()[0] == 0
+
+    def test_idempotent(self, temp_db):
+        upsert_daily_summary(temp_db, _ds("2026-05-01", highest=99, charged=53))
+        backfill_body_battery_from_daily_summaries(temp_db)
+        first = _bb_row(temp_db, "2026-05-01")
+        backfill_body_battery_from_daily_summaries(temp_db)
+        second = _bb_row(temp_db, "2026-05-01")
+        assert first == second

--- a/tests/test_db_body_battery.py
+++ b/tests/test_db_body_battery.py
@@ -77,6 +77,47 @@ class TestUpsertBodyBatteryFromDailySummary:
         upsert_body_battery_from_daily_summary(temp_db, {"bodyBatteryHighestValue": 99})
         assert temp_db.execute("SELECT COUNT(*) FROM body_battery").fetchone()[0] == 0
 
+    def test_partial_daily_summary_does_not_clobber_existing_aggregates(self, temp_db):
+        # Realistic: a sync sets {highest, lowest, charged}. A later sync of
+        # the same date returns a partial daily_summary that only has highest.
+        # The other fields must not be wiped to NULL.
+        upsert_body_battery_from_daily_summary(
+            temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, at_wake=99)
+        )
+        upsert_body_battery_from_daily_summary(temp_db, _ds("2026-05-01", highest=80))
+        row = _bb_row(temp_db, "2026-05-01")
+        assert row["highest"] == 80  # latest value wins
+        assert row["lowest"] == 47  # preserved
+        assert row["charged"] == 53  # preserved
+        assert row["at_wake"] == 99  # preserved
+
+
+class TestUpsertBodyBatteryEventsOrdering:
+    """Real sync order is daily_summary FIRST, body_battery_events AFTER.
+    The events upsert must not wipe the aggregates that daily_summary just
+    populated (issue #13 + Copilot review on PR #40).
+    """
+
+    def test_events_payload_after_daily_summary_preserves_aggregates(self, temp_db):
+        # Step 1: daily_summary populates aggregates
+        upsert_body_battery_from_daily_summary(
+            temp_db, _ds("2026-05-01", highest=99, lowest=47, charged=53, drained=54, at_wake=99)
+        )
+        # Step 2: events endpoint fires with time-series data, no aggregates
+        events_payload = {"bodyBattery": {"data": [["2026-05-01T22:00", 50, 1, 3]]}}
+        upsert_body_battery(temp_db, events_payload, cal_date="2026-05-01")
+
+        row = _bb_row(temp_db, "2026-05-01")
+        # Aggregates from daily_summary must survive the events upsert
+        assert row["highest"] == 99
+        assert row["lowest"] == 47
+        assert row["charged"] == 53
+        assert row["drained"] == 54
+        assert row["at_wake"] == 99
+        # raw_json now reflects the events payload (the time-series is what
+        # the body_battery row's raw_json is meant to hold)
+        assert "bodyBattery" in json.loads(row["raw_json"])
+
 
 class TestBackfillBodyBatteryFromDailySummaries:
     def test_inserts_missing_rows_and_fills_existing_nulls(self, temp_db):

--- a/tests/test_db_new_columns.py
+++ b/tests/test_db_new_columns.py
@@ -61,6 +61,7 @@ from garmin_mcp.db import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _cols(conn, table: str) -> set[str]:
     return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
 
@@ -71,15 +72,19 @@ def _row(conn, table: str, pk_col: str, pk_val) -> dict:
 
 
 def _splits(conn, activity_id: int) -> list[dict]:
-    return [dict(r) for r in conn.execute(
-        "SELECT * FROM activity_splits WHERE activity_id = ? ORDER BY split_number",
-        (activity_id,),
-    )]
+    return [
+        dict(r)
+        for r in conn.execute(
+            "SELECT * FROM activity_splits WHERE activity_id = ? ORDER BY split_number",
+            (activity_id,),
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------
 # Schema: new columns must exist after init_db
 # ---------------------------------------------------------------------------
+
 
 class TestSchemaNewColumns:
     def test_activity_splits_swim_columns(self, temp_db):
@@ -90,19 +95,31 @@ class TestSchemaNewColumns:
     def test_activity_splits_performance_columns(self, temp_db):
         cols = _cols(temp_db, "activity_splits")
         for col in (
-            "normalized_power", "avg_respiration_rate", "max_respiration_rate",
-            "start_latitude", "start_longitude", "end_latitude", "end_longitude",
-            "start_time_gmt", "calories",
-            "left_pedal_smoothness", "right_pedal_smoothness",
-            "left_torque_effectiveness", "right_torque_effectiveness",
+            "normalized_power",
+            "avg_respiration_rate",
+            "max_respiration_rate",
+            "start_latitude",
+            "start_longitude",
+            "end_latitude",
+            "end_longitude",
+            "start_time_gmt",
+            "calories",
+            "left_pedal_smoothness",
+            "right_pedal_smoothness",
+            "left_torque_effectiveness",
+            "right_torque_effectiveness",
             "surface_unpaved_pct",
         ):
             assert col in cols, f"Missing: {col}"
 
     def test_sleep_new_columns(self, temp_db):
         cols = _cols(temp_db, "sleep")
-        for col in ("body_battery_change", "resting_heart_rate",
-                    "avg_skin_temp_deviation_c", "avg_skin_temp_deviation_f"):
+        for col in (
+            "body_battery_change",
+            "resting_heart_rate",
+            "avg_skin_temp_deviation_c",
+            "avg_skin_temp_deviation_f",
+        ):
             assert col in cols, f"Missing: {col}"
 
     def test_heart_rate_new_column(self, temp_db):
@@ -145,27 +162,31 @@ class TestSchemaNewColumns:
 
     def test_daily_events_columns(self, temp_db):
         cols = _cols(temp_db, "daily_events")
-        for col in ("activity_type", "activity_sub_type",
-                    "start_timestamp_local", "end_timestamp_local",
-                    "duration_seconds", "device_id"):
+        for col in (
+            "activity_type",
+            "activity_sub_type",
+            "start_timestamp_local",
+            "end_timestamp_local",
+            "duration_seconds",
+            "device_id",
+        ):
             assert col in cols, f"Missing: {col}"
 
     def test_wellness_activity_columns(self, temp_db):
         cols = _cols(temp_db, "wellness_activity")
-        for col in ("activity_name", "wellness_activity_type",
-                    "start_timestamp_local", "end_timestamp_local"):
+        for col in ("activity_name", "wellness_activity_type", "start_timestamp_local", "end_timestamp_local"):
             assert col in cols, f"Missing: {col}"
 
     def test_health_snapshot_columns(self, temp_db):
         cols = _cols(temp_db, "health_snapshot")
-        for col in ("activity_name", "wellness_activity_type",
-                    "start_timestamp_local", "end_timestamp_local"):
+        for col in ("activity_name", "wellness_activity_type", "start_timestamp_local", "end_timestamp_local"):
             assert col in cols, f"Missing: {col}"
 
 
 # ---------------------------------------------------------------------------
 # activity_splits — swim fields
 # ---------------------------------------------------------------------------
+
 
 class TestActivitySplitsSwim:
     _POOL_LAP = {
@@ -191,9 +212,15 @@ class TestActivitySplitsSwim:
         assert row["num_active_lengths"] == 10
 
     def test_zero_swim_values_stored_as_null(self, temp_db):
-        rest_lap = dict(self._POOL_LAP, averageSwimCadence=0, averageSWOLF=0,
-                        totalNumberOfStrokes=0, swimStroke=None, numberOfActiveLengths=0,
-                        distance=0)
+        rest_lap = dict(
+            self._POOL_LAP,
+            averageSwimCadence=0,
+            averageSWOLF=0,
+            totalNumberOfStrokes=0,
+            swimStroke=None,
+            numberOfActiveLengths=0,
+            distance=0,
+        )
         upsert_activity_splits(temp_db, 222, [rest_lap])
         row = _splits(temp_db, 222)[0]
         assert row["avg_swim_cadence"] is None
@@ -203,8 +230,11 @@ class TestActivitySplitsSwim:
 
     def test_non_swim_lap_leaves_swim_fields_null(self, temp_db):
         run_lap = {
-            "distance": 1000, "duration": 300, "averageHR": 155,
-            "averageRunCadence": 170, "elevationGain": 10,
+            "distance": 1000,
+            "duration": 300,
+            "averageHR": 155,
+            "averageRunCadence": 170,
+            "elevationGain": 10,
         }
         upsert_activity_splits(temp_db, 333, [run_lap])
         row = _splits(temp_db, 333)[0]
@@ -216,6 +246,7 @@ class TestActivitySplitsSwim:
 # ---------------------------------------------------------------------------
 # activity_splits — performance fields
 # ---------------------------------------------------------------------------
+
 
 class TestActivitySplitsPerformance:
     _CYCLING_LAP = {
@@ -285,6 +316,7 @@ class TestActivitySplitsPerformance:
 # sleep
 # ---------------------------------------------------------------------------
 
+
 class TestSleepNewColumns:
     _RECORD = {
         "dailySleepDTO": {
@@ -309,10 +341,12 @@ class TestSleepNewColumns:
         assert row["avg_skin_temp_deviation_f"] == pytest.approx(-0.54, abs=0.01)
 
     def test_missing_new_fields_stored_as_null(self, temp_db):
-        record = {"dailySleepDTO": {
-            "calendarDate": "2026-05-09",
-            "sleepTimeSeconds": 25200,
-        }}
+        record = {
+            "dailySleepDTO": {
+                "calendarDate": "2026-05-09",
+                "sleepTimeSeconds": 25200,
+            }
+        }
         upsert_sleep(temp_db, record)
         row = _row(temp_db, "sleep", "calendar_date", "2026-05-09")
         assert row["body_battery_change"] is None
@@ -381,40 +415,53 @@ class TestSleepNewColumns:
 # heart_rate
 # ---------------------------------------------------------------------------
 
+
 class TestHeartRateNewColumn:
     def test_7day_avg_stored(self, temp_db):
-        upsert_heart_rate(temp_db, {
-            "calendarDate": "2026-05-10",
-            "restingHeartRate": 54,
-            "minHeartRate": 48,
-            "maxHeartRate": 168,
-            "lastSevenDaysAvgRestingHeartRate": 56.3,
-        })
+        upsert_heart_rate(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "restingHeartRate": 54,
+                "minHeartRate": 48,
+                "maxHeartRate": 168,
+                "lastSevenDaysAvgRestingHeartRate": 56.3,
+            },
+        )
         row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-10")
         assert row["last_7day_avg_resting"] == pytest.approx(56.3, abs=0.1)
 
     def test_missing_7day_avg_is_null(self, temp_db):
-        upsert_heart_rate(temp_db, {
-            "calendarDate": "2026-05-09",
-            "restingHeartRate": 55,
-        })
+        upsert_heart_rate(
+            temp_db,
+            {
+                "calendarDate": "2026-05-09",
+                "restingHeartRate": 55,
+            },
+        )
         row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-09")
         assert row["last_7day_avg_resting"] is None
         assert row["resting_hr"] == 55
 
     def test_rest_then_gql_preserves_7day_avg(self, temp_db):
         """REST record sets 7-day avg; GQL detail overwrites (no such field) — value must survive."""
-        upsert_heart_rate(temp_db, {
-            "calendarDate": "2026-05-10",
-            "restingHeartRate": 58,
-            "lastSevenDaysAvgRestingHeartRate": 59,
-        })
+        upsert_heart_rate(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "restingHeartRate": 58,
+                "lastSevenDaysAvgRestingHeartRate": 59,
+            },
+        )
         # GQL heart_rate_detail record has no lastSevenDaysAvgRestingHeartRate
-        upsert_heart_rate(temp_db, {
-            "calendarDate": "2026-05-10",
-            "restingHeartRate": 58,
-            "maxHeartRate": 160,
-        })
+        upsert_heart_rate(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "restingHeartRate": 58,
+                "maxHeartRate": 160,
+            },
+        )
         row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-10")
         assert row["last_7day_avg_resting"] == pytest.approx(59, abs=0.1)
         assert row["max_hr"] == 160
@@ -422,11 +469,14 @@ class TestHeartRateNewColumn:
     def test_gql_then_rest_populates_7day_avg(self, temp_db):
         """GQL writes first (no 7-day field), then REST fills it in."""
         upsert_heart_rate(temp_db, {"calendarDate": "2026-05-10", "restingHeartRate": 58})
-        upsert_heart_rate(temp_db, {
-            "calendarDate": "2026-05-10",
-            "restingHeartRate": 58,
-            "lastSevenDaysAvgRestingHeartRate": 59,
-        })
+        upsert_heart_rate(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "restingHeartRate": 58,
+                "lastSevenDaysAvgRestingHeartRate": 59,
+            },
+        )
         row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-10")
         assert row["last_7day_avg_resting"] == pytest.approx(59, abs=0.1)
 
@@ -435,15 +485,19 @@ class TestHeartRateNewColumn:
 # spo2
 # ---------------------------------------------------------------------------
 
+
 class TestSpo2NewColumns:
     def test_spo2_events_stored(self, temp_db):
-        upsert_spo2(temp_db, {
-            "calendarDate": "2026-05-10",
-            "averageSpO2": 96.0,
-            "lowestSpO2": 88.0,
-            "numberOfEventsBelowThreshold": 3,
-            "durationOfEventsBelowThreshold": 420.0,
-        })
+        upsert_spo2(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "averageSpO2": 96.0,
+                "lowestSpO2": 88.0,
+                "numberOfEventsBelowThreshold": 3,
+                "durationOfEventsBelowThreshold": 420.0,
+            },
+        )
         row = _row(temp_db, "spo2", "calendar_date", "2026-05-10")
         assert row["events_below_threshold"] == 3
         assert row["duration_below_threshold_secs"] == pytest.approx(420.0)
@@ -459,50 +513,66 @@ class TestSpo2NewColumns:
 # respiration
 # ---------------------------------------------------------------------------
 
+
 class TestRespirationNewColumn:
     def test_avg_sleep_respiration_stored(self, temp_db):
-        upsert_respiration(temp_db, {
-            "calendarDate": "2026-05-10",
-            "avgWakingRespirationValue": 16.2,
-            "avgSleepRespirationValue": 14.8,
-            "lowestRespirationValue": 13.0,
-            "highestRespirationValue": 22.0,
-        })
+        upsert_respiration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "avgWakingRespirationValue": 16.2,
+                "avgSleepRespirationValue": 14.8,
+                "lowestRespirationValue": 13.0,
+                "highestRespirationValue": 22.0,
+            },
+        )
         row = _row(temp_db, "respiration", "calendar_date", "2026-05-10")
         assert row["avg_waking"] == pytest.approx(16.2, abs=0.1)
         assert row["avg_sleep"] == pytest.approx(14.8, abs=0.1)
 
     def test_missing_sleep_respiration_is_null(self, temp_db):
-        upsert_respiration(temp_db, {
-            "calendarDate": "2026-05-09",
-            "avgWakingRespirationValue": 15.0,
-        })
+        upsert_respiration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-09",
+                "avgWakingRespirationValue": 15.0,
+            },
+        )
         row = _row(temp_db, "respiration", "calendar_date", "2026-05-09")
         assert row["avg_sleep"] is None
 
     def test_sleep_respiration_preserved_on_overwrite(self, temp_db):
         """First write has sleep respiration; second write lacks it — value must survive."""
-        upsert_respiration(temp_db, {
-            "calendarDate": "2026-05-10",
-            "avgWakingRespirationValue": 16.0,
-            "avgSleepRespirationValue": 14.5,
-        })
-        upsert_respiration(temp_db, {
-            "calendarDate": "2026-05-10",
-            "avgWakingRespirationValue": 16.0,
-            # no avgSleepRespirationValue (e.g. same-day sync before sleep data is ready)
-        })
+        upsert_respiration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "avgWakingRespirationValue": 16.0,
+                "avgSleepRespirationValue": 14.5,
+            },
+        )
+        upsert_respiration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "avgWakingRespirationValue": 16.0,
+                # no avgSleepRespirationValue (e.g. same-day sync before sleep data is ready)
+            },
+        )
         row = _row(temp_db, "respiration", "calendar_date", "2026-05-10")
         assert row["avg_sleep"] == pytest.approx(14.5, abs=0.1)
 
     def test_sleep_respiration_filled_on_later_write(self, temp_db):
         """First write has no sleep value; later write fills it in."""
         upsert_respiration(temp_db, {"calendarDate": "2026-05-10", "avgWakingRespirationValue": 16.0})
-        upsert_respiration(temp_db, {
-            "calendarDate": "2026-05-10",
-            "avgWakingRespirationValue": 16.0,
-            "avgSleepRespirationValue": 14.5,
-        })
+        upsert_respiration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "avgWakingRespirationValue": 16.0,
+                "avgSleepRespirationValue": 14.5,
+            },
+        )
         row = _row(temp_db, "respiration", "calendar_date", "2026-05-10")
         assert row["avg_sleep"] == pytest.approx(14.5, abs=0.1)
 
@@ -511,15 +581,19 @@ class TestRespirationNewColumn:
 # hydration
 # ---------------------------------------------------------------------------
 
+
 class TestHydrationNewColumns:
     def test_sweat_loss_and_activity_intake_stored(self, temp_db):
-        upsert_hydration(temp_db, {
-            "calendarDate": "2026-05-10",
-            "goalInML": 2500,
-            "valueInML": 2100,
-            "sweatLossInML": 620,
-            "activityIntakeInML": 400,
-        })
+        upsert_hydration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "goalInML": 2500,
+                "valueInML": 2100,
+                "sweatLossInML": 620,
+                "activityIntakeInML": 400,
+            },
+        )
         row = _row(temp_db, "hydration", "calendar_date", "2026-05-10")
         assert row["sweat_loss_ml"] == pytest.approx(620)
         assert row["activity_intake_ml"] == pytest.approx(400)
@@ -532,13 +606,16 @@ class TestHydrationNewColumns:
 
     def test_sweat_loss_preserved_on_overwrite(self, temp_db):
         """First write has sweat/activity data; second write lacks them — values must survive."""
-        upsert_hydration(temp_db, {
-            "calendarDate": "2026-05-10",
-            "goalInML": 2500,
-            "valueInML": 2100,
-            "sweatLossInML": 1200,
-            "activityIntakeInML": 350,
-        })
+        upsert_hydration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "goalInML": 2500,
+                "valueInML": 2100,
+                "sweatLossInML": 1200,
+                "activityIntakeInML": 350,
+            },
+        )
         upsert_hydration(temp_db, {"calendarDate": "2026-05-10", "goalInML": 2500, "valueInML": 2100})
         row = _row(temp_db, "hydration", "calendar_date", "2026-05-10")
         assert row["sweat_loss_ml"] == pytest.approx(1200)
@@ -546,13 +623,16 @@ class TestHydrationNewColumns:
 
     def test_zero_activity_intake_stored_not_null(self, temp_db):
         """activityIntakeInML == 0 is valid (no activity fluids), must not become NULL."""
-        upsert_hydration(temp_db, {
-            "calendarDate": "2026-05-10",
-            "goalInML": 2500,
-            "valueInML": 0,
-            "sweatLossInML": 500,
-            "activityIntakeInML": 0,
-        })
+        upsert_hydration(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "goalInML": 2500,
+                "valueInML": 0,
+                "sweatLossInML": 500,
+                "activityIntakeInML": 0,
+            },
+        )
         row = _row(temp_db, "hydration", "calendar_date", "2026-05-10")
         assert row["activity_intake_ml"] == 0.0
 
@@ -561,26 +641,33 @@ class TestHydrationNewColumns:
 # weight
 # ---------------------------------------------------------------------------
 
+
 class TestWeightNewColumns:
     def test_metabolic_age_and_physique_rating_stored(self, temp_db):
-        upsert_weight(temp_db, {
-            "calendarDate": "2026-05-10",
-            "date": 1746835200000,
-            "weight": 77000,
-            "bmi": 25.7,
-            "metabolicAge": 38.0,
-            "physiqueRating": 4,
-        })
+        upsert_weight(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "date": 1746835200000,
+                "weight": 77000,
+                "bmi": 25.7,
+                "metabolicAge": 38.0,
+                "physiqueRating": 4,
+            },
+        )
         row = _row(temp_db, "weight", "calendar_date", "2026-05-10")
         assert row["metabolic_age"] == pytest.approx(38.0)
         assert row["physique_rating"] == 4
 
     def test_missing_body_comp_fields_are_null(self, temp_db):
-        upsert_weight(temp_db, {
-            "calendarDate": "2026-05-09",
-            "date": 1746748800000,
-            "weight": 77500,
-        })
+        upsert_weight(
+            temp_db,
+            {
+                "calendarDate": "2026-05-09",
+                "date": 1746748800000,
+                "weight": 77500,
+            },
+        )
         row = _row(temp_db, "weight", "calendar_date", "2026-05-09")
         assert row["metabolic_age"] is None
         assert row["physique_rating"] is None
@@ -591,6 +678,7 @@ class TestWeightNewColumns:
 # endurance_score
 # ---------------------------------------------------------------------------
 
+
 class TestEnduranceScoreNewColumns:
     _CONTRIBUTORS = [
         {"activityTypeId": None, "contribution": 83.93, "group": 0},
@@ -598,14 +686,17 @@ class TestEnduranceScoreNewColumns:
     ]
 
     def test_feedback_phrase_and_contributors_stored(self, temp_db):
-        upsert_endurance_score(temp_db, {
-            "calendarDate": "2026-05-10",
-            "overallScore": 5200,
-            "classification": "PRODUCTIVE",
-            "vo2Max": 46.0,
-            "feedbackPhrase": "ENDURANCE_SCORE_IMPROVING",
-            "contributors": self._CONTRIBUTORS,
-        })
+        upsert_endurance_score(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "overallScore": 5200,
+                "classification": "PRODUCTIVE",
+                "vo2Max": 46.0,
+                "feedbackPhrase": "ENDURANCE_SCORE_IMPROVING",
+                "contributors": self._CONTRIBUTORS,
+            },
+        )
         row = _row(temp_db, "endurance_score", "calendar_date", "2026-05-10")
         assert row["feedback_phrase"] == "ENDURANCE_SCORE_IMPROVING"
         parsed = json.loads(row["contributors"])
@@ -613,10 +704,13 @@ class TestEnduranceScoreNewColumns:
         assert parsed[0]["contribution"] == pytest.approx(83.93)
 
     def test_null_contributors_stored_as_null(self, temp_db):
-        upsert_endurance_score(temp_db, {
-            "calendarDate": "2026-05-09",
-            "overallScore": 5100,
-        })
+        upsert_endurance_score(
+            temp_db,
+            {
+                "calendarDate": "2026-05-09",
+                "overallScore": 5100,
+            },
+        )
         row = _row(temp_db, "endurance_score", "calendar_date", "2026-05-09")
         assert row["feedback_phrase"] is None
         assert row["contributors"] is None
@@ -626,30 +720,37 @@ class TestEnduranceScoreNewColumns:
 # hill_score
 # ---------------------------------------------------------------------------
 
+
 class TestHillScoreNewColumns:
     def test_vo2max_and_feedback_stored(self, temp_db):
-        upsert_hill_score(temp_db, {
-            "calendarDate": "2026-05-10",
-            "overallScore": 58,
-            "enduranceScore": 62,
-            "strengthScore": 54,
-            "vo2Max": 46.0,
-            "vo2MaxPreciseValue": 46.3,
-            "hillScoreFeedbackPhraseId": "HILL_SCORE_IMPROVING",
-        })
+        upsert_hill_score(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "overallScore": 58,
+                "enduranceScore": 62,
+                "strengthScore": 54,
+                "vo2Max": 46.0,
+                "vo2MaxPreciseValue": 46.3,
+                "hillScoreFeedbackPhraseId": "HILL_SCORE_IMPROVING",
+            },
+        )
         row = _row(temp_db, "hill_score", "calendar_date", "2026-05-10")
         assert row["vo2_max"] == pytest.approx(46.0)
         assert row["vo2_max_precise"] == pytest.approx(46.3)
         assert row["feedback_phrase_id"] == "HILL_SCORE_IMPROVING"
 
     def test_existing_hill_fields_unaffected(self, temp_db):
-        upsert_hill_score(temp_db, {
-            "calendarDate": "2026-05-09",
-            "overallScore": 55,
-            "enduranceScore": 58,
-            "strengthScore": 52,
-            "vo2Max": 45.5,
-        })
+        upsert_hill_score(
+            temp_db,
+            {
+                "calendarDate": "2026-05-09",
+                "overallScore": 55,
+                "enduranceScore": 58,
+                "strengthScore": 52,
+                "vo2Max": 45.5,
+            },
+        )
         row = _row(temp_db, "hill_score", "calendar_date", "2026-05-09")
         assert row["overall_score"] == 55
         assert row["endurance_score"] == 58
@@ -661,17 +762,21 @@ class TestHillScoreNewColumns:
 # gear
 # ---------------------------------------------------------------------------
 
+
 class TestGearNewColumns:
     def test_usage_stats_stored(self, temp_db):
-        upsert_gear(temp_db, {
-            "uuid": "abc-123",
-            "gearTypeName": "shoes",
-            "displayName": "Canyon CFSLX",
-            "distanceUsedMeters": 467282.78,
-            "durationUsedSeconds": 85673,
-            "daysUsed": 13,
-            "dateBegin": "2024-01-01",
-        })
+        upsert_gear(
+            temp_db,
+            {
+                "uuid": "abc-123",
+                "gearTypeName": "shoes",
+                "displayName": "Canyon CFSLX",
+                "distanceUsedMeters": 467282.78,
+                "durationUsedSeconds": 85673,
+                "daysUsed": 13,
+                "dateBegin": "2024-01-01",
+            },
+        )
         row = _row(temp_db, "gear", "gear_id", "abc-123")
         assert row["distance_used_meters"] == pytest.approx(467282.78, rel=1e-4)
         assert row["duration_used_seconds"] == 85673
@@ -689,16 +794,21 @@ class TestGearNewColumns:
 # Hollow tables: daily_events, wellness_activity, health_snapshot
 # ---------------------------------------------------------------------------
 
+
 class TestDailyEvents:
     def test_scalar_fields_extracted(self, temp_db):
-        upsert_daily_events(temp_db, {
-            "activityType": "RUNNING",
-            "activitySubType": "TRAIL_RUNNING",
-            "startTimestampLocal": "2026-05-10T07:00:00",
-            "endTimestampLocal": "2026-05-10T08:00:00",
-            "duration": 3600.0,
-            "deviceId": "device-42",
-        }, cal_date="2026-05-10")
+        upsert_daily_events(
+            temp_db,
+            {
+                "activityType": "RUNNING",
+                "activitySubType": "TRAIL_RUNNING",
+                "startTimestampLocal": "2026-05-10T07:00:00",
+                "endTimestampLocal": "2026-05-10T08:00:00",
+                "duration": 3600.0,
+                "deviceId": "device-42",
+            },
+            cal_date="2026-05-10",
+        )
         row = _row(temp_db, "daily_events", "calendar_date", "2026-05-10")
         assert row["activity_type"] == "RUNNING"
         assert row["activity_sub_type"] == "TRAIL_RUNNING"
@@ -727,12 +837,16 @@ class TestDailyEvents:
 
 class TestWellnessActivity:
     def test_scalar_fields_extracted(self, temp_db):
-        upsert_wellness_activity(temp_db, {
-            "activityName": "Morning Walk",
-            "wellnessActivityType": "WALKING",
-            "startTimestampLocal": "2026-05-10T06:30:00",
-            "endTimestampLocal": "2026-05-10T07:00:00",
-        }, cal_date="2026-05-10")
+        upsert_wellness_activity(
+            temp_db,
+            {
+                "activityName": "Morning Walk",
+                "wellnessActivityType": "WALKING",
+                "startTimestampLocal": "2026-05-10T06:30:00",
+                "endTimestampLocal": "2026-05-10T07:00:00",
+            },
+            cal_date="2026-05-10",
+        )
         row = _row(temp_db, "wellness_activity", "calendar_date", "2026-05-10")
         assert row["activity_name"] == "Morning Walk"
         assert row["wellness_activity_type"] == "WALKING"
@@ -748,13 +862,16 @@ class TestWellnessActivity:
 
 class TestHealthSnapshot:
     def test_scalar_fields_extracted(self, temp_db):
-        upsert_health_snapshot(temp_db, {
-            "calendarDate": "2026-05-10",
-            "activityName": "Health Snapshot",
-            "wellnessActivityType": "HEALTH_SNAPSHOT",
-            "startTimestampLocal": "2026-05-10T08:00:00",
-            "endTimestampLocal": "2026-05-10T08:02:00",
-        })
+        upsert_health_snapshot(
+            temp_db,
+            {
+                "calendarDate": "2026-05-10",
+                "activityName": "Health Snapshot",
+                "wellnessActivityType": "HEALTH_SNAPSHOT",
+                "startTimestampLocal": "2026-05-10T08:00:00",
+                "endTimestampLocal": "2026-05-10T08:02:00",
+            },
+        )
         row = _row(temp_db, "health_snapshot", "calendar_date", "2026-05-10")
         assert row["activity_name"] == "Health Snapshot"
         assert row["wellness_activity_type"] == "HEALTH_SNAPSHOT"
@@ -770,6 +887,7 @@ class TestHealthSnapshot:
 # Migration: _add_columns / _backfill_from_raw
 # ---------------------------------------------------------------------------
 
+
 class TestAddColumns:
     def test_adds_missing_column(self, temp_db):
         _add_columns(temp_db, "sleep", [("test_col_xyzzy", "REAL")])
@@ -781,10 +899,14 @@ class TestAddColumns:
         assert "resting_heart_rate" in _cols(temp_db, "sleep")
 
     def test_returns_only_added_columns(self, temp_db):
-        added = _add_columns(temp_db, "sleep", [
-            ("resting_heart_rate", "INTEGER"),   # already exists
-            ("test_brand_new_col", "TEXT"),       # new
-        ])
+        added = _add_columns(
+            temp_db,
+            "sleep",
+            [
+                ("resting_heart_rate", "INTEGER"),  # already exists
+                ("test_brand_new_col", "TEXT"),  # new
+            ],
+        )
         assert added == ["test_brand_new_col"]
 
 
@@ -951,9 +1073,7 @@ class TestMigrationFunctions:
             );
         """)
         migrate_activity_splits_v2(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM activity_splits WHERE activity_id = 1001"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM activity_splits WHERE activity_id = 1001").fetchone())
         assert row["normalized_power"] == 230
         assert row["avg_respiration_rate"] == pytest.approx(33.5, abs=0.1)
         assert row["start_latitude"] == pytest.approx(49.46, abs=0.01)
@@ -981,9 +1101,7 @@ class TestMigrationFunctions:
         de_cols = _cols(conn, "daily_events")
         assert "activity_type" in de_cols
         assert "start_timestamp_local" in de_cols
-        wa = dict(conn.execute(
-            "SELECT * FROM wellness_activity WHERE calendar_date = '2026-05-10'"
-        ).fetchone())
+        wa = dict(conn.execute("SELECT * FROM wellness_activity WHERE calendar_date = '2026-05-10'").fetchone())
         assert wa["activity_name"] == "Walk"
         assert wa["wellness_activity_type"] == "WALKING"
         conn.close()
@@ -1002,9 +1120,7 @@ class TestMigrationFunctions:
             );
         """)
         migrate_endurance_score_table(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM endurance_score WHERE calendar_date = '2026-05-10'"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM endurance_score WHERE calendar_date = '2026-05-10'").fetchone())
         assert row["feedback_phrase"] == "PRODUCTIVE"
         parsed = json.loads(row["contributors"])
         assert len(parsed) == 2
@@ -1015,6 +1131,7 @@ class TestMigrationFunctions:
 # New v2/v3 migrations: sleep_v2 (RENAME COLUMN + nested backfill), activity,
 # fitness_age, weight_v3, gear_v2
 # ---------------------------------------------------------------------------
+
 
 class TestSleepMigrationV2:
     """RENAME COLUMN + nested json_extract backfill from dailySleepDTO."""
@@ -1073,9 +1190,7 @@ class TestSleepMigrationV2:
     def test_backfill_from_nested_raw_json(self):
         conn = self._old_db_with_rename_candidates()
         migrate_sleep_table_v2(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM sleep WHERE calendar_date = '2026-05-10'"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM sleep WHERE calendar_date = '2026-05-10'").fetchone())
         assert row["sleep_need_minutes"] == 540
         assert row["highest_spo2"] == pytest.approx(99.0)
         assert row["sleep_score_overall"] == 87
@@ -1138,17 +1253,20 @@ class TestActivityMigration:
         conn = self._old_activity_db()
         migrate_activity_table(conn)
         cols = _cols(conn, "activity")
-        for c in ("body_battery_change", "total_work_kcal",
-                  "avg_grade_adjusted_speed", "activity_steps", "activity_min_hr"):
+        for c in (
+            "body_battery_change",
+            "total_work_kcal",
+            "avg_grade_adjusted_speed",
+            "activity_steps",
+            "activity_min_hr",
+        ):
             assert c in cols, f"Missing: {c}"
         conn.close()
 
     def test_backfill_from_summary_dto(self):
         conn = self._old_activity_db()
         migrate_activity_table(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM activity WHERE activity_id = 9001"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM activity WHERE activity_id = 9001").fetchone())
         assert row["body_battery_change"] == -25
         assert row["total_work_kcal"] == pytest.approx(850.5)
         assert row["avg_grade_adjusted_speed"] == pytest.approx(3.42, abs=0.01)
@@ -1201,9 +1319,7 @@ class TestFitnessAgeMigration:
         )
         conn.commit()
         migrate_fitness_age_table(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM fitness_age WHERE calendar_date = '2026-05-10'"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM fitness_age WHERE calendar_date = '2026-05-10'").fetchone())
         assert row["achievable_fitness_age"] == pytest.approx(35.0)
         conn.close()
 
@@ -1229,9 +1345,7 @@ class TestWeightMigrationV3:
         )
         conn.commit()
         migrate_weight_table_v3(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM weight WHERE timestamp = 1746835200000"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM weight WHERE timestamp = 1746835200000").fetchone())
         assert row["visceral_fat"] == pytest.approx(7.5)
         conn.close()
 
@@ -1255,14 +1369,11 @@ class TestGearMigrationV2:
         """)
         conn.execute(
             "INSERT INTO gear VALUES (?, ?, ?)",
-            ("uuid-7", "Canyon",
-             json.dumps({"status": "active", "maxUsageDistanceMeters": 1500000.0})),
+            ("uuid-7", "Canyon", json.dumps({"status": "active", "maxUsageDistanceMeters": 1500000.0})),
         )
         conn.commit()
         migrate_gear_table_v2(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM gear WHERE gear_id = 'uuid-7'"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM gear WHERE gear_id = 'uuid-7'").fetchone())
         assert row["status"] == "active"
         assert row["max_usage_distance_meters"] == pytest.approx(1500000.0)
         conn.close()
@@ -1271,6 +1382,7 @@ class TestGearMigrationV2:
 # ---------------------------------------------------------------------------
 # End-to-end: full upgrade from old schema + idempotency of init_db itself
 # ---------------------------------------------------------------------------
+
 
 class TestFullUpgradePath:
     """Simulate a user upgrading from pre-PR DB by running init_db on it."""
@@ -1297,17 +1409,19 @@ class TestFullUpgradePath:
                 raw_json TEXT
             );
         """)
-        raw = json.dumps({
-            "dailySleepDTO": {
-                "calendarDate": "2026-05-10",
-                "sleepTimeSeconds": 28000,
-                "sleepNeed": {"actual": 540},
-                "sleepScores": {
-                    "overall": {"value": 85},
-                    "lightPercentage": {"value": 50},
-                },
+        raw = json.dumps(
+            {
+                "dailySleepDTO": {
+                    "calendarDate": "2026-05-10",
+                    "sleepTimeSeconds": 28000,
+                    "sleepNeed": {"actual": 540},
+                    "sleepScores": {
+                        "overall": {"value": 85},
+                        "lightPercentage": {"value": 50},
+                    },
+                }
             }
-        })
+        )
         conn.execute(
             "INSERT INTO sleep VALUES (?, ?, ?, ?, ?)",
             ("2026-05-10", 28000, None, None, raw),
@@ -1322,9 +1436,7 @@ class TestFullUpgradePath:
         assert "sleep_need_seconds" not in cols
         assert "sleep_score_composition" not in cols
 
-        row = dict(conn.execute(
-            "SELECT * FROM sleep WHERE calendar_date = '2026-05-10'"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM sleep WHERE calendar_date = '2026-05-10'").fetchone())
         assert row["sleep_need_minutes"] == 540
         assert row["sleep_light_pct"] == 50
         assert row["sleep_score_overall"] == 85
@@ -1344,17 +1456,14 @@ class TestFullUpgradePath:
         """)
         conn.execute(
             "INSERT INTO sleep VALUES (?, ?, ?, ?)",
-            ("2026-05-10", 28000, None,
-             json.dumps({"dailySleepDTO": {"sleepNeed": {"actual": 500}}})),
+            ("2026-05-10", 28000, None, json.dumps({"dailySleepDTO": {"sleepNeed": {"actual": 500}}})),
         )
         conn.commit()
 
         init_db(conn)
         init_db(conn)  # idempotency check
 
-        row = dict(conn.execute(
-            "SELECT * FROM sleep WHERE calendar_date = '2026-05-10'"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM sleep WHERE calendar_date = '2026-05-10'").fetchone())
         assert row["sleep_need_minutes"] == 500
         conn.close()
 
@@ -1362,6 +1471,7 @@ class TestFullUpgradePath:
 # ---------------------------------------------------------------------------
 # Edge cases flagged in code review
 # ---------------------------------------------------------------------------
+
 
 class TestZeroValueBackfill:
     """Regression: data.get(jk) must not coerce 0/False/'' to None."""
@@ -1390,8 +1500,7 @@ class TestZeroValueBackfill:
         """)
         conn.execute(
             "INSERT INTO activity VALUES (?, ?)",
-            (1, json.dumps({"summaryDTO": {"differenceBodyBattery": 0,
-                                            "steps": 0, "totalWork": 0.0}})),
+            (1, json.dumps({"summaryDTO": {"differenceBodyBattery": 0, "steps": 0, "totalWork": 0.0}})),
         )
         conn.commit()
         migrate_activity_table(conn)
@@ -1410,16 +1519,19 @@ class TestZeroValueBackfill:
         """)
         conn.execute(
             "INSERT INTO spo2 VALUES (?, ?)",
-            ("2026-05-10", json.dumps({
-                "numberOfEventsBelowThreshold": 0,
-                "durationOfEventsBelowThreshold": 0,
-            })),
+            (
+                "2026-05-10",
+                json.dumps(
+                    {
+                        "numberOfEventsBelowThreshold": 0,
+                        "durationOfEventsBelowThreshold": 0,
+                    }
+                ),
+            ),
         )
         conn.commit()
         migrate_spo2_table(conn)
-        row = dict(conn.execute(
-            "SELECT * FROM spo2 WHERE calendar_date = '2026-05-10'"
-        ).fetchone())
+        row = dict(conn.execute("SELECT * FROM spo2 WHERE calendar_date = '2026-05-10'").fetchone())
         assert row["events_below_threshold"] == 0
         assert row["duration_below_threshold_secs"] == 0
         conn.close()
@@ -1433,8 +1545,12 @@ class TestSleepNullNestedScore:
             "dailySleepDTO": {
                 "calendarDate": "2026-05-10",
                 "sleepTimeSeconds": 27000,
-                "sleepScores": {"overall": None, "remPercentage": None, "deepPercentage": None,
-                                "lightPercentage": None},
+                "sleepScores": {
+                    "overall": None,
+                    "remPercentage": None,
+                    "deepPercentage": None,
+                    "lightPercentage": None,
+                },
             }
         }
         upsert_sleep(temp_db, record)  # must not raise
@@ -1507,11 +1623,14 @@ class TestActivityUpsertPreservesSummaryData:
 
     def test_flat_then_detail_populates_summary_columns(self, temp_db):
         upsert_activity(temp_db, {"activityId": 8888, "activityName": "First"})
-        upsert_activity(temp_db, {
-            "activityId": 8888,
-            "activityName": "Second",
-            "summaryDTO": {"differenceBodyBattery": -15, "steps": 7000},
-        })
+        upsert_activity(
+            temp_db,
+            {
+                "activityId": 8888,
+                "activityName": "Second",
+                "summaryDTO": {"differenceBodyBattery": -15, "steps": 7000},
+            },
+        )
         row = _row(temp_db, "activity", "activity_id", 8888)
         assert row["activity_name"] == "Second"
         assert row["body_battery_change"] == -15

--- a/tests/test_db_new_columns.py
+++ b/tests/test_db_new_columns.py
@@ -1,0 +1,1589 @@
+"""
+Tests for new columns added to garmin_mcp/db.py — both schema presence and
+correct extraction from Garmin API JSON payloads.
+
+Covers:
+  - activity_splits: swim fields + performance fields (NP, respiration, GPS, power phase)
+  - sleep:           body_battery_change, resting_heart_rate, skin temp deviation
+  - heart_rate:      last_7day_avg_resting
+  - spo2:            events_below_threshold, duration_below_threshold_secs
+  - respiration:     avg_sleep
+  - hydration:       sweat_loss_ml, activity_intake_ml
+  - weight:          metabolic_age, physique_rating
+  - endurance_score: feedback_phrase, contributors
+  - hill_score:      vo2_max, vo2_max_precise, feedback_phrase_id
+  - gear:            distance_used_meters, duration_used_seconds, days_used
+  - daily_events:    activity_type, activity_sub_type, timestamps, duration, device_id
+  - wellness_activity: activity_name, wellness_activity_type, timestamps
+  - health_snapshot: activity_name, wellness_activity_type, timestamps
+  - migrations:      _add_columns / _backfill_from_raw on pre-existing tables
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from garmin_mcp.db import (
+    _add_columns,
+    _backfill_from_raw,
+    init_db,
+    migrate_activity_splits_v2,
+    migrate_activity_table,
+    migrate_endurance_score_table,
+    migrate_fitness_age_table,
+    migrate_gear_table,
+    migrate_gear_table_v2,
+    migrate_heart_rate_table,
+    migrate_hill_score_table,
+    migrate_hollow_tables,
+    migrate_sleep_table,
+    migrate_sleep_table_v2,
+    migrate_spo2_table,
+    migrate_weight_table_v3,
+    upsert_activity,
+    upsert_activity_splits,
+    upsert_daily_events,
+    upsert_endurance_score,
+    upsert_gear,
+    upsert_health_snapshot,
+    upsert_heart_rate,
+    upsert_hill_score,
+    upsert_hydration,
+    upsert_respiration,
+    upsert_sleep,
+    upsert_spo2,
+    upsert_weight,
+    upsert_wellness_activity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _cols(conn, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _row(conn, table: str, pk_col: str, pk_val) -> dict:
+    row = conn.execute(f"SELECT * FROM {table} WHERE {pk_col} = ?", (pk_val,)).fetchone()
+    return dict(row) if row else {}
+
+
+def _splits(conn, activity_id: int) -> list[dict]:
+    return [dict(r) for r in conn.execute(
+        "SELECT * FROM activity_splits WHERE activity_id = ? ORDER BY split_number",
+        (activity_id,),
+    )]
+
+
+# ---------------------------------------------------------------------------
+# Schema: new columns must exist after init_db
+# ---------------------------------------------------------------------------
+
+class TestSchemaNewColumns:
+    def test_activity_splits_swim_columns(self, temp_db):
+        cols = _cols(temp_db, "activity_splits")
+        for col in ("avg_swim_cadence", "avg_swolf", "total_strokes", "swim_stroke", "num_active_lengths"):
+            assert col in cols, f"Missing: {col}"
+
+    def test_activity_splits_performance_columns(self, temp_db):
+        cols = _cols(temp_db, "activity_splits")
+        for col in (
+            "normalized_power", "avg_respiration_rate", "max_respiration_rate",
+            "start_latitude", "start_longitude", "end_latitude", "end_longitude",
+            "start_time_gmt", "calories",
+            "left_pedal_smoothness", "right_pedal_smoothness",
+            "left_torque_effectiveness", "right_torque_effectiveness",
+            "surface_unpaved_pct",
+        ):
+            assert col in cols, f"Missing: {col}"
+
+    def test_sleep_new_columns(self, temp_db):
+        cols = _cols(temp_db, "sleep")
+        for col in ("body_battery_change", "resting_heart_rate",
+                    "avg_skin_temp_deviation_c", "avg_skin_temp_deviation_f"):
+            assert col in cols, f"Missing: {col}"
+
+    def test_heart_rate_new_column(self, temp_db):
+        assert "last_7day_avg_resting" in _cols(temp_db, "heart_rate")
+
+    def test_spo2_new_columns(self, temp_db):
+        cols = _cols(temp_db, "spo2")
+        assert "events_below_threshold" in cols
+        assert "duration_below_threshold_secs" in cols
+
+    def test_respiration_new_column(self, temp_db):
+        assert "avg_sleep" in _cols(temp_db, "respiration")
+
+    def test_hydration_new_columns(self, temp_db):
+        cols = _cols(temp_db, "hydration")
+        assert "sweat_loss_ml" in cols
+        assert "activity_intake_ml" in cols
+
+    def test_weight_new_columns(self, temp_db):
+        cols = _cols(temp_db, "weight")
+        assert "metabolic_age" in cols
+        assert "physique_rating" in cols
+
+    def test_endurance_score_new_columns(self, temp_db):
+        cols = _cols(temp_db, "endurance_score")
+        assert "feedback_phrase" in cols
+        assert "contributors" in cols
+
+    def test_hill_score_new_columns(self, temp_db):
+        cols = _cols(temp_db, "hill_score")
+        assert "vo2_max" in cols
+        assert "vo2_max_precise" in cols
+        assert "feedback_phrase_id" in cols
+
+    def test_gear_new_columns(self, temp_db):
+        cols = _cols(temp_db, "gear")
+        assert "distance_used_meters" in cols
+        assert "duration_used_seconds" in cols
+        assert "days_used" in cols
+
+    def test_daily_events_columns(self, temp_db):
+        cols = _cols(temp_db, "daily_events")
+        for col in ("activity_type", "activity_sub_type",
+                    "start_timestamp_local", "end_timestamp_local",
+                    "duration_seconds", "device_id"):
+            assert col in cols, f"Missing: {col}"
+
+    def test_wellness_activity_columns(self, temp_db):
+        cols = _cols(temp_db, "wellness_activity")
+        for col in ("activity_name", "wellness_activity_type",
+                    "start_timestamp_local", "end_timestamp_local"):
+            assert col in cols, f"Missing: {col}"
+
+    def test_health_snapshot_columns(self, temp_db):
+        cols = _cols(temp_db, "health_snapshot")
+        for col in ("activity_name", "wellness_activity_type",
+                    "start_timestamp_local", "end_timestamp_local"):
+            assert col in cols, f"Missing: {col}"
+
+
+# ---------------------------------------------------------------------------
+# activity_splits — swim fields
+# ---------------------------------------------------------------------------
+
+class TestActivitySplitsSwim:
+    _POOL_LAP = {
+        "distance": 500,
+        "duration": 841.929,
+        "averageHR": 125,
+        "maxHR": 148,
+        "averageSwimCadence": 21,
+        "averageSWOLF": 100,
+        "totalNumberOfStrokes": 253,
+        "swimStroke": "FREESTYLE",
+        "numberOfActiveLengths": 10,
+        "averageSpeed": 0.666,
+    }
+
+    def test_swim_fields_stored(self, temp_db):
+        upsert_activity_splits(temp_db, 111, [self._POOL_LAP])
+        row = _splits(temp_db, 111)[0]
+        assert row["avg_swim_cadence"] == 21
+        assert row["avg_swolf"] == 100
+        assert row["total_strokes"] == 253
+        assert row["swim_stroke"] == "FREESTYLE"
+        assert row["num_active_lengths"] == 10
+
+    def test_zero_swim_values_stored_as_null(self, temp_db):
+        rest_lap = dict(self._POOL_LAP, averageSwimCadence=0, averageSWOLF=0,
+                        totalNumberOfStrokes=0, swimStroke=None, numberOfActiveLengths=0,
+                        distance=0)
+        upsert_activity_splits(temp_db, 222, [rest_lap])
+        row = _splits(temp_db, 222)[0]
+        assert row["avg_swim_cadence"] is None
+        assert row["avg_swolf"] is None
+        assert row["total_strokes"] is None
+        assert row["num_active_lengths"] is None
+
+    def test_non_swim_lap_leaves_swim_fields_null(self, temp_db):
+        run_lap = {
+            "distance": 1000, "duration": 300, "averageHR": 155,
+            "averageRunCadence": 170, "elevationGain": 10,
+        }
+        upsert_activity_splits(temp_db, 333, [run_lap])
+        row = _splits(temp_db, 333)[0]
+        assert row["avg_swim_cadence"] is None
+        assert row["swim_stroke"] is None
+        assert row["avg_cadence"] == 170
+
+
+# ---------------------------------------------------------------------------
+# activity_splits — performance fields
+# ---------------------------------------------------------------------------
+
+class TestActivitySplitsPerformance:
+    _CYCLING_LAP = {
+        "distance": 5000,
+        "duration": 600,
+        "averageHR": 155,
+        "maxHR": 170,
+        "averageBikeCadence": 90,
+        "normalizedPower": 240,
+        "avgRespirationRate": 32.5,
+        "maxRespirationRate": 40.1,
+        "startLatitude": 49.468,
+        "startLongitude": 11.077,
+        "endLatitude": 49.510,
+        "endLongitude": 11.120,
+        "startTimeGMT": "2026-05-10T06:00:00.0",
+        "calories": 120,
+        "leftPedalSmoothness": 76.5,
+        "rightPedalSmoothness": 74.2,
+        "leftTorqueEffectiveness": 91.0,
+        "rightTorqueEffectiveness": 89.5,
+        "surfaceTypeUnpavedPercentage": 45.0,
+    }
+
+    def test_cycling_performance_fields_stored(self, temp_db):
+        upsert_activity_splits(temp_db, 444, [self._CYCLING_LAP])
+        row = _splits(temp_db, 444)[0]
+        assert row["normalized_power"] == 240
+        assert row["avg_respiration_rate"] == pytest.approx(32.5, abs=0.1)
+        assert row["max_respiration_rate"] == pytest.approx(40.1, abs=0.1)
+        assert row["start_latitude"] == pytest.approx(49.468, abs=0.001)
+        assert row["start_longitude"] == pytest.approx(11.077, abs=0.001)
+        assert row["end_latitude"] == pytest.approx(49.510, abs=0.001)
+        assert row["end_longitude"] == pytest.approx(11.120, abs=0.001)
+        assert row["start_time_gmt"] == "2026-05-10T06:00:00.0"
+        assert row["calories"] == 120
+        assert row["left_pedal_smoothness"] == pytest.approx(76.5, abs=0.1)
+        assert row["right_pedal_smoothness"] == pytest.approx(74.2, abs=0.1)
+        assert row["left_torque_effectiveness"] == pytest.approx(91.0, abs=0.1)
+        assert row["right_torque_effectiveness"] == pytest.approx(89.5, abs=0.1)
+        assert row["surface_unpaved_pct"] == pytest.approx(45.0, abs=0.1)
+
+    def test_missing_performance_fields_are_null(self, temp_db):
+        bare_lap = {"distance": 1000, "duration": 300, "averageHR": 140}
+        upsert_activity_splits(temp_db, 555, [bare_lap])
+        row = _splits(temp_db, 555)[0]
+        assert row["normalized_power"] is None
+        assert row["avg_respiration_rate"] is None
+        assert row["start_latitude"] is None
+        assert row["calories"] is None
+        assert row["surface_unpaved_pct"] is None
+
+    def test_multiple_laps_all_get_performance_data(self, temp_db):
+        laps = [
+            dict(self._CYCLING_LAP, normalizedPower=200, calories=80),
+            dict(self._CYCLING_LAP, normalizedPower=220, calories=90),
+            dict(self._CYCLING_LAP, normalizedPower=250, calories=110),
+        ]
+        upsert_activity_splits(temp_db, 666, laps)
+        rows = _splits(temp_db, 666)
+        assert len(rows) == 3
+        assert [r["normalized_power"] for r in rows] == [200, 220, 250]
+        assert [r["calories"] for r in rows] == [80, 90, 110]
+
+
+# ---------------------------------------------------------------------------
+# sleep
+# ---------------------------------------------------------------------------
+
+class TestSleepNewColumns:
+    _RECORD = {
+        "dailySleepDTO": {
+            "calendarDate": "2026-05-10",
+            "sleepTimeSeconds": 27000,
+            "deepSleepSeconds": 5400,
+            "lightSleepSeconds": 14400,
+            "remSleepSeconds": 7200,
+        },
+        "bodyBatteryChange": 42,
+        "restingHeartRate": 52,
+        "avgSkinTempDeviationC": -0.3,
+        "avgSkinTempDeviationF": -0.54,
+    }
+
+    def test_new_sleep_fields_stored(self, temp_db):
+        upsert_sleep(temp_db, self._RECORD)
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-10")
+        assert row["body_battery_change"] == 42
+        assert row["resting_heart_rate"] == 52
+        assert row["avg_skin_temp_deviation_c"] == pytest.approx(-0.3, abs=0.01)
+        assert row["avg_skin_temp_deviation_f"] == pytest.approx(-0.54, abs=0.01)
+
+    def test_missing_new_fields_stored_as_null(self, temp_db):
+        record = {"dailySleepDTO": {
+            "calendarDate": "2026-05-09",
+            "sleepTimeSeconds": 25200,
+        }}
+        upsert_sleep(temp_db, record)
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-09")
+        assert row["body_battery_change"] is None
+        assert row["resting_heart_rate"] is None
+        assert row["avg_skin_temp_deviation_c"] is None
+
+    def test_existing_sleep_fields_still_work(self, temp_db):
+        upsert_sleep(temp_db, self._RECORD)
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-10")
+        assert row["sleep_time_seconds"] == 27000
+        assert row["deep_sleep_seconds"] == 5400
+
+    def test_rest_then_gql_preserves_bb_fields(self, temp_db):
+        """REST record (has BB/HR) written first, then GQL overwrites — values must survive."""
+        rest_record = {
+            "dailySleepDTO": {"calendarDate": "2026-05-10", "sleepTimeSeconds": 27000},
+            "bodyBatteryChange": 42,
+            "restingHeartRate": 52,
+            "avgSkinTempDeviationC": -0.3,
+            "avgSkinTempDeviationF": -0.54,
+        }
+        gql_record = {
+            "dailySleepDTO": {"calendarDate": "2026-05-10", "sleepTimeSeconds": 27000},
+            # GQL endpoints do not carry these fields
+        }
+        upsert_sleep(temp_db, rest_record)
+        upsert_sleep(temp_db, gql_record)
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-10")
+        assert row["body_battery_change"] == 42
+        assert row["resting_heart_rate"] == 52
+        assert row["avg_skin_temp_deviation_c"] == pytest.approx(-0.3, abs=0.01)
+
+    def test_gql_then_rest_populates_bb_fields(self, temp_db):
+        """GQL record (no BB/HR) written first, then REST record fills in values."""
+        gql_record = {
+            "dailySleepDTO": {"calendarDate": "2026-05-10", "sleepTimeSeconds": 27000},
+        }
+        rest_record = {
+            "dailySleepDTO": {"calendarDate": "2026-05-10", "sleepTimeSeconds": 27000},
+            "bodyBatteryChange": 38,
+            "restingHeartRate": 55,
+            "avgSkinTempDeviationC": 0.1,
+            "avgSkinTempDeviationF": 0.18,
+        }
+        upsert_sleep(temp_db, gql_record)
+        upsert_sleep(temp_db, rest_record)
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-10")
+        assert row["body_battery_change"] == 38
+        assert row["resting_heart_rate"] == 55
+        assert row["avg_skin_temp_deviation_c"] == pytest.approx(0.1, abs=0.01)
+
+    def test_zero_skin_temp_stored_not_null(self, temp_db):
+        """avgSkinTempDeviationC == 0 is a valid measurement, must not be coerced to NULL."""
+        record = {
+            "dailySleepDTO": {"calendarDate": "2026-05-10", "sleepTimeSeconds": 27000},
+            "avgSkinTempDeviationC": 0,
+            "avgSkinTempDeviationF": 0,
+        }
+        upsert_sleep(temp_db, record)
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-10")
+        assert row["avg_skin_temp_deviation_c"] == 0.0
+        assert row["avg_skin_temp_deviation_f"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# heart_rate
+# ---------------------------------------------------------------------------
+
+class TestHeartRateNewColumn:
+    def test_7day_avg_stored(self, temp_db):
+        upsert_heart_rate(temp_db, {
+            "calendarDate": "2026-05-10",
+            "restingHeartRate": 54,
+            "minHeartRate": 48,
+            "maxHeartRate": 168,
+            "lastSevenDaysAvgRestingHeartRate": 56.3,
+        })
+        row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-10")
+        assert row["last_7day_avg_resting"] == pytest.approx(56.3, abs=0.1)
+
+    def test_missing_7day_avg_is_null(self, temp_db):
+        upsert_heart_rate(temp_db, {
+            "calendarDate": "2026-05-09",
+            "restingHeartRate": 55,
+        })
+        row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-09")
+        assert row["last_7day_avg_resting"] is None
+        assert row["resting_hr"] == 55
+
+    def test_rest_then_gql_preserves_7day_avg(self, temp_db):
+        """REST record sets 7-day avg; GQL detail overwrites (no such field) — value must survive."""
+        upsert_heart_rate(temp_db, {
+            "calendarDate": "2026-05-10",
+            "restingHeartRate": 58,
+            "lastSevenDaysAvgRestingHeartRate": 59,
+        })
+        # GQL heart_rate_detail record has no lastSevenDaysAvgRestingHeartRate
+        upsert_heart_rate(temp_db, {
+            "calendarDate": "2026-05-10",
+            "restingHeartRate": 58,
+            "maxHeartRate": 160,
+        })
+        row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-10")
+        assert row["last_7day_avg_resting"] == pytest.approx(59, abs=0.1)
+        assert row["max_hr"] == 160
+
+    def test_gql_then_rest_populates_7day_avg(self, temp_db):
+        """GQL writes first (no 7-day field), then REST fills it in."""
+        upsert_heart_rate(temp_db, {"calendarDate": "2026-05-10", "restingHeartRate": 58})
+        upsert_heart_rate(temp_db, {
+            "calendarDate": "2026-05-10",
+            "restingHeartRate": 58,
+            "lastSevenDaysAvgRestingHeartRate": 59,
+        })
+        row = _row(temp_db, "heart_rate", "calendar_date", "2026-05-10")
+        assert row["last_7day_avg_resting"] == pytest.approx(59, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# spo2
+# ---------------------------------------------------------------------------
+
+class TestSpo2NewColumns:
+    def test_spo2_events_stored(self, temp_db):
+        upsert_spo2(temp_db, {
+            "calendarDate": "2026-05-10",
+            "averageSpO2": 96.0,
+            "lowestSpO2": 88.0,
+            "numberOfEventsBelowThreshold": 3,
+            "durationOfEventsBelowThreshold": 420.0,
+        })
+        row = _row(temp_db, "spo2", "calendar_date", "2026-05-10")
+        assert row["events_below_threshold"] == 3
+        assert row["duration_below_threshold_secs"] == pytest.approx(420.0)
+
+    def test_spo2_no_events_stored_as_null(self, temp_db):
+        upsert_spo2(temp_db, {"calendarDate": "2026-05-09", "averageSpO2": 98.0})
+        row = _row(temp_db, "spo2", "calendar_date", "2026-05-09")
+        assert row["events_below_threshold"] is None
+        assert row["duration_below_threshold_secs"] is None
+
+
+# ---------------------------------------------------------------------------
+# respiration
+# ---------------------------------------------------------------------------
+
+class TestRespirationNewColumn:
+    def test_avg_sleep_respiration_stored(self, temp_db):
+        upsert_respiration(temp_db, {
+            "calendarDate": "2026-05-10",
+            "avgWakingRespirationValue": 16.2,
+            "avgSleepRespirationValue": 14.8,
+            "lowestRespirationValue": 13.0,
+            "highestRespirationValue": 22.0,
+        })
+        row = _row(temp_db, "respiration", "calendar_date", "2026-05-10")
+        assert row["avg_waking"] == pytest.approx(16.2, abs=0.1)
+        assert row["avg_sleep"] == pytest.approx(14.8, abs=0.1)
+
+    def test_missing_sleep_respiration_is_null(self, temp_db):
+        upsert_respiration(temp_db, {
+            "calendarDate": "2026-05-09",
+            "avgWakingRespirationValue": 15.0,
+        })
+        row = _row(temp_db, "respiration", "calendar_date", "2026-05-09")
+        assert row["avg_sleep"] is None
+
+    def test_sleep_respiration_preserved_on_overwrite(self, temp_db):
+        """First write has sleep respiration; second write lacks it — value must survive."""
+        upsert_respiration(temp_db, {
+            "calendarDate": "2026-05-10",
+            "avgWakingRespirationValue": 16.0,
+            "avgSleepRespirationValue": 14.5,
+        })
+        upsert_respiration(temp_db, {
+            "calendarDate": "2026-05-10",
+            "avgWakingRespirationValue": 16.0,
+            # no avgSleepRespirationValue (e.g. same-day sync before sleep data is ready)
+        })
+        row = _row(temp_db, "respiration", "calendar_date", "2026-05-10")
+        assert row["avg_sleep"] == pytest.approx(14.5, abs=0.1)
+
+    def test_sleep_respiration_filled_on_later_write(self, temp_db):
+        """First write has no sleep value; later write fills it in."""
+        upsert_respiration(temp_db, {"calendarDate": "2026-05-10", "avgWakingRespirationValue": 16.0})
+        upsert_respiration(temp_db, {
+            "calendarDate": "2026-05-10",
+            "avgWakingRespirationValue": 16.0,
+            "avgSleepRespirationValue": 14.5,
+        })
+        row = _row(temp_db, "respiration", "calendar_date", "2026-05-10")
+        assert row["avg_sleep"] == pytest.approx(14.5, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# hydration
+# ---------------------------------------------------------------------------
+
+class TestHydrationNewColumns:
+    def test_sweat_loss_and_activity_intake_stored(self, temp_db):
+        upsert_hydration(temp_db, {
+            "calendarDate": "2026-05-10",
+            "goalInML": 2500,
+            "valueInML": 2100,
+            "sweatLossInML": 620,
+            "activityIntakeInML": 400,
+        })
+        row = _row(temp_db, "hydration", "calendar_date", "2026-05-10")
+        assert row["sweat_loss_ml"] == pytest.approx(620)
+        assert row["activity_intake_ml"] == pytest.approx(400)
+
+    def test_missing_sweat_loss_is_null(self, temp_db):
+        upsert_hydration(temp_db, {"calendarDate": "2026-05-09", "goalInML": 2000, "valueInML": 1800})
+        row = _row(temp_db, "hydration", "calendar_date", "2026-05-09")
+        assert row["sweat_loss_ml"] is None
+        assert row["activity_intake_ml"] is None
+
+    def test_sweat_loss_preserved_on_overwrite(self, temp_db):
+        """First write has sweat/activity data; second write lacks them — values must survive."""
+        upsert_hydration(temp_db, {
+            "calendarDate": "2026-05-10",
+            "goalInML": 2500,
+            "valueInML": 2100,
+            "sweatLossInML": 1200,
+            "activityIntakeInML": 350,
+        })
+        upsert_hydration(temp_db, {"calendarDate": "2026-05-10", "goalInML": 2500, "valueInML": 2100})
+        row = _row(temp_db, "hydration", "calendar_date", "2026-05-10")
+        assert row["sweat_loss_ml"] == pytest.approx(1200)
+        assert row["activity_intake_ml"] == pytest.approx(350)
+
+    def test_zero_activity_intake_stored_not_null(self, temp_db):
+        """activityIntakeInML == 0 is valid (no activity fluids), must not become NULL."""
+        upsert_hydration(temp_db, {
+            "calendarDate": "2026-05-10",
+            "goalInML": 2500,
+            "valueInML": 0,
+            "sweatLossInML": 500,
+            "activityIntakeInML": 0,
+        })
+        row = _row(temp_db, "hydration", "calendar_date", "2026-05-10")
+        assert row["activity_intake_ml"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# weight
+# ---------------------------------------------------------------------------
+
+class TestWeightNewColumns:
+    def test_metabolic_age_and_physique_rating_stored(self, temp_db):
+        upsert_weight(temp_db, {
+            "calendarDate": "2026-05-10",
+            "date": 1746835200000,
+            "weight": 77000,
+            "bmi": 25.7,
+            "metabolicAge": 38.0,
+            "physiqueRating": 4,
+        })
+        row = _row(temp_db, "weight", "calendar_date", "2026-05-10")
+        assert row["metabolic_age"] == pytest.approx(38.0)
+        assert row["physique_rating"] == 4
+
+    def test_missing_body_comp_fields_are_null(self, temp_db):
+        upsert_weight(temp_db, {
+            "calendarDate": "2026-05-09",
+            "date": 1746748800000,
+            "weight": 77500,
+        })
+        row = _row(temp_db, "weight", "calendar_date", "2026-05-09")
+        assert row["metabolic_age"] is None
+        assert row["physique_rating"] is None
+        assert row["weight"] == 77500
+
+
+# ---------------------------------------------------------------------------
+# endurance_score
+# ---------------------------------------------------------------------------
+
+class TestEnduranceScoreNewColumns:
+    _CONTRIBUTORS = [
+        {"activityTypeId": None, "contribution": 83.93, "group": 0},
+        {"activityTypeId": None, "contribution": 16.07, "group": 6},
+    ]
+
+    def test_feedback_phrase_and_contributors_stored(self, temp_db):
+        upsert_endurance_score(temp_db, {
+            "calendarDate": "2026-05-10",
+            "overallScore": 5200,
+            "classification": "PRODUCTIVE",
+            "vo2Max": 46.0,
+            "feedbackPhrase": "ENDURANCE_SCORE_IMPROVING",
+            "contributors": self._CONTRIBUTORS,
+        })
+        row = _row(temp_db, "endurance_score", "calendar_date", "2026-05-10")
+        assert row["feedback_phrase"] == "ENDURANCE_SCORE_IMPROVING"
+        parsed = json.loads(row["contributors"])
+        assert len(parsed) == 2
+        assert parsed[0]["contribution"] == pytest.approx(83.93)
+
+    def test_null_contributors_stored_as_null(self, temp_db):
+        upsert_endurance_score(temp_db, {
+            "calendarDate": "2026-05-09",
+            "overallScore": 5100,
+        })
+        row = _row(temp_db, "endurance_score", "calendar_date", "2026-05-09")
+        assert row["feedback_phrase"] is None
+        assert row["contributors"] is None
+
+
+# ---------------------------------------------------------------------------
+# hill_score
+# ---------------------------------------------------------------------------
+
+class TestHillScoreNewColumns:
+    def test_vo2max_and_feedback_stored(self, temp_db):
+        upsert_hill_score(temp_db, {
+            "calendarDate": "2026-05-10",
+            "overallScore": 58,
+            "enduranceScore": 62,
+            "strengthScore": 54,
+            "vo2Max": 46.0,
+            "vo2MaxPreciseValue": 46.3,
+            "hillScoreFeedbackPhraseId": "HILL_SCORE_IMPROVING",
+        })
+        row = _row(temp_db, "hill_score", "calendar_date", "2026-05-10")
+        assert row["vo2_max"] == pytest.approx(46.0)
+        assert row["vo2_max_precise"] == pytest.approx(46.3)
+        assert row["feedback_phrase_id"] == "HILL_SCORE_IMPROVING"
+
+    def test_existing_hill_fields_unaffected(self, temp_db):
+        upsert_hill_score(temp_db, {
+            "calendarDate": "2026-05-09",
+            "overallScore": 55,
+            "enduranceScore": 58,
+            "strengthScore": 52,
+            "vo2Max": 45.5,
+        })
+        row = _row(temp_db, "hill_score", "calendar_date", "2026-05-09")
+        assert row["overall_score"] == 55
+        assert row["endurance_score"] == 58
+        assert row["vo2_max"] == pytest.approx(45.5)
+        assert row["feedback_phrase_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# gear
+# ---------------------------------------------------------------------------
+
+class TestGearNewColumns:
+    def test_usage_stats_stored(self, temp_db):
+        upsert_gear(temp_db, {
+            "uuid": "abc-123",
+            "gearTypeName": "shoes",
+            "displayName": "Canyon CFSLX",
+            "distanceUsedMeters": 467282.78,
+            "durationUsedSeconds": 85673,
+            "daysUsed": 13,
+            "dateBegin": "2024-01-01",
+        })
+        row = _row(temp_db, "gear", "gear_id", "abc-123")
+        assert row["distance_used_meters"] == pytest.approx(467282.78, rel=1e-4)
+        assert row["duration_used_seconds"] == 85673
+        assert row["days_used"] == 13
+
+    def test_missing_usage_stats_are_null(self, temp_db):
+        upsert_gear(temp_db, {"uuid": "xyz-999", "gearTypeName": "shoes"})
+        row = _row(temp_db, "gear", "gear_id", "xyz-999")
+        assert row["distance_used_meters"] is None
+        assert row["duration_used_seconds"] is None
+        assert row["days_used"] is None
+
+
+# ---------------------------------------------------------------------------
+# Hollow tables: daily_events, wellness_activity, health_snapshot
+# ---------------------------------------------------------------------------
+
+class TestDailyEvents:
+    def test_scalar_fields_extracted(self, temp_db):
+        upsert_daily_events(temp_db, {
+            "activityType": "RUNNING",
+            "activitySubType": "TRAIL_RUNNING",
+            "startTimestampLocal": "2026-05-10T07:00:00",
+            "endTimestampLocal": "2026-05-10T08:00:00",
+            "duration": 3600.0,
+            "deviceId": "device-42",
+        }, cal_date="2026-05-10")
+        row = _row(temp_db, "daily_events", "calendar_date", "2026-05-10")
+        assert row["activity_type"] == "RUNNING"
+        assert row["activity_sub_type"] == "TRAIL_RUNNING"
+        assert row["start_timestamp_local"] == "2026-05-10T07:00:00"
+        assert row["end_timestamp_local"] == "2026-05-10T08:00:00"
+        assert row["duration_seconds"] == pytest.approx(3600.0)
+        assert row["device_id"] == "device-42"
+
+    def test_raw_json_still_stored(self, temp_db):
+        record = {"activityType": "CYCLING", "duration": 7200.0}
+        upsert_daily_events(temp_db, record, cal_date="2026-05-09")
+        row = _row(temp_db, "daily_events", "calendar_date", "2026-05-09")
+        assert row["raw_json"] is not None
+        assert json.loads(row["raw_json"])["activityType"] == "CYCLING"
+
+    def test_list_of_events_uses_first_typed_event(self, temp_db):
+        events = [
+            {"duration": 60.0},
+            {"activityType": "SWIMMING", "startTimestampLocal": "2026-05-08T09:00:00", "duration": 2700.0},
+        ]
+        upsert_daily_events(temp_db, events, cal_date="2026-05-08")
+        row = _row(temp_db, "daily_events", "calendar_date", "2026-05-08")
+        assert row["activity_type"] == "SWIMMING"
+        assert row["duration_seconds"] == pytest.approx(2700.0)
+
+
+class TestWellnessActivity:
+    def test_scalar_fields_extracted(self, temp_db):
+        upsert_wellness_activity(temp_db, {
+            "activityName": "Morning Walk",
+            "wellnessActivityType": "WALKING",
+            "startTimestampLocal": "2026-05-10T06:30:00",
+            "endTimestampLocal": "2026-05-10T07:00:00",
+        }, cal_date="2026-05-10")
+        row = _row(temp_db, "wellness_activity", "calendar_date", "2026-05-10")
+        assert row["activity_name"] == "Morning Walk"
+        assert row["wellness_activity_type"] == "WALKING"
+        assert row["start_timestamp_local"] == "2026-05-10T06:30:00"
+        assert row["end_timestamp_local"] == "2026-05-10T07:00:00"
+
+    def test_raw_json_preserved(self, temp_db):
+        record = {"activityName": "Yoga", "wellnessActivityType": "YOGA"}
+        upsert_wellness_activity(temp_db, record, cal_date="2026-05-09")
+        row = _row(temp_db, "wellness_activity", "calendar_date", "2026-05-09")
+        assert json.loads(row["raw_json"])["activityName"] == "Yoga"
+
+
+class TestHealthSnapshot:
+    def test_scalar_fields_extracted(self, temp_db):
+        upsert_health_snapshot(temp_db, {
+            "calendarDate": "2026-05-10",
+            "activityName": "Health Snapshot",
+            "wellnessActivityType": "HEALTH_SNAPSHOT",
+            "startTimestampLocal": "2026-05-10T08:00:00",
+            "endTimestampLocal": "2026-05-10T08:02:00",
+        })
+        row = _row(temp_db, "health_snapshot", "calendar_date", "2026-05-10")
+        assert row["activity_name"] == "Health Snapshot"
+        assert row["wellness_activity_type"] == "HEALTH_SNAPSHOT"
+
+    def test_missing_fields_are_null(self, temp_db):
+        upsert_health_snapshot(temp_db, {"calendarDate": "2026-05-09"})
+        row = _row(temp_db, "health_snapshot", "calendar_date", "2026-05-09")
+        assert row["activity_name"] is None
+        assert row["start_timestamp_local"] is None
+
+
+# ---------------------------------------------------------------------------
+# Migration: _add_columns / _backfill_from_raw
+# ---------------------------------------------------------------------------
+
+class TestAddColumns:
+    def test_adds_missing_column(self, temp_db):
+        _add_columns(temp_db, "sleep", [("test_col_xyzzy", "REAL")])
+        assert "test_col_xyzzy" in _cols(temp_db, "sleep")
+
+    def test_skips_existing_column(self, temp_db):
+        # Running twice must not raise
+        _add_columns(temp_db, "sleep", [("resting_heart_rate", "INTEGER")])
+        assert "resting_heart_rate" in _cols(temp_db, "sleep")
+
+    def test_returns_only_added_columns(self, temp_db):
+        added = _add_columns(temp_db, "sleep", [
+            ("resting_heart_rate", "INTEGER"),   # already exists
+            ("test_brand_new_col", "TEXT"),       # new
+        ])
+        assert added == ["test_brand_new_col"]
+
+
+class TestBackfillFromRaw:
+    def _make_db_with_old_schema(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE test_table (
+                id TEXT PRIMARY KEY,
+                raw_json TEXT
+            )
+        """)
+        conn.execute(
+            "INSERT INTO test_table VALUES (?, ?)",
+            ("row1", json.dumps({"myField": 42.5, "otherField": "hello"})),
+        )
+        conn.execute(
+            "INSERT INTO test_table VALUES (?, ?)",
+            ("row2", json.dumps({"myField": 99.0})),
+        )
+        conn.commit()
+        return conn
+
+    def test_backfills_new_column_from_raw_json(self):
+        conn = self._make_db_with_old_schema()
+        conn.execute("ALTER TABLE test_table ADD COLUMN my_field REAL")
+        _backfill_from_raw(conn, "test_table", ["id"], ["my_field"], {"my_field": "myField"})
+        rows = {r["id"]: dict(r) for r in conn.execute("SELECT * FROM test_table")}
+        assert rows["row1"]["my_field"] == pytest.approx(42.5)
+        assert rows["row2"]["my_field"] == pytest.approx(99.0)
+        conn.close()
+
+    def test_does_not_overwrite_existing_non_null_value(self):
+        conn = self._make_db_with_old_schema()
+        conn.execute("ALTER TABLE test_table ADD COLUMN my_field REAL")
+        conn.execute("UPDATE test_table SET my_field = 1.0 WHERE id = 'row1'")
+        _backfill_from_raw(conn, "test_table", ["id"], ["my_field"], {"my_field": "myField"})
+        row = dict(conn.execute("SELECT my_field FROM test_table WHERE id = 'row1'").fetchone())
+        assert row["my_field"] == pytest.approx(1.0)  # not overwritten with 42.5
+        conn.close()
+
+    def test_skips_unparseable_raw_json(self):
+        conn = self._make_db_with_old_schema()
+        conn.execute("INSERT INTO test_table VALUES (?, ?)", ("bad_row", "not-json"))
+        conn.execute("ALTER TABLE test_table ADD COLUMN my_field REAL")
+        _backfill_from_raw(conn, "test_table", ["id"], ["my_field"], {"my_field": "myField"})
+        row = dict(conn.execute("SELECT my_field FROM test_table WHERE id = 'bad_row'").fetchone())
+        assert row["my_field"] is None
+        conn.close()
+
+    def test_noop_when_added_list_empty(self):
+        conn = self._make_db_with_old_schema()
+        conn.execute("ALTER TABLE test_table ADD COLUMN my_field REAL")
+        _backfill_from_raw(conn, "test_table", ["id"], [], {"my_field": "myField"})
+        row = dict(conn.execute("SELECT my_field FROM test_table WHERE id = 'row1'").fetchone())
+        assert row["my_field"] is None  # no backfill ran
+        conn.close()
+
+
+class TestMigrationFunctions:
+    """Each migrate_* function must be idempotent and backfill correctly."""
+
+    def _old_db(self, ddl: str) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(ddl)
+        conn.commit()
+        return conn
+
+    def test_migrate_sleep_adds_and_backfills(self):
+        conn = self._old_db("""
+            CREATE TABLE sleep (
+                calendar_date TEXT PRIMARY KEY,
+                sleep_time_seconds INTEGER,
+                raw_json TEXT
+            );
+            INSERT INTO sleep VALUES (
+                '2026-05-10', 27000,
+                '{"bodyBatteryChange": 40, "restingHeartRate": 53,
+                  "avgSkinTempDeviationC": -0.2, "avgSkinTempDeviationF": -0.36}'
+            );
+        """)
+        migrate_sleep_table(conn)
+        row = dict(conn.execute("SELECT * FROM sleep WHERE calendar_date = '2026-05-10'").fetchone())
+        assert row["body_battery_change"] == 40
+        assert row["resting_heart_rate"] == 53
+        assert row["avg_skin_temp_deviation_c"] == pytest.approx(-0.2, abs=0.01)
+        conn.close()
+
+    def test_migrate_sleep_is_idempotent(self, temp_db):
+        migrate_sleep_table(temp_db)  # second call — already has columns
+        assert "resting_heart_rate" in _cols(temp_db, "sleep")
+
+    def test_migrate_heart_rate_adds_and_backfills(self):
+        conn = self._old_db("""
+            CREATE TABLE heart_rate (
+                calendar_date TEXT PRIMARY KEY,
+                resting_hr INTEGER,
+                raw_json TEXT
+            );
+            INSERT INTO heart_rate VALUES (
+                '2026-05-10', 54,
+                '{"lastSevenDaysAvgRestingHeartRate": 57.0}'
+            );
+        """)
+        migrate_heart_rate_table(conn)
+        row = dict(conn.execute("SELECT * FROM heart_rate WHERE calendar_date = '2026-05-10'").fetchone())
+        assert row["last_7day_avg_resting"] == pytest.approx(57.0)
+        conn.close()
+
+    def test_migrate_hill_score_adds_and_backfills(self):
+        conn = self._old_db("""
+            CREATE TABLE hill_score (
+                calendar_date TEXT PRIMARY KEY,
+                overall_score INTEGER,
+                raw_json TEXT
+            );
+            INSERT INTO hill_score VALUES (
+                '2026-05-10', 58,
+                '{"vo2Max": 46.0, "vo2MaxPreciseValue": 46.3,
+                  "hillScoreFeedbackPhraseId": "IMPROVING"}'
+            );
+        """)
+        migrate_hill_score_table(conn)
+        row = dict(conn.execute("SELECT * FROM hill_score WHERE calendar_date = '2026-05-10'").fetchone())
+        assert row["vo2_max"] == pytest.approx(46.0)
+        assert row["vo2_max_precise"] == pytest.approx(46.3)
+        assert row["feedback_phrase_id"] == "IMPROVING"
+        conn.close()
+
+    def test_migrate_gear_adds_and_backfills(self):
+        conn = self._old_db("""
+            CREATE TABLE gear (
+                gear_id TEXT PRIMARY KEY,
+                display_name TEXT,
+                raw_json TEXT
+            );
+            INSERT INTO gear VALUES (
+                'uuid-1', 'Canyon',
+                '{"distanceUsedMeters": 12345.6, "durationUsedSeconds": 43200, "daysUsed": 5}'
+            );
+        """)
+        migrate_gear_table(conn)
+        row = dict(conn.execute("SELECT * FROM gear WHERE gear_id = 'uuid-1'").fetchone())
+        assert row["distance_used_meters"] == pytest.approx(12345.6, rel=1e-4)
+        assert row["duration_used_seconds"] == 43200
+        assert row["days_used"] == 5
+        conn.close()
+
+    def test_migrate_activity_splits_v2_adds_and_backfills(self):
+        conn = self._old_db("""
+            CREATE TABLE activity_splits (
+                activity_id INTEGER,
+                split_number INTEGER,
+                raw_json TEXT,
+                PRIMARY KEY (activity_id, split_number)
+            );
+            INSERT INTO activity_splits VALUES (
+                1001, 1,
+                '{"normalizedPower": 230, "avgRespirationRate": 33.5,
+                  "startLatitude": 49.46, "startLongitude": 11.07,
+                  "calories": 115, "surfaceTypeUnpavedPercentage": 60.0}'
+            );
+        """)
+        migrate_activity_splits_v2(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM activity_splits WHERE activity_id = 1001"
+        ).fetchone())
+        assert row["normalized_power"] == 230
+        assert row["avg_respiration_rate"] == pytest.approx(33.5, abs=0.1)
+        assert row["start_latitude"] == pytest.approx(49.46, abs=0.01)
+        assert row["calories"] == 115
+        assert row["surface_unpaved_pct"] == pytest.approx(60.0)
+        conn.close()
+
+    def test_migrate_hollow_tables_adds_columns(self):
+        conn = self._old_db("""
+            CREATE TABLE daily_events (calendar_date TEXT PRIMARY KEY, raw_json TEXT);
+            CREATE TABLE wellness_activity (calendar_date TEXT PRIMARY KEY, raw_json TEXT);
+            CREATE TABLE health_snapshot (calendar_date TEXT PRIMARY KEY, raw_json TEXT);
+            INSERT INTO daily_events VALUES (
+                '2026-05-10',
+                '{"activityType": "RUNNING", "startTimestampLocal": "2026-05-10T07:00:00",
+                  "endTimestampLocal": "2026-05-10T08:00:00", "duration": 3600.0}'
+            );
+            INSERT INTO wellness_activity VALUES (
+                '2026-05-10',
+                '{"activityName": "Walk", "wellnessActivityType": "WALKING",
+                  "startTimestampLocal": "2026-05-10T06:00:00"}'
+            );
+        """)
+        migrate_hollow_tables(conn)
+        de_cols = _cols(conn, "daily_events")
+        assert "activity_type" in de_cols
+        assert "start_timestamp_local" in de_cols
+        wa = dict(conn.execute(
+            "SELECT * FROM wellness_activity WHERE calendar_date = '2026-05-10'"
+        ).fetchone())
+        assert wa["activity_name"] == "Walk"
+        assert wa["wellness_activity_type"] == "WALKING"
+        conn.close()
+
+    def test_migrate_endurance_score_stores_contributors_as_json(self):
+        contrib = [{"group": 0, "contribution": 80.0}, {"group": 6, "contribution": 20.0}]
+        conn = self._old_db(f"""
+            CREATE TABLE endurance_score (
+                calendar_date TEXT PRIMARY KEY,
+                overall_score INTEGER,
+                raw_json TEXT
+            );
+            INSERT INTO endurance_score VALUES (
+                '2026-05-10', 5200,
+                '{json.dumps({"feedbackPhrase": "PRODUCTIVE", "contributors": contrib})}'
+            );
+        """)
+        migrate_endurance_score_table(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM endurance_score WHERE calendar_date = '2026-05-10'"
+        ).fetchone())
+        assert row["feedback_phrase"] == "PRODUCTIVE"
+        parsed = json.loads(row["contributors"])
+        assert len(parsed) == 2
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# New v2/v3 migrations: sleep_v2 (RENAME COLUMN + nested backfill), activity,
+# fitness_age, weight_v3, gear_v2
+# ---------------------------------------------------------------------------
+
+class TestSleepMigrationV2:
+    """RENAME COLUMN + nested json_extract backfill from dailySleepDTO."""
+
+    def _old_db_with_rename_candidates(self) -> sqlite3.Connection:
+        """Pre-v2 schema: has the old (wrongly-named) columns sleep_need_seconds
+        and sleep_score_composition. These must be renamed in place."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE sleep (
+                calendar_date TEXT PRIMARY KEY,
+                sleep_time_seconds INTEGER,
+                sleep_need_seconds INTEGER,
+                sleep_score_composition INTEGER,
+                raw_json TEXT
+            );
+        """)
+        raw = {
+            "dailySleepDTO": {
+                "calendarDate": "2026-05-10",
+                "sleepTimeSeconds": 28800,
+                "sleepNeed": {"actual": 540},  # minutes
+                "highestSpO2Value": 99,
+                "sleepScores": {
+                    "overall": {"value": 87},
+                    "lightPercentage": {"value": 53},
+                    "remPercentage": {"value": 21},
+                    "deepPercentage": {"value": 26},
+                },
+            }
+        }
+        conn.execute(
+            "INSERT INTO sleep (calendar_date, sleep_time_seconds, raw_json) VALUES (?, ?, ?)",
+            ("2026-05-10", 28800, json.dumps(raw)),
+        )
+        conn.commit()
+        return conn
+
+    def test_renames_sleep_need_seconds_to_minutes(self):
+        conn = self._old_db_with_rename_candidates()
+        migrate_sleep_table_v2(conn)
+        cols = _cols(conn, "sleep")
+        assert "sleep_need_minutes" in cols
+        assert "sleep_need_seconds" not in cols
+        conn.close()
+
+    def test_renames_composition_to_light_pct(self):
+        conn = self._old_db_with_rename_candidates()
+        migrate_sleep_table_v2(conn)
+        cols = _cols(conn, "sleep")
+        assert "sleep_light_pct" in cols
+        assert "sleep_score_composition" not in cols
+        conn.close()
+
+    def test_backfill_from_nested_raw_json(self):
+        conn = self._old_db_with_rename_candidates()
+        migrate_sleep_table_v2(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM sleep WHERE calendar_date = '2026-05-10'"
+        ).fetchone())
+        assert row["sleep_need_minutes"] == 540
+        assert row["highest_spo2"] == pytest.approx(99.0)
+        assert row["sleep_score_overall"] == 87
+        assert row["sleep_light_pct"] == 53
+        assert row["sleep_score_rem"] == 21
+        assert row["sleep_score_deep"] == 26
+        conn.close()
+
+    def test_idempotent_on_fresh_schema(self, temp_db):
+        # temp_db already ran init_db, which includes migrate_sleep_table_v2.
+        # Second call must be a no-op without errors.
+        migrate_sleep_table_v2(temp_db)
+        cols = _cols(temp_db, "sleep")
+        assert "sleep_need_minutes" in cols
+        assert "sleep_light_pct" in cols
+        assert "sleep_need_seconds" not in cols
+
+    def test_idempotent_when_renames_already_done(self):
+        """Second run must not error even though target columns already exist."""
+        conn = self._old_db_with_rename_candidates()
+        migrate_sleep_table_v2(conn)
+        # Run again — RENAME COLUMN would fail if old name still present, but
+        # the migration checks first.
+        migrate_sleep_table_v2(conn)
+        cols = _cols(conn, "sleep")
+        assert "sleep_need_minutes" in cols
+        conn.close()
+
+
+class TestActivityMigration:
+    """migrate_activity_table adds 5 columns and backfills from summaryDTO."""
+
+    def _old_activity_db(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE activity (
+                activity_id INTEGER PRIMARY KEY,
+                activity_type TEXT,
+                raw_json TEXT
+            );
+        """)
+        raw = {
+            "summaryDTO": {
+                "differenceBodyBattery": -25,
+                "totalWork": 850.5,
+                "avgGradeAdjustedSpeed": 3.42,
+                "steps": 11250,
+                "minHR": 92,
+            }
+        }
+        conn.execute(
+            "INSERT INTO activity (activity_id, activity_type, raw_json) VALUES (?, ?, ?)",
+            (9001, "running", json.dumps(raw)),
+        )
+        conn.commit()
+        return conn
+
+    def test_adds_all_new_activity_columns(self):
+        conn = self._old_activity_db()
+        migrate_activity_table(conn)
+        cols = _cols(conn, "activity")
+        for c in ("body_battery_change", "total_work_kcal",
+                  "avg_grade_adjusted_speed", "activity_steps", "activity_min_hr"):
+            assert c in cols, f"Missing: {c}"
+        conn.close()
+
+    def test_backfill_from_summary_dto(self):
+        conn = self._old_activity_db()
+        migrate_activity_table(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM activity WHERE activity_id = 9001"
+        ).fetchone())
+        assert row["body_battery_change"] == -25
+        assert row["total_work_kcal"] == pytest.approx(850.5)
+        assert row["avg_grade_adjusted_speed"] == pytest.approx(3.42, abs=0.01)
+        assert row["activity_steps"] == 11250
+        assert row["activity_min_hr"] == 92
+        conn.close()
+
+    def test_idempotent(self, temp_db):
+        migrate_activity_table(temp_db)
+        assert "body_battery_change" in _cols(temp_db, "activity")
+
+    def test_missing_summary_dto_leaves_nulls(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE activity (
+                activity_id INTEGER PRIMARY KEY,
+                raw_json TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO activity VALUES (?, ?)",
+            (1, json.dumps({"activityName": "X"})),
+        )
+        conn.commit()
+        migrate_activity_table(conn)
+        row = dict(conn.execute("SELECT * FROM activity WHERE activity_id = 1").fetchone())
+        assert row["body_battery_change"] is None
+        assert row["total_work_kcal"] is None
+        conn.close()
+
+
+class TestFitnessAgeMigration:
+    def test_adds_achievable_fitness_age(self, temp_db):
+        migrate_fitness_age_table(temp_db)
+        assert "achievable_fitness_age" in _cols(temp_db, "fitness_age")
+
+    def test_backfill_from_raw(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE fitness_age (
+                calendar_date TEXT PRIMARY KEY,
+                raw_json TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO fitness_age VALUES (?, ?)",
+            ("2026-05-10", json.dumps({"achievableFitnessAge": 35.0})),
+        )
+        conn.commit()
+        migrate_fitness_age_table(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM fitness_age WHERE calendar_date = '2026-05-10'"
+        ).fetchone())
+        assert row["achievable_fitness_age"] == pytest.approx(35.0)
+        conn.close()
+
+
+class TestWeightMigrationV3:
+    def test_adds_visceral_fat(self, temp_db):
+        migrate_weight_table_v3(temp_db)
+        assert "visceral_fat" in _cols(temp_db, "weight")
+
+    def test_backfill_visceral_fat_from_raw(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE weight (
+                timestamp INTEGER PRIMARY KEY,
+                weight REAL,
+                raw_json TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO weight VALUES (?, ?, ?)",
+            (1746835200000, 77000, json.dumps({"visceralFat": 7.5})),
+        )
+        conn.commit()
+        migrate_weight_table_v3(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM weight WHERE timestamp = 1746835200000"
+        ).fetchone())
+        assert row["visceral_fat"] == pytest.approx(7.5)
+        conn.close()
+
+
+class TestGearMigrationV2:
+    def test_adds_status_and_max_distance(self, temp_db):
+        migrate_gear_table_v2(temp_db)
+        cols = _cols(temp_db, "gear")
+        assert "status" in cols
+        assert "max_usage_distance_meters" in cols
+
+    def test_backfill_status_and_max_distance(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE gear (
+                gear_id TEXT PRIMARY KEY,
+                display_name TEXT,
+                raw_json TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO gear VALUES (?, ?, ?)",
+            ("uuid-7", "Canyon",
+             json.dumps({"status": "active", "maxUsageDistanceMeters": 1500000.0})),
+        )
+        conn.commit()
+        migrate_gear_table_v2(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM gear WHERE gear_id = 'uuid-7'"
+        ).fetchone())
+        assert row["status"] == "active"
+        assert row["max_usage_distance_meters"] == pytest.approx(1500000.0)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full upgrade from old schema + idempotency of init_db itself
+# ---------------------------------------------------------------------------
+
+class TestFullUpgradePath:
+    """Simulate a user upgrading from pre-PR DB by running init_db on it."""
+
+    def test_init_db_is_idempotent(self, temp_db):
+        """Running init_db twice on a fresh DB must not raise or change schema."""
+        before_cols = _cols(temp_db, "sleep")
+        init_db(temp_db)  # second call
+        after_cols = _cols(temp_db, "sleep")
+        assert before_cols == after_cols
+
+    def test_init_db_recovers_old_sleep_schema(self):
+        """Old DB has sleep_need_seconds & sleep_score_composition (wrong names).
+        After init_db, the columns must be renamed and backfilled correctly."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        # Build a deliberately incomplete pre-PR sleep table
+        conn.executescript("""
+            CREATE TABLE sleep (
+                calendar_date TEXT PRIMARY KEY,
+                sleep_time_seconds INTEGER,
+                sleep_need_seconds INTEGER,
+                sleep_score_composition INTEGER,
+                raw_json TEXT
+            );
+        """)
+        raw = json.dumps({
+            "dailySleepDTO": {
+                "calendarDate": "2026-05-10",
+                "sleepTimeSeconds": 28000,
+                "sleepNeed": {"actual": 540},
+                "sleepScores": {
+                    "overall": {"value": 85},
+                    "lightPercentage": {"value": 50},
+                },
+            }
+        })
+        conn.execute(
+            "INSERT INTO sleep VALUES (?, ?, ?, ?, ?)",
+            ("2026-05-10", 28000, None, None, raw),
+        )
+        conn.commit()
+
+        init_db(conn)  # runs all migrations including sleep_v2
+
+        cols = _cols(conn, "sleep")
+        assert "sleep_need_minutes" in cols
+        assert "sleep_light_pct" in cols
+        assert "sleep_need_seconds" not in cols
+        assert "sleep_score_composition" not in cols
+
+        row = dict(conn.execute(
+            "SELECT * FROM sleep WHERE calendar_date = '2026-05-10'"
+        ).fetchone())
+        assert row["sleep_need_minutes"] == 540
+        assert row["sleep_light_pct"] == 50
+        assert row["sleep_score_overall"] == 85
+        conn.close()
+
+    def test_init_db_twice_on_old_schema_is_safe(self):
+        """Run init_db twice on a pre-PR DB — second pass must be a no-op."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE sleep (
+                calendar_date TEXT PRIMARY KEY,
+                sleep_time_seconds INTEGER,
+                sleep_need_seconds INTEGER,
+                raw_json TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sleep VALUES (?, ?, ?, ?)",
+            ("2026-05-10", 28000, None,
+             json.dumps({"dailySleepDTO": {"sleepNeed": {"actual": 500}}})),
+        )
+        conn.commit()
+
+        init_db(conn)
+        init_db(conn)  # idempotency check
+
+        row = dict(conn.execute(
+            "SELECT * FROM sleep WHERE calendar_date = '2026-05-10'"
+        ).fetchone())
+        assert row["sleep_need_minutes"] == 500
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases flagged in code review
+# ---------------------------------------------------------------------------
+
+class TestZeroValueBackfill:
+    """Regression: data.get(jk) must not coerce 0/False/'' to None."""
+
+    def test_zero_visceral_fat_preserved(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE weight (timestamp INTEGER PRIMARY KEY, weight REAL, raw_json TEXT);
+        """)
+        conn.execute(
+            "INSERT INTO weight VALUES (?, ?, ?)",
+            (1, 75000, json.dumps({"visceralFat": 0})),
+        )
+        conn.commit()
+        migrate_weight_table_v3(conn)
+        row = dict(conn.execute("SELECT * FROM weight WHERE timestamp = 1").fetchone())
+        assert row["visceral_fat"] == 0.0  # not NULL
+        conn.close()
+
+    def test_zero_body_battery_change_preserved(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE activity (activity_id INTEGER PRIMARY KEY, raw_json TEXT);
+        """)
+        conn.execute(
+            "INSERT INTO activity VALUES (?, ?)",
+            (1, json.dumps({"summaryDTO": {"differenceBodyBattery": 0,
+                                            "steps": 0, "totalWork": 0.0}})),
+        )
+        conn.commit()
+        migrate_activity_table(conn)
+        row = dict(conn.execute("SELECT * FROM activity WHERE activity_id = 1").fetchone())
+        assert row["body_battery_change"] == 0
+        assert row["activity_steps"] == 0
+        assert row["total_work_kcal"] == 0.0
+        conn.close()
+
+    def test_zero_spo2_events_preserved(self):
+        """Most users have events_below_threshold=0 — must not be NULL after backfill."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE spo2 (calendar_date TEXT PRIMARY KEY, raw_json TEXT);
+        """)
+        conn.execute(
+            "INSERT INTO spo2 VALUES (?, ?)",
+            ("2026-05-10", json.dumps({
+                "numberOfEventsBelowThreshold": 0,
+                "durationOfEventsBelowThreshold": 0,
+            })),
+        )
+        conn.commit()
+        migrate_spo2_table(conn)
+        row = dict(conn.execute(
+            "SELECT * FROM spo2 WHERE calendar_date = '2026-05-10'"
+        ).fetchone())
+        assert row["events_below_threshold"] == 0
+        assert row["duration_below_threshold_secs"] == 0
+        conn.close()
+
+
+class TestSleepNullNestedScore:
+    """Garmin sometimes returns sleepScores.overall = null for failed nights."""
+
+    def test_null_overall_score_does_not_crash(self, temp_db):
+        record = {
+            "dailySleepDTO": {
+                "calendarDate": "2026-05-10",
+                "sleepTimeSeconds": 27000,
+                "sleepScores": {"overall": None, "remPercentage": None, "deepPercentage": None,
+                                "lightPercentage": None},
+            }
+        }
+        upsert_sleep(temp_db, record)  # must not raise
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-10")
+        assert row["sleep_score_overall"] is None
+        assert row["sleep_score_rem"] is None
+        assert row["sleep_score_deep"] is None
+        assert row["sleep_light_pct"] is None
+
+    def test_missing_sleep_scores_dict_entirely(self, temp_db):
+        record = {"dailySleepDTO": {"calendarDate": "2026-05-09", "sleepTimeSeconds": 25000}}
+        upsert_sleep(temp_db, record)  # must not raise
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-09")
+        assert row["sleep_score_overall"] is None
+
+
+class TestSleepLightPctUpsert:
+    """Regression: upsert_sleep must write sleep_light_pct, not just the migration."""
+
+    def test_sleep_light_pct_persisted_via_upsert(self, temp_db):
+        record = {
+            "dailySleepDTO": {
+                "calendarDate": "2026-05-10",
+                "sleepTimeSeconds": 27000,
+                "sleepScores": {
+                    "overall": {"value": 85},
+                    "lightPercentage": {"value": 58},
+                    "remPercentage": {"value": 25},
+                    "deepPercentage": {"value": 17},
+                },
+            }
+        }
+        upsert_sleep(temp_db, record)
+        row = _row(temp_db, "sleep", "calendar_date", "2026-05-10")
+        assert row["sleep_light_pct"] == 58
+
+
+class TestActivityUpsertPreservesSummaryData:
+    """Regression: a flat list record (no summaryDTO) must not blank columns set
+    by a prior detailed record."""
+
+    def test_detail_then_flat_preserves_summary_columns(self, temp_db):
+        detailed = {
+            "activityId": 9999,
+            "activityName": "Detail Run",
+            "summaryDTO": {
+                "differenceBodyBattery": -20,
+                "totalWork": 180.5,
+                "steps": 8500,
+                "minHR": 95,
+                "avgGradeAdjustedSpeed": 3.1,
+            },
+        }
+        flat = {
+            "activityId": 9999,
+            "activityName": "List Run",
+            # no summaryDTO
+        }
+        upsert_activity(temp_db, detailed)
+        upsert_activity(temp_db, flat)
+        row = _row(temp_db, "activity", "activity_id", 9999)
+        # Basic fields take the latest write
+        assert row["activity_name"] == "List Run"
+        # Summary-only fields preserved from the detailed record
+        assert row["body_battery_change"] == -20
+        assert row["total_work_kcal"] == pytest.approx(180.5)
+        assert row["activity_steps"] == 8500
+        assert row["activity_min_hr"] == 95
+        assert row["avg_grade_adjusted_speed"] == pytest.approx(3.1, abs=0.01)
+
+    def test_flat_then_detail_populates_summary_columns(self, temp_db):
+        upsert_activity(temp_db, {"activityId": 8888, "activityName": "First"})
+        upsert_activity(temp_db, {
+            "activityId": 8888,
+            "activityName": "Second",
+            "summaryDTO": {"differenceBodyBattery": -15, "steps": 7000},
+        })
+        row = _row(temp_db, "activity", "activity_id", 8888)
+        assert row["activity_name"] == "Second"
+        assert row["body_battery_change"] == -15
+        assert row["activity_steps"] == 7000
+
+
+class TestRenameColumnGuard:
+    """Regression: RENAME COLUMN must not crash when both source and target exist."""
+
+    def test_sleep_v2_idempotent_when_target_pre_exists(self):
+        """User manually ALTERed in the new column — migration must not duplicate-key crash."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE sleep (
+                calendar_date TEXT PRIMARY KEY,
+                sleep_need_seconds INTEGER,
+                sleep_need_minutes INTEGER,
+                raw_json TEXT
+            );
+        """)
+        # Both columns exist — migration must skip the rename gracefully
+        migrate_sleep_table_v2(conn)  # must not raise
+        cols = _cols(conn, "sleep")
+        # Both can exist (we don't drop the legacy one), but no crash
+        assert "sleep_need_minutes" in cols
+        conn.close()
+
+
+class TestActivityKjToKcalRename:
+    """Pre-release intermediate had total_work_kj; the column rename must work."""
+
+    def test_renames_kj_to_kcal(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE activity (
+                activity_id INTEGER PRIMARY KEY,
+                total_work_kj REAL,
+                raw_json TEXT
+            );
+            INSERT INTO activity VALUES (1, 248.21, NULL);
+        """)
+        migrate_activity_table(conn)
+        cols = _cols(conn, "activity")
+        assert "total_work_kcal" in cols
+        assert "total_work_kj" not in cols
+        # Existing value preserved (already in kcal — just relabeled)
+        row = dict(conn.execute("SELECT * FROM activity WHERE activity_id = 1").fetchone())
+        assert row["total_work_kcal"] == pytest.approx(248.21)
+        conn.close()
+
+
+class TestHollowTableArrayRawJson:
+    """Edge: raw_json may be a JSON array (multi-event payloads)."""
+
+    def test_daily_events_array_raw_json_does_not_crash(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE daily_events (calendar_date TEXT PRIMARY KEY, raw_json TEXT);
+            CREATE TABLE wellness_activity (calendar_date TEXT PRIMARY KEY, raw_json TEXT);
+            CREATE TABLE health_snapshot (calendar_date TEXT PRIMARY KEY, raw_json TEXT);
+        """)
+        # raw_json is a JSON array, not an object
+        conn.execute(
+            "INSERT INTO daily_events VALUES (?, ?)",
+            ("2026-05-10", json.dumps([{"activityType": "RUN"}, {"activityType": "BIKE"}])),
+        )
+        conn.commit()
+        # Must not crash; array rows just don't get scalar fields backfilled
+        migrate_hollow_tables(conn)
+        # Schema columns added regardless
+        assert "activity_type" in _cols(conn, "daily_events")
+        conn.close()


### PR DESCRIPTION
## Summary

Closes #13 (body_battery aggregate backfill) and substantially expands what
Garmin Connect data is surfaced through the MCP server.

Surfaces ~50 previously-extracted-but-hidden Garmin fields by adding structured
columns alongside the existing `raw_json` blobs, then backfilling those columns
from historical raw_json. All migrations are idempotent and run automatically
on next `init_db()`.

Adds a `--start-date YYYY-MM-DD` flag to `garmin_mcp.sync` so users can do a
full-history backfill, not just incremental syncs.

## Notable changes

**Schema (`garmin_mcp/db.py`)** — 5 new migrations:
- `migrate_sleep_table_v2` — adds 6 sleep score / SpO2 / sleep-need columns
- `migrate_activity_table` — adds `body_battery_change`, `total_work_kcal`,
  `avg_grade_adjusted_speed`, `activity_steps`, `activity_min_hr`
- `migrate_fitness_age_table` — `achievable_fitness_age`
- `migrate_weight_table_v3` — `visceral_fat`
- `migrate_gear_table_v2` — `status`, `max_usage_distance_meters`

**Correctness fixes uncovered during review:**
- `upsert_activity` converted from `INSERT OR REPLACE` to `INSERT OR IGNORE
  + UPDATE` with `COALESCE` on `summaryDTO`-only columns. Flat-list activity
  records can no longer blank out detailed data populated by the
  `activity_details` endpoint.
- `_backfill_from_raw` dropped a `data.get(jk) or None` coercion that silently
  converted legitimate `0` / `False` / `""` values to `NULL` (affected
  `events_below_threshold = 0`, `body_battery_change = 0`, `visceral_fat = 0`,
  brand-new gear, etc.).
- `upsert_sleep` now writes `sleep_light_pct` (was migration-only — every new
  night was getting `NULL`). Also guards nested `sleepScores.*` access against
  `null` sub-dicts (`{"sleepScores": {"overall": null}}` no longer raises).
- `total_work_kj` renamed to `total_work_kcal`. Verified: Garmin's
  `summaryDTO.totalWork` is in kilocalories of mechanical work, not kJ —
  `224 W × 4648 s = 1041 kJ ≈ 248 kcal` matches the stored value of `248.21`.
- `RENAME COLUMN` operations are now guarded against duplicate-target crashes
  for users who manually `ALTER`ed in the new column.
- Removed `sleep_score_recovery` / `sleep_score_restfulness` (Garmin API has
  no numeric value for these — only a `qualifierKey` text).

**Sync (`garmin_mcp/sync.py`)**:
- New `--start-date YYYY-MM-DD` flag for backfills (default behavior unchanged
  — yesterday → today incremental)
- Validates ISO format and `start_date <= target_date`
- `sync_log.sync_type` and log messages distinguish `backfill` vs
  `incremental_sync`

**MCP exposure (`garmin_mcp/server.py`)** — new columns surfaced in:
`garmin_today`, `garmin_sleep`, `garmin_activity_detail`, `garmin_heart_rate`,
`garmin_body_battery`, `garmin_stress`, `garmin_devices`, `garmin_gear`,
`garmin_body_composition`, `garmin_fitness_age`.

## Compatibility

- Requires SQLite ≥ 3.25 for `ALTER TABLE ... RENAME COLUMN` (Sept 2018 —
  Python 3.10+ on any current OS satisfies this).
- Migrations are idempotent: running `init_db()` repeatedly on a fully-migrated
  DB produces zero data drift (verified by row-hash comparison across two
  passes on a real 18-month DB).
- Backwards-compatible with pre-PR DBs: missing columns are added, existing
  data is preserved, `raw_json` is backfilled into the new columns.

## Test plan

149 unit tests pass (up from 99 before this PR's tests were written).

Verified end-to-end in real-world conditions:

- [x] All 149 unit tests pass (`uv run pytest tests/`)
- [x] Ruff clean on all changed files
- [x] Schema diff: all expected columns present, all forbidden columns absent
- [x] All 21 modified MCP tools return clean responses on a real ~18-month DB
- [x] `garmin_activity_detail` returns the 8 new columns with real values
- [x] 35/35 production `raw_json` payloads replay cleanly through `upsert_*`
- [x] 3 realistic upgrade scenarios pass (fresh install, pre-PR user upgrade,
      dev-branch user with wrong-named columns)
- [x] `init_db()` ×3 on the same DB → zero data drift (idempotency)
- [x] Live sync against Garmin Connect on a fresh-install temp DB: 409 records
      upserted, all new columns populated correctly