### PR TITLE
fix: survive stalled requests during batch fetches

### DIFF
--- a/garmin_client/client.py
+++ b/garmin_client/client.py
@@ -21,6 +21,7 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -793,6 +794,26 @@ class GarminClient:
     # ── Batch fetching ───────────────────────────────────────────
 
     def _fetch_batch(self, rest: dict, gql: dict) -> dict:
+        """Fetch a batch with retries — a transient browser stall must not
+        kill a multi-year sync (each batch used to be a single point of
+        failure via Selenium's script timeout)."""
+        attempts = 3
+        last_exc = None
+        for attempt in range(1, attempts + 1):
+            try:
+                return self._fetch_batch_once(rest, gql)
+            except WebDriverException as e:
+                last_exc = e
+                log.warning("_fetch_batch attempt %d/%d failed: %s", attempt, attempts, e)
+                if attempt < attempts:
+                    time.sleep(10)
+        print(
+            f"  WARNING: batch of {len(rest) + len(gql)} endpoints failed "
+            f"after {attempts} attempts ({last_exc}) — skipping; re-run sync to fill this gap"
+        )
+        return {}
+
+    def _fetch_batch_once(self, rest: dict, gql: dict) -> dict:
         """Fetch a batch of REST + GraphQL endpoints in parallel via browser."""
         self._ensure_on_garmin()
         csrf = self._ensure_csrf()
@@ -812,7 +833,8 @@ class GarminClient:
 
                 async function get(url) {
                     try {
-                        var resp = await fetch(url, {credentials:'include', headers: h});
+                        var resp = await fetch(url, {credentials:'include', headers: h,
+                                                     signal: AbortSignal.timeout(60000)});
                         if (resp.status === 200) {
                             var text = await resp.text();
                             try { return {status: 200, data: JSON.parse(text)}; }
@@ -828,7 +850,8 @@ class GarminClient:
                             method: 'POST',
                             credentials: 'include',
                             headers: Object.assign({}, h, {'Content-Type': 'application/json'}),
-                            body: JSON.stringify({query: query})
+                            body: JSON.stringify({query: query}),
+                            signal: AbortSignal.timeout(60000)
                         });
                         if (resp.status === 200) return {status: 200, data: await resp.json()};
                         return {status: resp.status, data: null};

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,15 @@
 """Regression tests for garmin_client.client."""
 
+import inspect
+import tempfile
 import threading
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from garmin_client.client import _ProcessLifecycle
+from selenium.common.exceptions import TimeoutException
+
+from garmin_client.client import GarminClient, _ProcessLifecycle
 
 
 class TestProcessLifecycleThreadSafety(unittest.TestCase):
@@ -29,6 +35,57 @@ class TestProcessLifecycleThreadSafety(unittest.TestCase):
         t.join()
 
         self.assertEqual(errors, [], f"install() raised in worker thread: {errors}")
+
+
+class TestFetchBatchResilience(unittest.TestCase):
+    """A single stalled request used to kill an entire multi-year sync:
+    _fetch_batch's execute_async_script would hit Selenium's 120s script
+    timeout and the TimeoutException propagated uncaught out of fetch_all.
+    """
+
+    def _client(self) -> GarminClient:
+        tmp = tempfile.mkdtemp(prefix="garmin-test-profile-")
+        return GarminClient("test@example.com", "pw", profile_dir=Path(tmp))
+
+    def test_retries_after_transient_timeout(self):
+        client = self._client()
+        attempts = []
+        payload = {"steps_2025-01-01": {"status": 200, "data": {"steps": 1}}}
+
+        def fake_once(rest, gql):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise TimeoutException("script timeout")
+            return payload
+
+        client._fetch_batch_once = fake_once
+        with patch("garmin_client.client.time.sleep"):
+            result = client._fetch_batch({"steps_2025-01-01": "/url"}, {})
+
+        self.assertEqual(result, payload)
+        self.assertEqual(len(attempts), 2)
+
+    def test_persistent_failure_returns_empty_instead_of_raising(self):
+        client = self._client()
+        attempts = []
+
+        def fake_once(rest, gql):
+            attempts.append(1)
+            raise TimeoutException("script timeout")
+
+        client._fetch_batch_once = fake_once
+        with patch("garmin_client.client.time.sleep"):
+            result = client._fetch_batch({"steps_2025-01-01": "/url"}, {})
+
+        self.assertEqual(result, {})
+        self.assertEqual(len(attempts), 3)
+
+    def test_in_page_fetches_have_abort_timeout(self):
+        """Guard: every fetch() inside the batch script must carry an
+        AbortSignal timeout, otherwise one stalled request hangs the whole
+        script until Selenium's script timeout kills the sync."""
+        source = inspect.getsource(GarminClient._fetch_batch_once)
+        self.assertIn("AbortSignal.timeout", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A full 10-year sync died in year 2 with `selenium.common.exceptions.TimeoutException: Message: script timeout` propagating out of `fetch_all` → `_fetch_batch`. Root cause: the in-page JS awaits all endpoint fetches with no per-request timeout, so one stalled `fetch()` hangs the async script until Selenium's 120s script timeout kills it — and no call site catches the exception, so the whole sync crashes.

Two layers of defense:
- **Per-request timeout in the page:** every `fetch()` (REST and GraphQL) now carries `AbortSignal.timeout(60000)`. A stalled request now resolves as a per-endpoint error — already tolerated by all callers — instead of hanging the script.
- **Batch-level retry:** `_fetch_batch` retries up to 3× on `WebDriverException` (10s apart), then prints a loud warning and skips the batch so a long sync keeps going; the sync is upsert-based, so a re-run fills any skipped gap.

Tests (watched fail first): retry-then-succeed, persistent-failure-returns-empty, and a guard that the in-page fetches keep their AbortSignal timeout. Full suite: 254 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)