### PR TITLE
Cap the mcp SDK below 2.0 so the MCP server starts on a fresh install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "seleniumbase>=4.30",
     "httpx>=0.25",
-    "mcp[cli]>=1.0",
+    "mcp[cli]>=1.0,<2",
     "python-dotenv>=1.0",
     "fitparse>=1.2.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 seleniumbase>=4.30
 httpx>=0.25
-mcp[cli]>=1.0
+mcp[cli]>=1.0,<2
 fitparse>=1.2.0


### PR DESCRIPTION
`mcp` 2.0.0 removed `mcp.server.fastmcp`, which `garmin_mcp/server.py` imports — so `garmin-mcp` crashed on startup on every fresh install. Capped the dependency at `<2`; verified with `mcp` 1.29.0.

Closes #72