### PR TITLE
style: apply ruff format to fix the CI Lint job

### DIFF
--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -147,9 +147,7 @@ def garmin_schema(tables: str = "") -> str:
         wanted = [t.strip() for t in tables.split(",") if t.strip()]
 
         if not wanted:
-            counts = {
-                n: query(conn, f"SELECT COUNT(*) AS cnt FROM [{n}]")[0]["cnt"] for n in names
-            }
+            counts = {n: query(conn, f"SELECT COUNT(*) AS cnt FROM [{n}]")[0]["cnt"] for n in names}
             return json.dumps(
                 {
                     "tables": {n: c for n, c in counts.items() if c},
@@ -179,9 +177,7 @@ def garmin_schema(tables: str = "") -> str:
                 result["tables"][name]["caveat"] = _RAW_JSON_SENTINELS[name]
 
         if any(
-            _TS_EPOCH_MS in shape
-            for table in result["tables"].values()
-            for shape in table.get("raw_json", {}).values()
+            _TS_EPOCH_MS in shape for table in result["tables"].values() for shape in table.get("raw_json", {}).values()
         ):
             result["timestamps"] = _EPOCH_MS_HINT
 
@@ -1083,7 +1079,9 @@ def garmin_sleep(start_date: str = "", days: int = 7) -> str:
                ORDER BY calendar_date""",
             [start_date, end_date],
         )
-        return json.dumps({"period": {"start": start_date, "end": end_date}, "nights": rows}, separators=(",", ":"), default=str)
+        return json.dumps(
+            {"period": {"start": start_date, "end": end_date}, "nights": rows}, separators=(",", ":"), default=str
+        )
     finally:
         conn.close()
 

--- a/tests/test_server_schema.py
+++ b/tests/test_server_schema.py
@@ -84,9 +84,7 @@ def test_epoch_ms_table_documents_its_raw_json(temp_db_file):
     """Regression: stressValuesArray is timestamped in epoch milliseconds while
     bodyBattery.data uses local ISO text, so reading one like the other groups
     every sample into its own bucket instead of failing."""
-    _insert_raw_json(
-        temp_db_file, "stress", {"stressValuesArray": _samples([1785874500000, 23])}
-    )
+    _insert_raw_json(temp_db_file, "stress", {"stressValuesArray": _samples([1785874500000, 23])})
 
     result = _call(temp_db_file, "stress")
 
@@ -113,9 +111,7 @@ def test_shape_follows_the_data_not_a_declared_list(temp_db_file):
     """The point of reading the shape back: were Garmin to switch a feed from
     epoch milliseconds to ISO text, a hardcoded note would keep claiming the
     old format and send every query down the wrong path."""
-    _insert_raw_json(
-        temp_db_file, "stress", {"stressValuesArray": _samples(["2026-04-19T10:00:00.0", 23])}
-    )
+    _insert_raw_json(temp_db_file, "stress", {"stressValuesArray": _samples(["2026-04-19T10:00:00.0", 23])})
 
     result = _call(temp_db_file, "stress")
 


### PR DESCRIPTION
The Lint job on main has been red since #75 merged: `ruff format --check` flags two files (`garmin_mcp/server.py`, `tests/test_server_schema.py`) with lines exceeding the format rules. This applies `ruff format` — whitespace-only changes, no behavior change. `ruff check` passes and the full test suite still passes (251 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKN9arSgJzPu6XEe1iCKdr)_