### PR TITLE
fix: support mcp SDK v2 (FastMCP renamed to MCPServer)

### DIFF
--- a/garmin_mcp/server.py
+++ b/garmin_mcp/server.py
@@ -7,7 +7,10 @@ import logging
 import threading
 from datetime import date, timedelta
 
-from mcp.server.fastmcp import FastMCP
+try:  # mcp SDK v1
+    from mcp.server.fastmcp import FastMCP
+except ImportError:  # mcp SDK v2 renamed FastMCP to MCPServer
+    from mcp.server import MCPServer as FastMCP
 
 from .db import get_connection, init_db, query, query_readonly
 


### PR DESCRIPTION
Unblocks #78.

mcp 2.0 removed the `mcp.server.fastmcp` module (`FastMCP` is now `mcp.server.MCPServer`; the decorator API and `run(transport="stdio")` are unchanged), which is why #78's CI is red: the bound bump lets pip resolve mcp 2.x, and `garmin_mcp/server.py` fails to import.

This adds a try/except import so the server works with both mcp v1 and v2, making the `>=1.0,<3` range in #78 genuinely installable.

Verified:
- Under mcp 2.0.0 (clean venv): `garmin_mcp.server` imports and all 48 tools register (was `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` before the shim).
- Under mcp 1.27.0: full test suite passes (251 tests), ruff clean.

Merge order: land this first, then comment `@dependabot rebase` on #78 — its CI should go green and it can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)