### PR TITLE
Repair stale health_status GraphQL query (metricsMap/overallStatus undefined)

### DIFF
--- a/garmin_client/endpoints.py
+++ b/garmin_client/endpoints.py
@@ -142,11 +142,13 @@ def daily_graphql(display_name: str, date: str) -> dict:
         "sleep_detail": f'query{{sleepScalar(date:"{date}", sleepOnly: false)}}',
         "training_status_daily": f'query{{trainingStatusDailyScalar(calendarDate:"{date}")}}',
         "daily_events": f'query{{dailyEventsScalar(date:"{date}")}}',
-        "health_status": f'''query {{
-            healthStatusSummary(calendarDate:"{date}") {{
-                calendarDate overallStatus metricsMap
-            }}
-        }}''',
+        # ``HealthStatusSummaryDTO`` no longer exposes ``calendarDate``,
+        # ``overallStatus`` or ``metricsMap`` (Garmin renamed the schema); asking
+        # for them returns a FieldUndefined validation error for every day, which
+        # was being stored as a row. The current shape is a ``metrics`` list of
+        # ``{type, status, value}``. Days without data return a null node, which
+        # the GraphQL unwrapper drops, so nothing is written.
+        "health_status": f'query{{healthStatusSummary(calendarDate:"{date}"){{metrics{{type status value}}}}}}',
         "activity_trends_all": f'query{{activityTrendsScalar(activityType:"all",date:"{date}")}}',
         "activity_trends_running": f'query{{activityTrendsScalar(activityType:"running",date:"{date}")}}',
         "activity_trends_cycling": f'query{{activityTrendsScalar(activityType:"cycling",date:"{date}")}}',

--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -3000,6 +3000,12 @@ def _unwrap_gql_data(data):
     if not isinstance(data, dict):
         return data
 
+    # A GraphQL error-only response (validation/execution errors with no data)
+    # must not be stored as if it were a record — otherwise every failing day
+    # lands a junk row (see the stale healthStatusSummary query).
+    if data.get("errors") and not data.get("data"):
+        return []
+
     # Handle { data: { scalar: ... } }
     if "data" in data and isinstance(data["data"], dict):
         data = data["data"]

--- a/tests/test_health_status_query.py
+++ b/tests/test_health_status_query.py
@@ -1,0 +1,77 @@
+"""Tests for the health_status GraphQL query fix.
+
+``HealthStatusSummaryDTO`` no longer exposes ``calendarDate``/``overallStatus``/
+``metricsMap``; the stale query returned a FieldUndefined validation error for
+every day, and that error response was being stored as a row. The query now
+requests the current ``metrics`` shape, and GraphQL error-only responses are
+never stored.
+"""
+
+import pytest
+
+from garmin_client.endpoints import daily_graphql
+from garmin_mcp.db import _unwrap_gql_data, save_to_db
+
+
+def _query():
+    return daily_graphql("user", "2026-06-01")["health_status"]
+
+
+def _count(conn):
+    return conn.execute("SELECT COUNT(*) FROM health_status").fetchone()[0]
+
+
+@pytest.mark.unit
+class TestHealthStatusQuery:
+    def test_query_drops_removed_fields(self):
+        q = _query()
+        assert "overallStatus" not in q
+        assert "metricsMap" not in q
+
+    def test_query_uses_current_metrics_shape(self):
+        q = _query()
+        assert "healthStatusSummary" in q
+        assert "metrics" in q
+        for field in ("type", "status", "value"):
+            assert field in q
+
+
+@pytest.mark.unit
+class TestHealthStatusStorage:
+    def test_null_node_writes_no_row(self, temp_db):
+        resp = {"data": {"healthStatusSummary": None}}
+        assert save_to_db(temp_db, "gql_health_status", resp, cal_date="2026-06-01") == 0
+        assert _count(temp_db) == 0
+
+    def test_populated_node_is_stored(self, temp_db):
+        resp = {"data": {"healthStatusSummary": {"metrics": [{"type": "HRV", "status": "BALANCED", "value": 65}]}}}
+        assert save_to_db(temp_db, "gql_health_status", resp, cal_date="2026-06-01") == 1
+        row = temp_db.execute("SELECT calendar_date, raw_json FROM health_status").fetchone()
+        assert row[0] == "2026-06-01"
+        assert "HRV" in row[1]
+
+    def test_validation_error_response_writes_no_row(self, temp_db):
+        # The pre-fix failure mode: a FieldUndefined validation error (no data
+        # key) must not be stored.
+        resp = {
+            "errors": [
+                {
+                    "message": "Validation error of type FieldUndefined: Field 'overallStatus' ...",
+                    "extensions": {"classification": "ValidationError"},
+                }
+            ]
+        }
+        save_to_db(temp_db, "gql_health_status", resp, cal_date="2026-06-01")
+        assert _count(temp_db) == 0
+
+
+@pytest.mark.unit
+class TestUnwrapGqlData:
+    def test_error_only_response_unwraps_to_empty(self):
+        assert _unwrap_gql_data({"errors": [{"message": "boom"}]}) == []
+
+    def test_null_scalar_unwraps_to_empty(self):
+        assert _unwrap_gql_data({"data": {"healthStatusSummary": None}}) == []
+
+    def test_value_is_unwrapped(self):
+        assert _unwrap_gql_data({"data": {"scalar": [1, 2, 3]}}) == [1, 2, 3]


### PR DESCRIPTION
Closes #56.

## Problem

The `health_status` GraphQL query requests fields that no longer exist on `HealthStatusSummaryDTO` (`calendarDate`, `overallStatus`, `metricsMap`), so Garmin returns a `FieldUndefined` validation error **for every day**:

```json
{"errors":[{"message":"Validation error of type FieldUndefined: Field 'metricsMap' in type 'HealthStatusSummaryDTO' is undefined @ 'healthStatusSummary/metricsMap'","extensions":{"classification":"ValidationError"}}]}
```

Because `_unwrap_gql_data` doesn't discard error-only responses, that error object is then stored as a `health_status` row — so the table fills with one identical validation-error row per synced day instead of real data. (Garmin has disabled introspection — `__type { fields }` also errors — so the current fields were found by probing the live API.)

## Change

- Update the query to the current shape: `healthStatusSummary(calendarDate:"…"){ metrics { type status value } }`. This validates (HTTP 200) and returns a `null` node on days with no data, which the unwrapper drops — so nothing junk is written.
- Harden `_unwrap_gql_data` to discard GraphQL responses that carry `errors` and no `data`, so **no** endpoint persists a validation error as a row (the activities path was already guarded; this generalises it).

## Testing

- New `tests/test_health_status_query.py`: the query no longer references the removed fields and uses the `metrics` shape; null node writes no row; a populated node is stored; a validation-error response writes no row; `_unwrap_gql_data` drops error-only and null responses.
- Full suite green (164 passed); `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)