### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "garmin-givemydata"
-version = "0.1.11"
+version = "0.1.12"
 description = "Get your Garmin Connect data back. Browser-based extraction + 48-table SQLite database + MCP server for AI analysis."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump for the v0.1.12 release. See the release notes for the full changelog since v0.1.11.