### PR TITLE
Track parsed FIT files and backfill trackpoints from disk

### DIFF
--- a/garmin_givemydata.py
+++ b/garmin_givemydata.py
@@ -27,7 +27,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from garmin_client import GarminClient
-from garmin_mcp.db import get_connection, init_db, save_to_db
+from garmin_mcp.db import get_connection, init_db, record_fit_parse, save_to_db
 from garmin_mcp.db import query as db_query
 
 
@@ -206,12 +206,15 @@ def _save_trackpoints_from_fit(conn, fit_path: Path) -> tuple[str, int]:
     try:
         activity_id, trackpoints = parse_trackpoints_from_fit_archive(fit_path)
     except Exception:
+        record_fit_parse(conn, fit_path.name, None, "failed", 0)
         return "failed", 0
 
     if activity_id is None or not trackpoints:
+        record_fit_parse(conn, fit_path.name, activity_id, "skipped", 0)
         return "skipped", 0
 
     count = save_to_db(conn, "activity_trackpoints", trackpoints, cal_date=str(activity_id))
+    record_fit_parse(conn, fit_path.name, activity_id, "ingested", count)
     return "ingested", count
 
 
@@ -229,6 +232,37 @@ def _parse_trackpoints_from_fit_dir(conn, fit_dir: Path) -> dict[str, int]:
         return summary
 
     for fit_path in sorted(fit_dir.glob("*.zip")):
+        summary["targeted"] += 1
+        status, count = _save_trackpoints_from_fit(conn, fit_path)
+        if status == "ingested":
+            summary["ingested"] += 1
+            summary["rows"] += count
+        elif status == "skipped":
+            summary["skipped"] += 1
+        else:
+            summary["failed"] += 1
+
+    return summary
+
+
+def _backfill_unparsed_fit(conn, fit_dir: Path) -> dict[str, int]:
+    """Parse FIT archives present on disk but not yet recorded in ``fit_files``.
+
+    Covers files that exist without having been parsed into this database —
+    e.g. after wiping garmin.db but keeping fit/, restoring fit/ from another
+    machine, or an interrupted run. Idempotent: once a file is recorded (even as
+    'skipped' for a GPS-less activity) it is not parsed again.
+    """
+    summary = {"targeted": 0, "ingested": 0, "skipped": 0, "failed": 0, "rows": 0}
+
+    if not fit_dir.exists():
+        return summary
+
+    parsed = {r["filename"] for r in db_query(conn, "SELECT filename FROM fit_files")}
+
+    for fit_path in sorted(fit_dir.glob("*.zip")):
+        if fit_path.name in parsed:
+            continue
         summary["targeted"] += 1
         status, count = _save_trackpoints_from_fit(conn, fit_path)
         if status == "ingested":
@@ -655,13 +689,6 @@ examples:
                 )
 
                 downloaded = 0
-                trackpoint_summary = {
-                    "targeted": 0,
-                    "ingested": 0,
-                    "skipped": 0,
-                    "failed": 0,
-                    "rows": 0,
-                }
                 for i, (aid, name, date_str) in enumerate(new_activities):
                     safe_name = ""
                     if name:
@@ -679,16 +706,6 @@ examples:
                         with open(filepath, "wb") as f:
                             f.write(data)
                         downloaded += 1
-                        if args.parse_trackpoints:
-                            trackpoint_summary["targeted"] += 1
-                            status, count = _save_trackpoints_from_fit(conn, filepath)
-                            if status == "ingested":
-                                trackpoint_summary["ingested"] += 1
-                                trackpoint_summary["rows"] += count
-                            elif status == "skipped":
-                                trackpoint_summary["skipped"] += 1
-                            else:
-                                trackpoint_summary["failed"] += 1
 
                     if downloaded > 0 and downloaded % 10 == 0:
                         print(f"  {downloaded}/{len(new_activities)} downloaded...")
@@ -697,10 +714,16 @@ examples:
                         time.sleep(1)
 
                 print(f"  FIT files: {downloaded} downloaded to {fit_dir}/")
-                if args.parse_trackpoints and trackpoint_summary["targeted"]:
-                    _print_trackpoint_summary(trackpoint_summary, prefix="  ")
             else:
                 print(f"\nFIT files: all {len(existing_fits)} already downloaded")
+
+            # Parse trackpoints for every FIT on disk not yet recorded in the
+            # database — covers freshly downloaded files and any kept from a
+            # previous database (e.g. a wipe + resync that retained fit/).
+            if args.parse_trackpoints:
+                summary = _backfill_unparsed_fit(conn, fit_dir)
+                if summary["targeted"]:
+                    _print_trackpoint_summary(summary, prefix="  ")
 
     finally:
         client.close()

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -677,6 +677,18 @@ CREATE TABLE IF NOT EXISTS sync_log (
     created_at          TEXT DEFAULT (datetime('now'))
 );
 
+-- Tracks which FIT archives have had their trackpoints parsed, so a sync can
+-- reconcile files already on disk (e.g. after wiping the DB but keeping fit/)
+-- without re-parsing every run — including activities that legitimately have
+-- no GPS trackpoints (recorded as 'skipped').
+CREATE TABLE IF NOT EXISTS fit_files (
+    filename            TEXT PRIMARY KEY,
+    activity_id         INTEGER,
+    status              TEXT,
+    point_count         INTEGER,
+    parsed_at           TEXT DEFAULT (datetime('now'))
+);
+
 -- =========================================================================
 -- Indexes
 -- =========================================================================
@@ -3119,6 +3131,18 @@ def _extract_calories_records(data: Any, cal_date: str = None) -> list[dict]:
                 return [{**data, "calendarDate": record_date, "consumedKilocalories": sum(meal_calories)}]
 
     return []
+
+
+def record_fit_parse(conn, filename: str, activity_id, status: str, point_count: int) -> None:
+    """Record that a FIT archive has been parsed for trackpoints. Keyed by
+    filename so a reconciliation pass can skip files already handled — including
+    GPS-less activities (``status='skipped'``) that would otherwise be re-parsed
+    on every sync because they never land rows in activity_trackpoints."""
+    conn.execute(
+        "INSERT OR REPLACE INTO fit_files (filename, activity_id, status, point_count, parsed_at) "
+        "VALUES (?, ?, ?, ?, datetime('now'))",
+        (filename, activity_id, status, point_count),
+    )
 
 
 def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str = None) -> int:

--- a/tests/test_fit_files_tracking.py
+++ b/tests/test_fit_files_tracking.py
@@ -1,0 +1,82 @@
+"""Tests for FIT parse tracking and trackpoint backfill reconciliation.
+
+Trackpoints used to be parsed only for freshly downloaded FIT files, so FIT
+archives kept on disk across a DB wipe (or restored from elsewhere) were never
+parsed. The ``fit_files`` table records every parse — including GPS-less
+activities marked 'skipped' — so a sync reconciles on-disk files against it
+without re-parsing every run.
+"""
+
+import pytest
+
+import garmin_givemydata as ggm
+from garmin_mcp.db import record_fit_parse
+
+
+@pytest.mark.unit
+class TestFitFilesTable:
+    def test_table_exists(self, temp_db):
+        cols = {r[1] for r in temp_db.execute("PRAGMA table_info(fit_files)")}
+        assert {"filename", "activity_id", "status", "point_count", "parsed_at"} <= cols
+
+    def test_record_fit_parse_inserts(self, temp_db):
+        record_fit_parse(temp_db, "2025-01-01_111_Run.zip", 111, "ingested", 1234)
+        row = temp_db.execute("SELECT filename, activity_id, status, point_count FROM fit_files").fetchone()
+        assert tuple(row) == ("2025-01-01_111_Run.zip", 111, "ingested", 1234)
+
+    def test_record_fit_parse_upserts_by_filename(self, temp_db):
+        record_fit_parse(temp_db, "f.zip", 1, "failed", 0)
+        record_fit_parse(temp_db, "f.zip", 1, "ingested", 42)
+        rows = temp_db.execute("SELECT status, point_count FROM fit_files WHERE filename='f.zip'").fetchall()
+        assert len(rows) == 1
+        assert tuple(rows[0]) == ("ingested", 42)
+
+
+@pytest.mark.unit
+class TestBackfillUnparsedFit:
+    def _make_fit(self, d, name):
+        (d / name).write_bytes(b"PK\x03\x04")
+
+    def _fake_save(self):
+        # Mirror _save_trackpoints_from_fit: record the parse, return (status, count).
+        def fake(conn, path):
+            if "333" in path.name:  # pretend this activity has no GPS
+                record_fit_parse(conn, path.name, 333, "skipped", 0)
+                return "skipped", 0
+            aid = int(path.stem.split("_")[1])
+            record_fit_parse(conn, path.name, aid, "ingested", 5)
+            return "ingested", 5
+
+        return fake
+
+    def test_parses_all_then_is_idempotent(self, temp_db, tmp_path, monkeypatch):
+        for n in ("2025-01-01_111_Run.zip", "2025-01-02_222_Ride.zip", "2025-01-03_333_Strength.zip"):
+            self._make_fit(tmp_path, n)
+        monkeypatch.setattr(ggm, "_save_trackpoints_from_fit", self._fake_save())
+
+        first = ggm._backfill_unparsed_fit(temp_db, tmp_path)
+        assert first["targeted"] == 3
+        assert first["ingested"] == 2
+        assert first["skipped"] == 1
+        assert temp_db.execute("SELECT COUNT(*) FROM fit_files").fetchone()[0] == 3
+
+        # Second run: every file (incl. the GPS-less 'skipped' one) is recorded,
+        # so nothing is re-parsed.
+        second = ggm._backfill_unparsed_fit(temp_db, tmp_path)
+        assert second["targeted"] == 0
+
+    def test_only_new_file_is_parsed_on_next_run(self, temp_db, tmp_path, monkeypatch):
+        self._make_fit(tmp_path, "2025-01-01_111_Run.zip")
+        monkeypatch.setattr(ggm, "_save_trackpoints_from_fit", self._fake_save())
+
+        assert ggm._backfill_unparsed_fit(temp_db, tmp_path)["targeted"] == 1
+
+        # A new activity's FIT lands later.
+        self._make_fit(tmp_path, "2025-02-02_222_Ride.zip")
+        result = ggm._backfill_unparsed_fit(temp_db, tmp_path)
+        assert result["targeted"] == 1
+        assert result["ingested"] == 1
+
+    def test_missing_dir_is_safe(self, temp_db, tmp_path):
+        result = ggm._backfill_unparsed_fit(temp_db, tmp_path / "does-not-exist")
+        assert result["targeted"] == 0


### PR DESCRIPTION
Closes #58.

## Problem

Trackpoints are parsed only for FIT files freshly downloaded in the same run — the parse is called inside the download loop, which only iterates `new_activities`. A FIT archive present on disk but absent from the database (after wiping `garmin.db` while keeping `fit/`, restoring `fit/` from another machine, or an interrupted run) is therefore never parsed, leaving `activity_trackpoints` empty despite the files being present. The only recovery is knowing to run `--rebuild-trackpoints` by hand. (Also relevant to the reuse-existing-FIT workflow in #26.)

## Change

- **New `fit_files` table** recording every parse: `filename` (PK), `activity_id`, `status`, `point_count`, `parsed_at`.
- **`record_fit_parse()`** in `garmin_mcp/db.py`; `_save_trackpoints_from_fit` now records each outcome (ingested / skipped / failed).
- **`_backfill_unparsed_fit()`** reconciles every FIT on disk against `fit_files` after downloading, parsing any not yet recorded — covering both new downloads and files kept from a previous DB.
- GPS-less activities are recorded as `skipped`, so they aren't re-parsed on every run (matters for large strength/indoor libraries that never produce trackpoints).
- Unifies the inline parse-on-download path and `--rebuild-trackpoints` onto one **idempotent** reconciliation; re-parsing an activity replaces its trackpoints rather than duplicating them.

The `fit_files` table is created by the existing `CREATE TABLE IF NOT EXISTS` schema, so existing databases pick it up automatically; the first sync afterwards records the FIT files already on disk.

## Testing

- New `tests/test_fit_files_tracking.py`: table creation, `record_fit_parse` upsert, and the reconciliation (parses all once, idempotent on re-run, only-new-file-on-next-run, GPS-less files recorded and not retried, missing-dir safe).
- Full test suite green (162 passed); `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)