### PR TITLE
Skip empty placeholder days when storing daily data

### DIFF
--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -1529,6 +1529,10 @@ def upsert_running_dynamics(conn: sqlite3.Connection, aid: int, record: dict) ->
 
 
 def upsert_daily_summary(conn: sqlite3.Connection, record: dict) -> None:
+    # A daily summary is keyed by its date; without one the row is unqueryable
+    # junk (calendar_date NULL) and only pollutes the table. Skip it.
+    if not (record.get("calendarDate") or "").strip():
+        return
     conn.execute(
         """
         INSERT OR REPLACE INTO daily_summary (
@@ -3121,6 +3125,81 @@ def _extract_calories_records(data: Any, cal_date: str = None) -> list[dict]:
     return []
 
 
+# ── Empty-day filtering ──────────────────────────────────────────────────
+# Garmin returns a row for every queried day even when the device recorded
+# nothing: every measurement field comes back null while identifier, goal and
+# default fields stay populated (e.g. ``weekGoal``, ``goalInML``,
+# ``chronologicalAge``, and the ``netRemainingKilocalories: 0.0`` trap). Writing
+# these placeholder rows inflates the database — most visibly with years of
+# empty days from before the account existed. For each daily endpoint we list
+# the API fields that carry an actual measurement; a record is written only when
+# at least one of them holds real data. Endpoints absent from the map are never
+# filtered, so non-daily payloads (activities, sleep, profile, …) pass through
+# untouched.
+
+_DAILY_SIGNAL_FIELDS = {
+    "heart_rate": ("restingHeartRate", "minHeartRate", "maxHeartRate", "heartRateValues"),
+    "heart_rate_detail": ("restingHeartRate", "minHeartRate", "maxHeartRate", "heartRateValues"),
+    "stress": ("avgStressLevel", "maxStressLevel", "stressValuesArray"),
+    "spo2": ("averageSpO2", "lowestSpO2", "latestSpO2", "spo2ValuesArray"),
+    "respiration": (
+        "avgWakingRespirationValue",
+        "avgSleepRespirationValue",
+        "lowestRespirationValue",
+        "highestRespirationValue",
+        "respirationValuesArray",
+    ),
+    "floors": ("floorValuesArray",),
+    "intensity_minutes": ("moderateMinutes", "vigorousMinutes", "weeklyTotal", "imValuesArray"),
+    "intensity_minutes_weekly": ("moderateMinutes", "vigorousMinutes", "weeklyTotal", "imValuesArray"),
+    "hydration": ("valueInML", "sweatLossInML", "activityIntakeInML"),
+    "daily_movement": ("movementValues",),
+    "training_status_daily": ("latestTrainingStatusData",),
+    "training_status_weekly": ("latestTrainingStatusData",),
+    "training_status": ("latestTrainingStatusData",),
+}
+
+
+def _has_value(v) -> bool:
+    """A field counts as real data when it's a non-empty container or any
+    non-None scalar — ``0`` and ``False`` are genuine measurements, so only
+    ``None`` and empty list/dict/str are treated as absent."""
+    if v is None:
+        return False
+    if isinstance(v, (list, dict, str)):
+        return len(v) > 0
+    return True
+
+
+def _daily_record_has_data(name: str, rec) -> bool:
+    """Return True if a daily record carries real measurements, or if its
+    endpoint isn't a filterable daily one. False marks an all-null placeholder
+    day that should not be written."""
+    if not isinstance(rec, dict):
+        return True
+    if name == "daily_summary":
+        # Garmin's own flags are the only reliable signal: an empty day still
+        # carries identifiers and ``netRemainingKilocalories: 0.0``.
+        return bool(
+            rec.get("includesWellnessData") or rec.get("includesActivityData") or rec.get("includesCalorieConsumedData")
+        )
+    if name in ("body_battery_events", "body_battery_stress"):
+        # Time series nested under bodyBattery/stress with a constant "labels"
+        # list and a "data" list that is empty on void days.
+        bb = rec.get("bodyBattery") or {}
+        st = rec.get("stress") or {}
+        return bool(bb.get("data") or st.get("data"))
+    if name == "fitness_age":
+        # Empty days return every component flagged ``stale``; real data has at
+        # least one component that isn't.
+        comps = rec.get("components") or {}
+        return any(isinstance(c, dict) and not c.get("stale") for c in comps.values())
+    signals = _DAILY_SIGNAL_FIELDS.get(name)
+    if not signals:
+        return True
+    return any(_has_value(rec.get(f)) for f in signals)
+
+
 def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str = None) -> int:
     """Route fetched data to the correct table and upsert it.
 
@@ -3150,6 +3229,13 @@ def save_to_db(conn: sqlite3.Connection, endpoint_name: str, data, cal_date: str
         data = _unwrap_gql_data(data)
 
     records = _ensure_list(data)
+
+    # Drop placeholder rows for days Garmin has no recorded data for. Non-daily
+    # endpoints (and any record carrying real measurements) pass through.
+    records = [r for r in records if _daily_record_has_data(name, r)]
+    if not records:
+        return 0
+
     count = 0
 
     try:

--- a/tests/test_daily_summary_date_guard.py
+++ b/tests/test_daily_summary_date_guard.py
@@ -1,0 +1,46 @@
+"""Tests that daily_summary rows without a calendar date are not written.
+
+A daily summary is keyed by its date. A payload without one produces a row
+with ``calendar_date = NULL`` that can't be queried by date and only pollutes
+the table, so ``upsert_daily_summary`` must drop it.
+"""
+
+import pytest
+
+from garmin_mcp.db import save_to_db, upsert_daily_summary
+
+
+def _row_count(conn):
+    return conn.execute("SELECT COUNT(*) FROM daily_summary").fetchone()[0]
+
+
+def _null_date_count(conn):
+    return conn.execute("SELECT COUNT(*) FROM daily_summary WHERE calendar_date IS NULL").fetchone()[0]
+
+
+@pytest.mark.unit
+class TestDailySummaryDateGuard:
+    def test_missing_calendar_date_is_skipped(self, temp_db):
+        upsert_daily_summary(temp_db, {"totalSteps": 1000, "includesWellnessData": True})
+        assert _row_count(temp_db) == 0
+
+    def test_none_calendar_date_is_skipped(self, temp_db):
+        upsert_daily_summary(temp_db, {"calendarDate": None, "totalSteps": 1000})
+        assert _row_count(temp_db) == 0
+
+    def test_blank_calendar_date_is_skipped(self, temp_db):
+        upsert_daily_summary(temp_db, {"calendarDate": "   ", "totalSteps": 1000})
+        assert _row_count(temp_db) == 0
+
+    def test_valid_calendar_date_is_written(self, temp_db):
+        upsert_daily_summary(temp_db, {"calendarDate": "2025-06-01", "totalSteps": 1000})
+        assert _row_count(temp_db) == 1
+        assert _null_date_count(temp_db) == 0
+
+    def test_save_to_db_writes_no_null_date_row(self, temp_db):
+        # Real measurements but no date: passes the empty-day filter, then the
+        # date guard drops it — no NULL-date junk row lands in the table.
+        rec = {"includesWellnessData": True, "totalSteps": 1234}
+        save_to_db(temp_db, "daily_summary", [rec])
+        assert _null_date_count(temp_db) == 0
+        assert _row_count(temp_db) == 0

--- a/tests/test_empty_day_filter.py
+++ b/tests/test_empty_day_filter.py
@@ -1,0 +1,224 @@
+"""Tests for empty-day filtering in save_to_db.
+
+Garmin returns a row for every queried day even when the device recorded
+nothing — every measurement field comes back null while identifier, goal and
+default fields stay populated. These placeholder rows (most visibly years of
+empty days from before the account existed) must not be written. The payloads
+below mirror real Garmin API responses for an empty (void) day versus a day
+with data, including the traps that defeat a naive "any non-null field" check:
+
+* daily_summary always returns ``netRemainingKilocalories: 0.0``
+* intensity_minutes always returns ``weekGoal: 150``
+* hydration always returns ``goalInML``/``baseGoalInML``
+
+so ``0`` must count as real data while a goal/default must not.
+"""
+
+import pytest
+
+from garmin_mcp.db import _daily_record_has_data, save_to_db
+
+# ── Sample API payloads ───────────────────────────────────────────────────
+
+EMPTY_DAILY_SUMMARY = {
+    "calendarDate": "2020-06-15",
+    "source": "GARMIN",
+    "totalSteps": None,
+    "totalKilocalories": None,
+    "restingHeartRate": None,
+    "netRemainingKilocalories": 0.0,  # trap: non-null even on void days
+    "includesWellnessData": False,
+    "includesActivityData": False,
+    "includesCalorieConsumedData": False,
+}
+
+REAL_DAILY_SUMMARY = {
+    "calendarDate": "2025-06-01",
+    "source": "GARMIN",
+    "totalSteps": 5738,
+    "totalKilocalories": 1703.0,
+    "restingHeartRate": 52,
+    "includesWellnessData": True,
+    "includesActivityData": False,
+    "includesCalorieConsumedData": False,
+}
+
+# A real day on which the wearer happened to take zero steps. 0 is a genuine
+# measurement and the day must be kept.
+REAL_ZERO_STEP_DAILY_SUMMARY = {
+    "calendarDate": "2025-11-24",
+    "totalSteps": 0,
+    "totalKilocalories": 1694.0,
+    "includesWellnessData": True,
+}
+
+EMPTY_PAYLOADS = {
+    "heart_rate": {
+        "calendarDate": "2020-06-15",
+        "maxHeartRate": None,
+        "minHeartRate": None,
+        "restingHeartRate": None,
+        "heartRateValues": None,
+    },
+    "stress": {"calendarDate": "2020-06-15", "maxStressLevel": None, "avgStressLevel": None, "stressValuesArray": []},
+    "spo2": {"calendarDate": "2020-06-15", "averageSpO2": None, "lowestSpO2": None, "spo2ValuesArray": []},
+    "respiration": {
+        "calendarDate": "2020-06-15",
+        "avgWakingRespirationValue": None,
+        "lowestRespirationValue": None,
+        "highestRespirationValue": None,
+        "respirationValuesArray": None,
+    },
+    "floors": {"floorValuesArray": [], "startTimestampGMT": None},
+    "intensity_minutes": {
+        "calendarDate": "2020-06-15",
+        "moderateMinutes": None,
+        "vigorousMinutes": None,
+        "weeklyTotal": None,
+        "weekGoal": 150,
+    },  # weekGoal is a trap
+    "hydration": {
+        "calendarDate": "2020-06-15",
+        "valueInML": None,
+        "sweatLossInML": None,
+        "activityIntakeInML": None,
+        "goalInML": 2800.0,
+        "baseGoalInML": 2800.0,
+    },  # goals are traps
+    "daily_movement": {"calendarDate": "2020-06-15", "movementValues": [], "movementValueDescriptors": []},
+    "training_status": {"userId": None, "latestTrainingStatusData": None},
+    "fitness_age": {"chronologicalAge": 25, "components": {"rhr": {"stale": True}, "bmi": {"stale": True}}},
+    "body_battery_events": {
+        "bodyBattery": {"labels": ["timestampGmt", "value"], "data": []},
+        "stress": {"labels": ["timestampGmt", "value"], "data": []},
+    },
+}
+
+REAL_PAYLOADS = {
+    "heart_rate": {"calendarDate": "2025-06-01", "maxHeartRate": 142, "minHeartRate": 48, "restingHeartRate": 52},
+    "stress": {"calendarDate": "2025-06-01", "maxStressLevel": 88, "avgStressLevel": 30},
+    "spo2": {"calendarDate": "2025-06-01", "averageSpO2": 96, "lowestSpO2": 91},
+    "respiration": {"calendarDate": "2025-06-01", "avgWakingRespirationValue": 14.0, "lowestRespirationValue": 11.0},
+    "floors": {"floorValuesArray": [[0, 1700000000000, 3]], "startTimestampGMT": "2025-06-01T16:00:00.0"},
+    "intensity_minutes": {
+        "calendarDate": "2025-06-01",
+        "moderateMinutes": 30,
+        "vigorousMinutes": 0,
+        "weeklyTotal": 120,
+        "weekGoal": 150,
+    },
+    "hydration": {
+        "calendarDate": "2025-05-04",
+        "valueInML": 0.0,
+        "sweatLossInML": 2147.0,
+        "activityIntakeInML": 0.0,
+        "goalInML": 4947.0,
+    },
+    "daily_movement": {"calendarDate": "2025-06-01", "movementValues": [[0, 12], [1, 30]]},
+    "training_status": {"userId": 1, "latestTrainingStatusData": {"123": {"trainingStatus": 3}}},
+    "fitness_age": {"chronologicalAge": 25, "components": {"rhr": {"stale": False, "value": 52}}},
+    "body_battery_events": {
+        "bodyBattery": {"labels": ["timestampGmt", "value"], "data": [[1700000000000, 55]]},
+        "stress": {"labels": [], "data": []},
+    },
+}
+
+
+# ── _daily_record_has_data ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDailyRecordHasData:
+    def test_empty_daily_summary_has_no_data(self):
+        assert _daily_record_has_data("daily_summary", EMPTY_DAILY_SUMMARY) is False
+
+    def test_real_daily_summary_has_data(self):
+        assert _daily_record_has_data("daily_summary", REAL_DAILY_SUMMARY) is True
+
+    def test_zero_step_day_is_real_data(self):
+        # 0 is a genuine measurement — the includes flag confirms a tracked day.
+        assert _daily_record_has_data("daily_summary", REAL_ZERO_STEP_DAILY_SUMMARY) is True
+
+    def test_net_remaining_calories_is_not_a_signal(self):
+        # netRemainingKilocalories: 0.0 must not by itself keep a void day.
+        rec = {
+            "calendarDate": "2020-01-01",
+            "netRemainingKilocalories": 0.0,
+            "includesWellnessData": False,
+            "includesActivityData": False,
+            "includesCalorieConsumedData": False,
+        }
+        assert _daily_record_has_data("daily_summary", rec) is False
+
+    @pytest.mark.parametrize("name", sorted(EMPTY_PAYLOADS))
+    def test_empty_payloads_have_no_data(self, name):
+        assert _daily_record_has_data(name, EMPTY_PAYLOADS[name]) is False
+
+    @pytest.mark.parametrize("name", sorted(REAL_PAYLOADS))
+    def test_real_payloads_have_data(self, name):
+        assert _daily_record_has_data(name, REAL_PAYLOADS[name]) is True
+
+    def test_goal_default_does_not_count_as_data(self):
+        # intensity_minutes always carries weekGoal=150; hydration carries goals.
+        assert _daily_record_has_data("intensity_minutes", EMPTY_PAYLOADS["intensity_minutes"]) is False
+        assert _daily_record_has_data("hydration", EMPTY_PAYLOADS["hydration"]) is False
+
+    def test_unmapped_endpoint_is_never_filtered(self):
+        # Non-daily endpoints (sleep, activities, profile, …) pass through.
+        assert _daily_record_has_data("sleep", {"anything": None}) is True
+        assert _daily_record_has_data("activities", {}) is True
+
+    def test_non_dict_record_passes_through(self):
+        assert _daily_record_has_data("heart_rate", None) is True
+        assert _daily_record_has_data("heart_rate", [1, 2, 3]) is True
+
+
+# ── save_to_db end-to-end ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSaveToDbFiltersEmptyDays:
+    def _daily_summary_rows(self, conn):
+        return conn.execute("SELECT COUNT(*) FROM daily_summary").fetchone()[0]
+
+    def test_empty_daily_summary_writes_no_row(self, temp_db):
+        assert save_to_db(temp_db, "daily_summary", [EMPTY_DAILY_SUMMARY]) == 0
+        assert self._daily_summary_rows(temp_db) == 0
+
+    def test_real_daily_summary_writes_one_row(self, temp_db):
+        assert save_to_db(temp_db, "daily_summary", [REAL_DAILY_SUMMARY]) == 1
+        assert self._daily_summary_rows(temp_db) == 1
+
+    def test_mixed_batch_keeps_only_real_days(self, temp_db):
+        batch = [EMPTY_DAILY_SUMMARY, REAL_DAILY_SUMMARY, REAL_ZERO_STEP_DAILY_SUMMARY]
+        assert save_to_db(temp_db, "daily_summary", batch) == 2
+        assert self._daily_summary_rows(temp_db) == 2
+
+    @pytest.mark.parametrize(
+        "name,table",
+        [
+            ("heart_rate", "heart_rate"),
+            ("stress", "stress"),
+            ("spo2", "spo2"),
+            ("respiration", "respiration"),
+            ("intensity_minutes", "intensity_minutes"),
+        ],
+    )
+    def test_empty_day_writes_no_row(self, temp_db, name, table):
+        assert save_to_db(temp_db, name, [EMPTY_PAYLOADS[name]], cal_date="2020-06-15") == 0
+        assert temp_db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+
+    @pytest.mark.parametrize(
+        "name,table",
+        [
+            ("heart_rate", "heart_rate"),
+            ("stress", "stress"),
+            ("spo2", "spo2"),
+            ("respiration", "respiration"),
+            ("intensity_minutes", "intensity_minutes"),
+        ],
+    )
+    def test_real_day_writes_one_row(self, temp_db, name, table):
+        cal = REAL_PAYLOADS[name].get("calendarDate", "2025-06-01")
+        assert save_to_db(temp_db, name, [REAL_PAYLOADS[name]], cal_date=cal) == 1
+        assert temp_db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 1


### PR DESCRIPTION
Closes #57.

## Problem

The historical window is a hard-coded 10 years, but Garmin returns a row for **every** queried day — including years before the account existed — with all measurement fields `null`. `save_to_db` writes these verbatim, so `daily_summary` and every per-day table fill with empty placeholder rows. For an account created in late 2023, a full sync produces ~2,700 empty `daily_summary` rows out of ~3,660 (only ~950 are real), and row counts become meaningless. (Same phenomenon a user observed in #13 — "3651 empty body_battery_events files".)

## Change

- `save_to_db` drops all-null daily records:
  - `daily_summary` uses Garmin's own `includes{Wellness,Activity,CalorieConsumed}Data` flags — the only reliable signal, since an empty day still carries identifiers and `netRemainingKilocalories: 0.0`.
  - Other daily endpoints (`heart_rate`, `stress`, `spo2`, `respiration`, `floors`, `intensity_minutes`, `hydration`, `daily_movement`, `body_battery_events`, `fitness_age`, `training_status`) use a per-endpoint signal-field check.
  - `0` counts as a real measurement (a genuine 0-step day is kept); goals/defaults (`weekGoal`, `goalInML`, …) do not. Non-daily endpoints (activities, sleep, profile) are never filtered.
- Drop `daily_summary` records that arrive without a `calendarDate` — they were stored as unqueryable `calendar_date NULL` rows.

Scope is deliberately limited to *not storing* empty rows. The fetch still walks the full window; an optional early-stop once a year returns no data could be a follow-up.

## Testing

- `tests/test_empty_day_filter.py`: `_daily_record_has_data` across endpoints (incl. the `netRemainingKilocalories: 0.0`, `weekGoal`, `goalInML` traps and a real 0-step day), plus `save_to_db` writing 0 rows for empty days and 1 for real days.
- `tests/test_daily_summary_date_guard.py`: missing/null/blank `calendarDate` is skipped; a valid one is written.
- Full suite green (203 passed); `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)