### PR TITLE
fix: read vo2max from the nested generic/cycling payload

### DIFF
--- a/garmin_mcp/db.py
+++ b/garmin_mcp/db.py
@@ -2469,9 +2469,14 @@ def upsert_weight(conn: sqlite3.Connection, record: dict, cal_date: str = None) 
 
 
 def upsert_vo2max(conn: sqlite3.Connection, record: dict, sport: str = "RUNNING") -> None:
-    d = record.get("calendarDate") or record.get("date")
-    val = record.get("vo2MaxPreciseValue") or record.get("value") or record.get("generic")
-    if not d:
+    # Garmin nests the payload under "generic" (or "cycling" for that sport):
+    # {"cycling": null, "generic": {"calendarDate": ..., "vo2MaxPreciseValue": ...}, ...}
+    inner = record.get("cycling") if sport == "CYCLING" else record.get("generic")
+    if not isinstance(inner, dict):
+        inner = record
+    d = inner.get("calendarDate") or inner.get("date") or record.get("calendarDate") or record.get("date")
+    val = inner.get("vo2MaxPreciseValue") or inner.get("vo2MaxValue") or inner.get("value")
+    if not d or val is None:
         return
     conn.execute(
         "INSERT OR REPLACE INTO vo2max (calendar_date, sport, value, raw_json) VALUES (?, ?, ?, ?)",

--- a/tests/test_db_vo2max.py
+++ b/tests/test_db_vo2max.py
@@ -1,0 +1,101 @@
+"""
+Tests for upsert_vo2max — Garmin nests the payload one level down under
+"generic" (or "cycling"), so the upsert must read calendarDate/value from the
+nested dict, not the top level (issue #73).
+"""
+
+import pytest
+
+from garmin_mcp.db import save_to_db, upsert_vo2max
+
+
+def _rows(conn):
+    return conn.execute("SELECT calendar_date, sport, value FROM vo2max ORDER BY calendar_date, sport").fetchall()
+
+
+NESTED_RUNNING_RECORD = {
+    "cycling": None,
+    "generic": {
+        "calendarDate": "2026-07-07",
+        "fitnessAge": None,
+        "fitnessAgeDescription": None,
+        "maxMetCategory": 0,
+        "vo2MaxPreciseValue": 45.3,
+        "vo2MaxValue": 45,
+    },
+    "heatAltitudeAcclimation": None,
+    "userId": 125263072,
+}
+
+
+class TestUpsertVo2max:
+    def test_nested_generic_record_inserted(self, temp_db):
+        upsert_vo2max(temp_db, NESTED_RUNNING_RECORD, "RUNNING")
+        rows = _rows(temp_db)
+        assert len(rows) == 1
+        assert rows[0]["calendar_date"] == "2026-07-07"
+        assert rows[0]["sport"] == "RUNNING"
+        assert rows[0]["value"] == pytest.approx(45.3)
+
+    def test_nested_cycling_record_inserted(self, temp_db):
+        record = {
+            "cycling": {"calendarDate": "2026-07-08", "vo2MaxPreciseValue": 52.1, "vo2MaxValue": 52},
+            "generic": None,
+        }
+        upsert_vo2max(temp_db, record, "CYCLING")
+        rows = _rows(temp_db)
+        assert len(rows) == 1
+        assert rows[0]["sport"] == "CYCLING"
+        assert rows[0]["calendar_date"] == "2026-07-08"
+        assert rows[0]["value"] == pytest.approx(52.1)
+
+    def test_flat_record_still_supported(self, temp_db):
+        upsert_vo2max(temp_db, {"calendarDate": "2026-07-09", "vo2MaxPreciseValue": 44.8}, "RUNNING")
+        rows = _rows(temp_db)
+        assert len(rows) == 1
+        assert rows[0]["calendar_date"] == "2026-07-09"
+        assert rows[0]["value"] == pytest.approx(44.8)
+
+    def test_falls_back_to_vo2max_value_when_precise_missing(self, temp_db):
+        record = {"generic": {"calendarDate": "2026-07-10", "vo2MaxValue": 46}}
+        upsert_vo2max(temp_db, record, "RUNNING")
+        rows = _rows(temp_db)
+        assert len(rows) == 1
+        assert rows[0]["value"] == pytest.approx(46)
+
+    def test_record_without_date_skipped(self, temp_db):
+        upsert_vo2max(temp_db, {"generic": {"vo2MaxPreciseValue": 45.3}}, "RUNNING")
+        assert _rows(temp_db) == []
+
+    def test_record_without_value_skipped(self, temp_db):
+        upsert_vo2max(temp_db, {"generic": {"calendarDate": "2026-07-11"}}, "RUNNING")
+        assert _rows(temp_db) == []
+
+    def test_value_is_never_a_dict(self, temp_db):
+        # The old code fell back to record["generic"] (a dict) for the value
+        # column; ensure only numeric values are ever written.
+        upsert_vo2max(temp_db, NESTED_RUNNING_RECORD, "RUNNING")
+        row = _rows(temp_db)[0]
+        assert isinstance(row["value"], float)
+
+
+class TestSaveToDbVo2max:
+    def test_vo2max_trend_endpoint(self, temp_db):
+        count = save_to_db(temp_db, "vo2max_trend", [NESTED_RUNNING_RECORD])
+        assert count == 1
+        rows = _rows(temp_db)
+        assert rows[0]["calendar_date"] == "2026-07-07"
+        assert rows[0]["value"] == pytest.approx(45.3)
+
+    def test_gql_vo2max_running_endpoint(self, temp_db):
+        payload = {"data": {"vo2MaxScalar": [NESTED_RUNNING_RECORD]}}
+        count = save_to_db(temp_db, "gql_vo2max_running", payload)
+        assert count == 1
+        rows = _rows(temp_db)
+        assert rows[0]["sport"] == "RUNNING"
+        assert rows[0]["value"] == pytest.approx(45.3)
+
+    def test_gql_vo2max_cycling_empty_for_running_only_account(self, temp_db):
+        count = save_to_db(temp_db, "gql_vo2max_cycling", {"data": {"vo2MaxScalar": []}})
+        assert count == 0
+        assert _rows(temp_db) == []


### PR DESCRIPTION
The `vo2max` table stayed empty on every sync: `upsert_vo2max` read `calendarDate` off the top level of each record, but Garmin nests the payload under `"generic"` (or `"cycling"` for that sport), so the date lookup always returned `None` and every record was silently dropped. The old code could also write a whole dict into the numeric `value` column via the `record.get("generic")` fallback.

Now the upsert reads the nested dict first (falling back to the flat shape for other payloads), only writes numeric values, and skips records with no value.

Includes 10 tests covering the nested running/cycling shapes, the GraphQL-wrapped payload, flat legacy records, and the empty-account no-op. Full suite: 251 passed.

Root cause diagnosis and suggested fix by @LucyDH666 in #73.

Closes #73

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKN9arSgJzPu6XEe1iCKdr)_