### PR TITLE
fix: load export credentials from the data dir, not the package

### DIFF
--- a/garmin_mcp/export.py
+++ b/garmin_mcp/export.py
@@ -421,16 +421,14 @@ def download_activity_files(
 
     from garmin_client import GarminClient
 
-    project_dir = Path(__file__).parent.parent
-    profile_dir = project_dir / "browser_profile"
+    # Resolve credentials and browser profile from the real data directory
+    # (GARMIN_DATA_DIR / cwd / ~/.garmin-givemydata), not the installed package
+    # location. Reuses the main module's data-dir logic so pip/pipx/brew installs
+    # find the .env that lives next to the database. See issue #53.
+    from garmin_givemydata import PROFILE_DIR, load_env
 
-    env_file = project_dir / ".env"
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                key, _, value = line.partition("=")
-                os.environ.setdefault(key.strip(), value.strip())
+    load_env()
+    profile_dir = PROFILE_DIR
 
     email = os.environ.get("GARMIN_EMAIL", "")
     password = os.environ.get("GARMIN_PASSWORD", "")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,12 +1,14 @@
 """Regression tests for garmin_mcp.export."""
 
 import json
+import os
 import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import garmin_givemydata
 from garmin_mcp import export
 
 
@@ -76,6 +78,49 @@ class TestExportJsonTables(unittest.TestCase):
             self.assertEqual(payload[0]["__activity_id"], 12345)
             self.assertEqual(payload[0]["__avg_hr"], 135)
             self.assertNotIn("items", payload[0])
+
+
+class TestExportCredentialResolution(unittest.TestCase):
+    """Regression for issue #53: ``--export-gpx`` resolved ``.env`` relative to
+    the installed package (``Path(__file__).parent.parent``) instead of the data
+    directory, so pip/pipx/brew installs printed "Credentials not found" because
+    no ``.env`` sits next to the package. The download path must load credentials
+    via the main module's ``load_env()`` (which reads ``DATA_DIR/.env``)."""
+
+    def test_credentials_loaded_via_data_dir_load_env(self):
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, email=None, password=None, profile_dir=None, **kwargs):
+                captured["email"] = email
+                captured["profile_dir"] = profile_dir
+
+            def login(self):
+                return False  # stop before any network/browser
+
+            def close(self):
+                pass
+
+        def fake_load_env():
+            # Simulates load_env() reading DATA_DIR/.env into the environment.
+            os.environ["GARMIN_EMAIL"] = "datadir@example.com"
+            os.environ["GARMIN_PASSWORD"] = "from-data-dir"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "gpx"
+            with (
+                patch("garmin_client.GarminClient", FakeClient),
+                patch.object(garmin_givemydata, "load_env", fake_load_env),
+            ):
+                os.environ.pop("GARMIN_EMAIL", None)
+                os.environ.pop("GARMIN_PASSWORD", None)
+                # activity_ids given explicitly so no DB lookup is needed.
+                export.download_activity_files(out, file_format="gpx", activity_ids=[123])
+
+        # Credentials must have come from the data-dir loader, proving the path
+        # resolution bug is fixed (otherwise email would be "" -> early return).
+        self.assertEqual(captured.get("email"), "datadir@example.com")
+        self.assertEqual(captured.get("profile_dir"), garmin_givemydata.PROFILE_DIR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #53.

## Problem
`--export-gpx` (and `--export-tcx`) print **"Credentials not found. Run ./setup.sh first."** on pip/pipx/brew installs even when the user has a valid `.env`. `download_activity_files` resolved `.env` and the browser profile relative to the installed package (`Path(__file__).parent.parent` = site-packages), instead of the real data directory where `.env` lives. The main fetch path already does this correctly via `_get_data_dir()`/`load_env()`; only the export path reimplemented it against the wrong directory.

## Fix
`download_activity_files` now loads credentials via the main module's `load_env()` and uses `PROFILE_DIR`, both derived from `DATA_DIR` (`GARMIN_DATA_DIR` → cwd → `~/.garmin-givemydata`). One source of truth for credential/profile resolution.

## Verification
- Added a regression test (`tests/test_export.py::TestExportCredentialResolution`) asserting credentials are loaded via the data-dir `load_env()`.
- Reproduced the original failure and the fix in a pipx-style layout (package in an isolated path with no `.env`, data dir holding `.env`+`garmin.db`): before → "Credentials not found"; after → credentials resolved from the data dir and the download proceeds to login.
- Full suite green (218 tests), ruff check + format clean.