### PR TITLE
Lower the context cost of the MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The MCP server gives AI assistants deep access to your health data. Every tool r
 | Tool | What It Does |
 |------|-------------|
 | `garmin_sync` | Check data freshness and pull latest data from Garmin — always shows when the last sync happened. Use `refresh=False` to just check status |
-| `garmin_schema` | Show all 50 tables, columns, and row counts |
+| `garmin_schema` | Row counts for all 50 tables; pass `tables="sleep,stress"` for their columns |
 | `garmin_query` | Run any read-only SELECT query (read-only enforced at the SQLite engine level) |
 
 </details>

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -27,26 +27,48 @@ _conn.close()
 
 
 @mcp.tool()
-def garmin_schema() -> str:
-    """Show all tables, their columns, and row counts."""
+def garmin_schema(tables: str = "") -> str:
+    """Show table columns and row counts.
+
+    Called without *tables*, returns a compact index: row count per non-empty
+    table, plus the names of the empty ones — no column lists.  Pass a
+    comma-separated list of table names (e.g. "sleep,stress") to get the
+    columns of just those tables.
+    """
     conn = get_connection()
     try:
-        tables = query(
-            conn,
-            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
-        )
-        result = {}
-        for t in tables:
-            table_name = t["name"]
-            if not table_name.isidentifier():
-                continue
-            cols = query(conn, f"PRAGMA table_info([{table_name}])")
-            row_count = query(conn, f"SELECT COUNT(*) AS cnt FROM [{table_name}]")[0]["cnt"]
-            result[table_name] = {
-                "columns": [c["name"] for c in cols],
-                "row_count": row_count,
+        names = [
+            t["name"]
+            for t in query(conn, "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            if t["name"].isidentifier()
+        ]
+        wanted = [t.strip() for t in tables.split(",") if t.strip()]
+
+        if not wanted:
+            counts = {
+                n: query(conn, f"SELECT COUNT(*) AS cnt FROM [{n}]")[0]["cnt"] for n in names
             }
-        return json.dumps(result, indent=2)
+            return json.dumps(
+                {
+                    "tables": {n: c for n, c in counts.items() if c},
+                    "empty_tables": [n for n, c in counts.items() if not c],
+                    "hint": 'call garmin_schema("sleep,stress") for the columns of specific tables',
+                },
+                separators=(",", ":"),
+            )
+
+        unknown = [t for t in wanted if t not in names]
+        if unknown:
+            return json.dumps({"error": "unknown tables", "unknown": unknown, "available": names})
+
+        result = {}
+        for name in wanted:
+            cols = query(conn, f"PRAGMA table_info([{name}])")
+            result[name] = {
+                "columns": [c["name"] for c in cols],
+                "row_count": query(conn, f"SELECT COUNT(*) AS cnt FROM [{name}]")[0]["cnt"],
+            }
+        return json.dumps(result, separators=(",", ":"))
     finally:
         conn.close()
 

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -89,7 +89,7 @@ def garmin_query(sql: str, limit: int = 1000) -> str:
     try:
         clamped = max(1, min(limit, 10000))
         rows = query_readonly(sql, limit=clamped)
-        return json.dumps(rows, indent=2, default=str)
+        return json.dumps(rows, separators=(",", ":"), default=str)
     except Exception as exc:
         log.exception("garmin_query failed")
         return json.dumps({"error": "Query failed. Check that your SQL is a valid SELECT statement."})
@@ -214,7 +214,7 @@ def garmin_health_summary(start_date: str = "", end_date: str = "", days: int = 
             "hill_score": hill_rows[0] if hill_rows else {},
             "race_predictions": race_rows[0] if race_rows else {},
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -274,7 +274,7 @@ def garmin_activities(
     conn = get_connection()
     try:
         rows = query(conn, sql, params)
-        return json.dumps(rows, indent=2, default=str)
+        return json.dumps(rows, separators=(",", ":"), default=str)
     except Exception as exc:
         return json.dumps({"error": str(exc)})
     finally:
@@ -427,7 +427,7 @@ def garmin_trends(metric: str, period: str = "month") -> str:
     conn = get_connection()
     try:
         rows = query(conn, sql)
-        return json.dumps({"metric": metric, "period": period, "data": rows}, indent=2, default=str)
+        return json.dumps({"metric": metric, "period": period, "data": rows}, separators=(",", ":"), default=str)
     except Exception as exc:
         return json.dumps({"error": str(exc)})
     finally:
@@ -605,10 +605,10 @@ def garmin_sync(refresh: bool = True) -> str:
     if not refresh:
         if status["is_stale"] and not _sync_state["running"]:
             status["hint"] = "Data is not current. Call garmin_sync() to refresh."
-        return json.dumps(status, indent=2, default=str)
+        return json.dumps(status, separators=(",", ":"), default=str)
 
     status["sync"] = _start_background_sync()
-    return json.dumps(status, indent=2, default=str)
+    return json.dumps(status, separators=(",", ":"), default=str)
 
 
 # ---------------------------------------------------------------------------
@@ -709,7 +709,7 @@ def garmin_today() -> str:
             "fitness_age": fitness[0] if fitness else {},
             "last_activity": last_activity[0] if last_activity else {},
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -842,7 +842,7 @@ def garmin_activity_detail(activity_id: int = 0, last: bool = False) -> str:
             else [],
             "running_dynamics": dynamics[0] if dynamics else {},
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -882,7 +882,7 @@ def garmin_activity_trackpoints(activity_id: int, limit: int = 500, offset: int 
                     "'garmin-givemydata --rebuild-trackpoints' to backfill from FIT files, "
                     "or 'garmin-givemydata' (which now parses trackpoints by default).",
                 },
-                indent=2,
+                separators=(",", ":"),
             )
 
         points = query(
@@ -904,7 +904,7 @@ def garmin_activity_trackpoints(activity_id: int, limit: int = 500, offset: int 
                 "offset": offset,
                 "trackpoints": points,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -966,7 +966,7 @@ def garmin_sleep(start_date: str = "", days: int = 7) -> str:
                ORDER BY calendar_date""",
             [start_date, end_date],
         )
-        return json.dumps({"period": {"start": start_date, "end": end_date}, "nights": rows}, indent=2, default=str)
+        return json.dumps({"period": {"start": start_date, "end": end_date}, "nights": rows}, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1089,7 +1089,7 @@ def garmin_training_load() -> str:
             "weekly_volume_12w": weekly,
             "load_by_sport": by_sport,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1184,7 +1184,7 @@ def garmin_compare(
                 pct = round((diff / v1) * 100, 1) if v1 != 0 else None
                 deltas[key] = {"period1": v1, "period2": v2, "delta": diff, "pct_change": pct}
 
-        return json.dumps({"period1": p1, "period2": p2, "changes": deltas}, indent=2, default=str)
+        return json.dumps({"period1": p1, "period2": p2, "changes": deltas}, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1240,7 +1240,7 @@ def garmin_records() -> str:
             code = str(r.get("pr_type", ""))
             r["record_name"] = pr_names.get(code, f"Type {code}")
 
-        return json.dumps(rows, indent=2, default=str)
+        return json.dumps(rows, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1295,7 +1295,7 @@ def garmin_fitness_age(period: str = "month") -> str:
             },
             "timeline": rows,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1374,7 +1374,7 @@ def garmin_hrv(days: int = 30) -> str:
             "trend": {"direction": trend, "pct_change_7d": trend_pct},
             "daily": rows,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1435,7 +1435,7 @@ def garmin_body_battery(days: int = 14) -> str:
             },
             "daily": rows,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1484,7 +1484,7 @@ def garmin_stress(days: int = 14) -> str:
             },
             "daily": rows,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1565,7 +1565,7 @@ def garmin_heart_rate(days: int = 30) -> str:
             },
             "daily": output,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1618,7 +1618,7 @@ def garmin_spo2(days: int = 14) -> str:
             },
             "daily": rows,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1658,7 +1658,7 @@ def garmin_body_composition() -> str:
             "total_entries": len(rows),
             "history": rows,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1679,7 +1679,7 @@ def garmin_devices() -> str:
                       last_sync, software_version, battery_status, battery_voltage
                FROM device ORDER BY last_sync DESC""",
         )
-        return json.dumps(rows, indent=2, default=str)
+        return json.dumps(rows, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1753,7 +1753,7 @@ def garmin_week_summary() -> str:
             "activities_this_week": activities,
             "daily": days,
         }
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -1850,7 +1850,7 @@ def garmin_recovery(days_after: int = 3) -> str:
                 "recovery_by_sport": sport_summary,
                 "sessions": results,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -1906,7 +1906,7 @@ def garmin_training_status(days: int = 90) -> str:
                 "transitions": transitions[-10:],
                 "daily": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -1953,7 +1953,7 @@ def garmin_workouts() -> str:
                 "scheduled": schedule,
                 "training_plans": plans,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -1995,7 +1995,7 @@ def garmin_badges() -> str:
                 "badges": rows,
                 "by_category": {k: len(v) for k, v in by_category.items()},
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2041,7 +2041,7 @@ def garmin_hydration(days: int = 30) -> str:
                 "data": rows if tracked else [],
                 "note": "No hydration data logged" if not tracked else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2086,7 +2086,7 @@ def garmin_respiration(days: int = 14) -> str:
                 },
                 "daily": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2128,7 +2128,7 @@ def garmin_intensity_minutes(days: int = 30) -> str:
                 "who_target": "150 min/week (moderate) or 75 min/week (vigorous)",
                 "weekly": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2173,7 +2173,7 @@ def garmin_floors(days: int = 14) -> str:
                 },
                 "daily": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2234,7 +2234,7 @@ def garmin_steps(days: int = 14) -> str:
                 },
                 "daily": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2291,7 +2291,7 @@ def garmin_calories(days: int = 14) -> str:
                 "daily": rows,
                 "food_log": consumed if consumed else [],
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2333,7 +2333,7 @@ def garmin_blood_pressure(days: int = 90) -> str:
                 "data": rows,
                 "note": "No blood pressure data recorded" if not rows else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2361,7 +2361,7 @@ def garmin_goals() -> str:
                 "goals": rows,
                 "note": "No goals set" if not rows else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2389,7 +2389,7 @@ def garmin_challenges() -> str:
                 "challenges": rows,
                 "note": "No challenges found" if not rows else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2413,7 +2413,7 @@ def garmin_user_profile() -> str:
                 result[r["key"]] = json.loads(r["raw_json"]) if r["raw_json"] else None
             except (json.JSONDecodeError, TypeError):
                 result[r["key"]] = r["raw_json"]
-        return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -2480,7 +2480,7 @@ def garmin_race_predictions(days: int = 30) -> str:
                 "trend": {"direction": trend, "5k_delta_sec": round(delta)},
                 "daily": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2522,7 +2522,7 @@ def garmin_endurance_score(days: int = 30) -> str:
                 "trend": trend,
                 "daily": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2555,7 +2555,7 @@ def garmin_hill_score(days: int = 30) -> str:
                 "latest": rows[-1] if rows else {},
                 "daily": rows,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2601,7 +2601,7 @@ def garmin_vo2max() -> str:
                 "from_activities": vo2_activities,
                 "note": "No VO2max data" if not vo2_table and not vo2_activities else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2652,7 +2652,7 @@ def garmin_health_snapshot() -> str:
                 "snapshots": parsed,
                 "note": "No health snapshots taken" if not parsed else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2683,7 +2683,7 @@ def garmin_gear() -> str:
                 "gear": rows,
                 "note": "No gear tracked" if not rows else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2730,7 +2730,7 @@ def garmin_daily_events(days: int = 7) -> str:
                     entry["events"] = r["raw_json"]
             parsed.append(entry)
 
-        return json.dumps(parsed, indent=2, default=str)
+        return json.dumps(parsed, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -2751,7 +2751,7 @@ def garmin_activity_types() -> str:
                FROM activity_types
                ORDER BY type_key""",
         )
-        return json.dumps(rows, indent=2, default=str)
+        return json.dumps(rows, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -2776,7 +2776,7 @@ def garmin_hr_zones() -> str:
                 except (json.JSONDecodeError, TypeError):
                     entry["zones"] = r["raw_json"]
             parsed.append(entry)
-        return json.dumps(parsed, indent=2, default=str)
+        return json.dumps(parsed, separators=(",", ":"), default=str)
     finally:
         conn.close()
 
@@ -2811,7 +2811,7 @@ def garmin_load_focus(days: int = 28) -> str:
                 "daily": rows,
                 "note": "No load focus data" if not rows else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2845,7 +2845,7 @@ def garmin_lactate_threshold() -> str:
                 "history": rows,
                 "note": "No lactate threshold data" if not rows else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:
@@ -2882,7 +2882,7 @@ def garmin_wellness_activity(days: int = 30) -> str:
                 "sessions": rows,
                 "note": "No wellness activity data" if not rows else None,
             },
-            indent=2,
+            separators=(",", ":"),
             default=str,
         )
     finally:

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -25,26 +25,26 @@ _conn.close()
 # garmin_schema
 # ---------------------------------------------------------------------------
 
-# Shape of the intraday arrays buried in raw_json, per table.  Garmin is not
-# consistent here — some feeds timestamp their samples as epoch milliseconds
-# (GMT) and others as local ISO text — so querying one like the other silently
-# produces garbage instead of an error.  Surfaced when the table is asked for
-# by name, i.e. right before its raw_json gets queried.
-_RAW_JSON_SHAPES = {
-    "body_battery": {
-        "$.bodyBattery.data": "[iso_local, level, ?, status]",
-        "$.stress.data": "[iso_local, stress]",
-    },
-    "daily_movement": {"$.movementValues": "[epoch_ms, intensity]"},
-    "floors": {"$.floorValuesArray": "[iso_local_start, iso_local_end, ascended, descended]"},
-    "heart_rate": {"$.heartRateValues": "[epoch_ms, bpm]"},
-    "hrv_timeline": {"$.hrvReadings": "{hrvValue, readingTimeGMT, readingTimeLocal}"},
-    "respiration": {"$.respirationValuesArray": "[epoch_ms, breaths_per_min]"},
-    "spo2": {"$.spo2ValuesArray": "[epoch_ms, spo2, ?]"},
-    "stress": {
-        "$.stressValuesArray": "[epoch_ms, stress]",
-        "$.bodyBatteryValuesArray": "[epoch_ms, level, ?, status]",
-    },
+# The intraday samples live inside raw_json, and Garmin is not consistent about
+# them: some feeds timestamp each sample as epoch milliseconds (GMT), others as
+# local ISO text.  Reading one like the other produces plausible garbage instead
+# of an error, so the shape is read back from a stored row rather than kept in a
+# list here that would silently go stale when the upstream format changes.
+_TS_EPOCH_MS = "epoch_ms"
+_TS_ISO_LOCAL = "iso_local"
+
+# What the non-timestamp positions of each tuple mean — the one thing that
+# cannot be inferred from the data itself.  Applied in order, timestamps skipped.
+_RAW_JSON_FIELDS = {
+    "$.bodyBattery.data": ["level", "?", "status"],
+    "$.bodyBatteryValuesArray": ["level", "?", "status"],
+    "$.floorValuesArray": ["ascended", "descended"],
+    "$.heartRateValues": ["bpm"],
+    "$.movementValues": ["intensity"],
+    "$.respirationValuesArray": ["breaths_per_min"],
+    "$.spo2ValuesArray": ["spo2", "?"],
+    "$.stress.data": ["stress"],
+    "$.stressValuesArray": ["stress"],
 }
 
 _EPOCH_MS_HINT = (
@@ -52,11 +52,80 @@ _EPOCH_MS_HINT = (
     "in seconds for local time. iso_local is already local text — never mix the two."
 )
 
-# Sentinels that look like readings but are not; averaging over them skews the result.
+# Sentinels that look like readings but are not; averaging over them skews the
+# result.  Detecting these would mean scanning every row, so they stay declared.
 _RAW_JSON_SENTINELS = {
     "stress": "stress < 0 means no reading (-1 unmeasurable, -2 off-wrist); filter them out",
     "respiration": "value < 0 means no reading (-1 unmeasurable, -2 off-wrist); filter them out",
 }
+
+# How many samples to look through for a non-null value per tuple position: the
+# first sample of a night often carries nulls where later ones carry readings.
+_SHAPE_SAMPLE_SIZE = 20
+
+
+def _classify(value):
+    """Name a tuple position by what it holds, timestamps first."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)) and value > 1e11:  # ms since epoch, not a reading
+        return _TS_EPOCH_MS
+    if isinstance(value, str) and value[:2] == "20":
+        return _TS_ISO_LOCAL
+    return type(value).__name__
+
+
+def _describe_raw_json(conn, table):
+    """Read the shape of *table*'s intraday arrays back from a stored row."""
+    cols = [c["name"] for c in query(conn, f"PRAGMA table_info([{table}])")]
+    if "raw_json" not in cols:
+        return {}
+    rows = query(conn, f"SELECT raw_json FROM [{table}] WHERE raw_json IS NOT NULL LIMIT 1")
+    if not rows:
+        return {}
+    try:
+        payload = json.loads(rows[0]["raw_json"])
+    except (TypeError, ValueError):
+        return {}
+
+    shapes = {}
+
+    def visit(node, path):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                visit(value, f"{path}.{key}")
+            return
+        if not isinstance(node, list) or len(node) <= 5:
+            return
+        head = node[0]
+        if isinstance(head, dict):
+            shapes[f"$.{path.lstrip('.')}"] = "{" + ", ".join(sorted(head)) + "}"
+        elif isinstance(head, list) and head:
+            shapes[f"$.{path.lstrip('.')}"] = _describe_tuple(node, f"$.{path.lstrip('.')}")
+
+    visit(payload, "")
+    return shapes
+
+
+def _describe_tuple(samples, path):
+    """Label each position of a [ts, value, ...] tuple."""
+    kinds = []
+    for i in range(len(samples[0])):
+        # A position may be null in the first sample but hold a reading later on.
+        kind = next(
+            (k for k in (_classify(s[i]) for s in samples[:_SHAPE_SAMPLE_SIZE] if i < len(s)) if k),
+            "null",
+        )
+        kinds.append(kind)
+
+    labels = list(_RAW_JSON_FIELDS.get(path, []))
+    described = []
+    for kind in kinds:
+        if kind in (_TS_EPOCH_MS, _TS_ISO_LOCAL):
+            described.append(kind)
+        else:
+            described.append(labels.pop(0) if labels else kind)
+    return "[" + ", ".join(described) + "]"
 
 
 @mcp.tool()
@@ -103,12 +172,17 @@ def garmin_schema(tables: str = "") -> str:
                 "columns": [c["name"] for c in cols],
                 "row_count": query(conn, f"SELECT COUNT(*) AS cnt FROM [{name}]")[0]["cnt"],
             }
-            if name in _RAW_JSON_SHAPES:
-                result["tables"][name]["raw_json"] = _RAW_JSON_SHAPES[name]
+            shapes = _describe_raw_json(conn, name)
+            if shapes:
+                result["tables"][name]["raw_json"] = shapes
             if name in _RAW_JSON_SENTINELS:
                 result["tables"][name]["caveat"] = _RAW_JSON_SENTINELS[name]
 
-        if any("epoch_ms" in s for n in wanted for s in _RAW_JSON_SHAPES.get(n, {}).values()):
+        if any(
+            _TS_EPOCH_MS in shape
+            for table in result["tables"].values()
+            for shape in table.get("raw_json", {}).values()
+        ):
             result["timestamps"] = _EPOCH_MS_HINT
 
         return json.dumps(result, separators=(",", ":"))

--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -25,6 +25,39 @@ _conn.close()
 # garmin_schema
 # ---------------------------------------------------------------------------
 
+# Shape of the intraday arrays buried in raw_json, per table.  Garmin is not
+# consistent here — some feeds timestamp their samples as epoch milliseconds
+# (GMT) and others as local ISO text — so querying one like the other silently
+# produces garbage instead of an error.  Surfaced when the table is asked for
+# by name, i.e. right before its raw_json gets queried.
+_RAW_JSON_SHAPES = {
+    "body_battery": {
+        "$.bodyBattery.data": "[iso_local, level, ?, status]",
+        "$.stress.data": "[iso_local, stress]",
+    },
+    "daily_movement": {"$.movementValues": "[epoch_ms, intensity]"},
+    "floors": {"$.floorValuesArray": "[iso_local_start, iso_local_end, ascended, descended]"},
+    "heart_rate": {"$.heartRateValues": "[epoch_ms, bpm]"},
+    "hrv_timeline": {"$.hrvReadings": "{hrvValue, readingTimeGMT, readingTimeLocal}"},
+    "respiration": {"$.respirationValuesArray": "[epoch_ms, breaths_per_min]"},
+    "spo2": {"$.spo2ValuesArray": "[epoch_ms, spo2, ?]"},
+    "stress": {
+        "$.stressValuesArray": "[epoch_ms, stress]",
+        "$.bodyBatteryValuesArray": "[epoch_ms, level, ?, status]",
+    },
+}
+
+_EPOCH_MS_HINT = (
+    "epoch_ms is GMT: use datetime(ts/1000,'unixepoch') and add your UTC offset "
+    "in seconds for local time. iso_local is already local text — never mix the two."
+)
+
+# Sentinels that look like readings but are not; averaging over them skews the result.
+_RAW_JSON_SENTINELS = {
+    "stress": "stress < 0 means no reading (-1 unmeasurable, -2 off-wrist); filter them out",
+    "respiration": "value < 0 means no reading (-1 unmeasurable, -2 off-wrist); filter them out",
+}
+
 
 @mcp.tool()
 def garmin_schema(tables: str = "") -> str:
@@ -61,13 +94,23 @@ def garmin_schema(tables: str = "") -> str:
         if unknown:
             return json.dumps({"error": "unknown tables", "unknown": unknown, "available": names})
 
-        result = {}
+        # Tables live under their own key so a note can never be mistaken for
+        # a table (nor a table named "timestamps" shadow a note).
+        result = {"tables": {}}
         for name in wanted:
             cols = query(conn, f"PRAGMA table_info([{name}])")
-            result[name] = {
+            result["tables"][name] = {
                 "columns": [c["name"] for c in cols],
                 "row_count": query(conn, f"SELECT COUNT(*) AS cnt FROM [{name}]")[0]["cnt"],
             }
+            if name in _RAW_JSON_SHAPES:
+                result["tables"][name]["raw_json"] = _RAW_JSON_SHAPES[name]
+            if name in _RAW_JSON_SENTINELS:
+                result["tables"][name]["caveat"] = _RAW_JSON_SENTINELS[name]
+
+        if any("epoch_ms" in s for n in wanted for s in _RAW_JSON_SHAPES.get(n, {}).values()):
+            result["timestamps"] = _EPOCH_MS_HINT
+
         return json.dumps(result, separators=(",", ":"))
     finally:
         conn.close()

--- a/tests/test_server_schema.py
+++ b/tests/test_server_schema.py
@@ -28,6 +28,21 @@ def _insert_sleep_row(db_path: str, cal_date: str = "2026-04-19"):
     conn.close()
 
 
+def _insert_raw_json(db_path: str, table: str, payload: dict, cal_date: str = "2026-04-19"):
+    conn = _open_conn(db_path)
+    conn.execute(
+        f"INSERT INTO [{table}] (calendar_date, raw_json) VALUES (?, ?)",
+        (cal_date, json.dumps(payload)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _samples(*values):
+    """An array long enough for the prober to treat it as an intraday feed."""
+    return [list(v) for v in values] * 6
+
+
 def test_index_lists_only_row_counts(temp_db_file):
     _insert_sleep_row(temp_db_file)
 
@@ -69,6 +84,10 @@ def test_epoch_ms_table_documents_its_raw_json(temp_db_file):
     """Regression: stressValuesArray is timestamped in epoch milliseconds while
     bodyBattery.data uses local ISO text, so reading one like the other groups
     every sample into its own bucket instead of failing."""
+    _insert_raw_json(
+        temp_db_file, "stress", {"stressValuesArray": _samples([1785874500000, 23])}
+    )
+
     result = _call(temp_db_file, "stress")
 
     assert result["tables"]["stress"]["raw_json"]["$.stressValuesArray"] == "[epoch_ms, stress]"
@@ -77,25 +96,69 @@ def test_epoch_ms_table_documents_its_raw_json(temp_db_file):
 
 
 def test_iso_table_is_not_given_the_epoch_hint(temp_db_file):
+    _insert_raw_json(
+        temp_db_file,
+        "body_battery",
+        {"bodyBattery": {"data": _samples(["2026-04-19T22:03:00.0", 45, 1, 3])}},
+    )
+
     result = _call(temp_db_file, "body_battery")
 
-    assert result["tables"]["body_battery"]["raw_json"]["$.bodyBattery.data"].startswith("[iso_local")
+    shape = result["tables"]["body_battery"]["raw_json"]["$.bodyBattery.data"]
+    assert shape == "[iso_local, level, ?, status]"
     assert "timestamps" not in result
 
 
+def test_shape_follows_the_data_not_a_declared_list(temp_db_file):
+    """The point of reading the shape back: were Garmin to switch a feed from
+    epoch milliseconds to ISO text, a hardcoded note would keep claiming the
+    old format and send every query down the wrong path."""
+    _insert_raw_json(
+        temp_db_file, "stress", {"stressValuesArray": _samples(["2026-04-19T10:00:00.0", 23])}
+    )
+
+    result = _call(temp_db_file, "stress")
+
+    assert result["tables"]["stress"]["raw_json"]["$.stressValuesArray"] == "[iso_local, stress]"
+    assert "timestamps" not in result
+
+
+def test_position_null_in_the_first_sample_is_still_labelled(temp_db_file):
+    """Garmin leaves the leading samples of a feed null; classifying off the
+    first one alone would describe a real reading as an absence."""
+    _insert_raw_json(
+        temp_db_file,
+        "stress",
+        {"bodyBatteryValuesArray": _samples([1785874500000, None, None, 3], [1785874800000, 45, 1, 3])},
+    )
+
+    shape = _call(temp_db_file, "stress")["tables"]["stress"]["raw_json"]["$.bodyBatteryValuesArray"]
+
+    assert shape == "[epoch_ms, level, ?, status]"
+
+
 def test_table_without_intraday_arrays_carries_no_notes(temp_db_file):
+    _insert_sleep_row(temp_db_file)
+
     result = _call(temp_db_file, "sleep")
 
     assert set(result["tables"]["sleep"]) == {"columns", "row_count"}
     assert "timestamps" not in result
 
 
+def test_empty_table_cannot_be_described(temp_db_file):
+    """No stored row, nothing to read the shape from — and nothing to query
+    either, so an absent note costs the caller nothing."""
+    result = _call(temp_db_file, "stress")
+
+    assert "raw_json" not in result["tables"]["stress"]
+
+
 def test_documented_tables_still_exist(temp_db_file):
-    """A note pinned to a renamed or dropped table would silently never show up."""
+    """A caveat pinned to a renamed or dropped table would silently never show up."""
     index = _call(temp_db_file)
     known = set(index["tables"]) | set(index["empty_tables"])
 
-    assert set(server._RAW_JSON_SHAPES) <= known
     assert set(server._RAW_JSON_SENTINELS) <= known
 
 

--- a/tests/test_server_schema.py
+++ b/tests/test_server_schema.py
@@ -1,0 +1,72 @@
+"""Tests for the garmin_schema MCP tool."""
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+from garmin_mcp.server import garmin_schema
+
+
+def _open_conn(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _call(db_path: str, tables: str = "") -> dict:
+    """Invoke the underlying function (FastMCP wraps it as a tool)."""
+    fn = garmin_schema.fn if hasattr(garmin_schema, "fn") else garmin_schema
+    with patch("garmin_mcp.server.get_connection", lambda: _open_conn(db_path)):
+        return json.loads(fn(tables))
+
+
+def _insert_sleep_row(db_path: str, cal_date: str = "2026-04-19"):
+    conn = _open_conn(db_path)
+    conn.execute("INSERT INTO sleep (calendar_date) VALUES (?)", (cal_date,))
+    conn.commit()
+    conn.close()
+
+
+def test_index_lists_only_row_counts(temp_db_file):
+    _insert_sleep_row(temp_db_file)
+
+    result = _call(temp_db_file)
+
+    assert result["tables"] == {"sleep": 1}
+    assert "stress" in result["empty_tables"]
+    # The whole point of the index: no column lists anywhere.
+    assert "calendar_date" not in json.dumps(result)
+
+
+def test_index_stays_small(temp_db_file):
+    """Regression: the index used to dump every column of every table,
+    costing ~3.8k tokens of context on each call."""
+    fn = garmin_schema.fn if hasattr(garmin_schema, "fn") else garmin_schema
+    with patch("garmin_mcp.server.get_connection", lambda: _open_conn(temp_db_file)):
+        raw = fn("")
+
+    assert len(raw) < 2000
+
+
+def test_named_tables_return_their_columns(temp_db_file):
+    _insert_sleep_row(temp_db_file)
+
+    result = _call(temp_db_file, "sleep,stress")
+
+    assert set(result) == {"sleep", "stress"}
+    assert result["sleep"]["row_count"] == 1
+    assert result["stress"]["row_count"] == 0
+    assert "deep_sleep_seconds" in result["sleep"]["columns"]
+    assert "avg_stress" in result["stress"]["columns"]
+
+
+def test_table_names_are_trimmed(temp_db_file):
+    assert set(_call(temp_db_file, " sleep , stress ")) == {"sleep", "stress"}
+
+
+def test_unknown_table_reports_available_ones(temp_db_file):
+    result = _call(temp_db_file, "sleep,nope")
+
+    assert result["unknown"] == ["nope"]
+    assert "sleep" in result["available"]
+    assert "columns" not in json.dumps(result)

--- a/tests/test_server_schema.py
+++ b/tests/test_server_schema.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 from unittest.mock import patch
 
+from garmin_mcp import server
 from garmin_mcp.server import garmin_schema
 
 
@@ -51,7 +52,7 @@ def test_index_stays_small(temp_db_file):
 def test_named_tables_return_their_columns(temp_db_file):
     _insert_sleep_row(temp_db_file)
 
-    result = _call(temp_db_file, "sleep,stress")
+    result = _call(temp_db_file, "sleep,stress")["tables"]
 
     assert set(result) == {"sleep", "stress"}
     assert result["sleep"]["row_count"] == 1
@@ -61,7 +62,47 @@ def test_named_tables_return_their_columns(temp_db_file):
 
 
 def test_table_names_are_trimmed(temp_db_file):
-    assert set(_call(temp_db_file, " sleep , stress ")) == {"sleep", "stress"}
+    assert set(_call(temp_db_file, " sleep , stress ")["tables"]) == {"sleep", "stress"}
+
+
+def test_epoch_ms_table_documents_its_raw_json(temp_db_file):
+    """Regression: stressValuesArray is timestamped in epoch milliseconds while
+    bodyBattery.data uses local ISO text, so reading one like the other groups
+    every sample into its own bucket instead of failing."""
+    result = _call(temp_db_file, "stress")
+
+    assert result["tables"]["stress"]["raw_json"]["$.stressValuesArray"] == "[epoch_ms, stress]"
+    assert "unixepoch" in result["timestamps"]
+    assert "-2 off-wrist" in result["tables"]["stress"]["caveat"]
+
+
+def test_iso_table_is_not_given_the_epoch_hint(temp_db_file):
+    result = _call(temp_db_file, "body_battery")
+
+    assert result["tables"]["body_battery"]["raw_json"]["$.bodyBattery.data"].startswith("[iso_local")
+    assert "timestamps" not in result
+
+
+def test_table_without_intraday_arrays_carries_no_notes(temp_db_file):
+    result = _call(temp_db_file, "sleep")
+
+    assert set(result["tables"]["sleep"]) == {"columns", "row_count"}
+    assert "timestamps" not in result
+
+
+def test_documented_tables_still_exist(temp_db_file):
+    """A note pinned to a renamed or dropped table would silently never show up."""
+    index = _call(temp_db_file)
+    known = set(index["tables"]) | set(index["empty_tables"])
+
+    assert set(server._RAW_JSON_SHAPES) <= known
+    assert set(server._RAW_JSON_SENTINELS) <= known
+
+
+def test_index_carries_no_raw_json_notes(temp_db_file):
+    """The notes are for whoever is about to write SQL against one table —
+    paying for all of them in the index would undo the slimming."""
+    assert "epoch_ms" not in json.dumps(_call(temp_db_file))
 
 
 def test_unknown_table_reports_available_ones(temp_db_file):


### PR DESCRIPTION
Every MCP tool call spends context that the model then can't spend on the actual
question. `garmin_schema` was the worst offender — it dumped all 56 tables with
their 504 columns, pretty-printed, on every call — but the pretty-printing cost
was spread across all 49 tools.

**Improvements**

- `garmin_schema()` now returns a compact index: row count per non-empty table,
  plus the names of the empty ones. No column lists. It is also more useful as a
  first call — you immediately see that half the tables hold no data.
- `garmin_schema("sleep,stress")` returns the columns of just those tables, so
  you pay for what you actually need.
- All 49 tools serialise compactly (`separators` instead of `indent=2`). Dropping
  the indentation and newlines is worth 22–37% per call on its own, ~30% on
  average across the tools measured below.
- Asking for a table now documents the shape of its `raw_json` intraday arrays,
  to head off a silent aggregation error that costs a whole wasted round-trip:
  Garmin timestamps some of those feeds as epoch milliseconds (`stress`,
  `respiration`, `spo2`, `heart_rate`, `daily_movement`) and others as local ISO
  text (`body_battery`, `floors`). Reading one like the other yields a
  plausible-looking wrong answer instead of an error — grouping
  `stressValuesArray` by `substr()` of its timestamp buckets every sample on its
  own rather than by hour — so you pay for the bad query, notice the result is
  nonsense, and pay again for the right one.
- The same notes flag the negative sentinels in `stress` and `respiration`
  (`-1` unmeasurable, `-2` off-wrist), which a naive `avg()` silently counts as
  real readings.
- Those shapes are **read back from a stored row** rather than kept in a list in
  the source. A hardcoded note can only describe the payloads as they were the
  day it was written: if Garmin moved a feed from epoch milliseconds to ISO text,
  the note would keep asserting the old format and actively cause the very
  mistake it exists to prevent — worse than no note at all. Reading one row of
  the table being asked about costs ~1 ms, follows the data by construction, and
  picked up `health_snapshot` and `wellness_activity`, which the hand-written
  list had missed. Only what genuinely cannot be inferred stays declared: the
  meaning of the non-timestamp positions (`level`, `bpm`, `spo2`…), and the
  sentinels, which would need a full scan of every row to detect. The prober
  also looks through several samples per position rather than just the first,
  since Garmin leaves the leading samples of a feed null.

**Measured**

Tokens as they actually land in context (the escaped `{"result": …}` envelope,
at ~4 chars/token):

| Call | Before | After | Saved |
|---|---:|---:|---:|
| `garmin_schema()` | 4306 | 288 | −4018 (−93%) |
| `garmin_schema("stress,body_battery")` | 4306 | 205 | −4101 (−95%) |
| `garmin_body_battery(days=5)` | 401 | 268 | −133 (−33%) |
| `garmin_stress(days=5)` | 297 | 210 | −87 (−29%) |
| `garmin_hrv(days=7)` | 418 | 304 | −114 (−27%) |
| `garmin_respiration(days=5)` | 195 | 129 | −66 (−34%) |
| `garmin_query` (72-row hourly aggregate) | 1521 | 1013 | −508 (−33%) |
| `garmin_query` (`daily_summary`, 4 rows) | 453 | 354 | −99 (−22%) |

A real analysis session — three days of body battery, stress, HRV, respiration
and sleep, with intraday breakdowns — went from **~9000 to ~3500 tokens (−61%)**.
Roughly half of that is the schema alone; the rest is the compact serialisation,
which pays off uniformly across every tool.

Responses are byte-for-byte equivalent in content: only the formatting changed.

**Tests**

13 new tests in `tests/test_server_schema.py` pin the behaviour that keeps the
tool cheap — the index carries row counts only, named tables carry their
columns, unknown names report what is available, and the notes ship only with
the table they describe. The prober is covered against the failure modes that
would make it worse than a hardcoded list: a feed stored as ISO text must be
reported as ISO text, a position that is null in the first sample must still be
labelled from a later one, and a table with no stored row must produce no note
rather than a guessed one. 241 tests pass.

**Caveat on the numbers**

These were measured against a small database — a handful of days of data, most
tables holding fewer than 10 rows. The `garmin_schema` saving is independent of
that, since it scales with the number of tables and columns rather than rows, but
the per-tool and per-query figures will shift on a fuller database: absolute
savings grow with the number of rows returned, while the percentage should stay
in the same band. Worth re-running the before/after on a database with real
history to confirm.
