### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "garmin-givemydata"
-version = "0.1.12"
+version = "0.1.13"
 description = "Get your Garmin Connect data back. Browser-based extraction + 48-table SQLite database + MCP server for AI analysis."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release 0.1.13.

Since 0.1.12:
- fix: repair stale health_status GraphQL query (#60, closes #56)
- fix: skip empty placeholder days when storing daily data (#61, closes #57)
- fix: backfill trackpoints from FIT files already on disk (#59, closes #58)
- fix: load export credentials from the data dir, not the package (#63, closes #53)
- feat: capture Garmin Connect+ nutrition — daily totals + per-food log (#52, closes #51)
- ci: bump codecov/codecov-action from 6 to 7 (#62)